### PR TITLE
Fix console logging to use readable format

### DIFF
--- a/src/TreeAgent.Web/Program.cs
+++ b/src/TreeAgent.Web/Program.cs
@@ -7,12 +7,9 @@ using TreeAgent.Web.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Configure structured logging
+// Configure console logging with readable output
 builder.Logging.ClearProviders();
-builder.Logging.AddConsole(options =>
-{
-    options.FormatterName = "json";
-});
+builder.Logging.AddConsole();
 
 // Add services to the container.
 var dbPath = builder.Configuration["TREEAGENT_DB_PATH"] ?? "treeagent.db";


### PR DESCRIPTION
## Summary

- Removes JSON formatter from console logging configuration
- Uses default console formatter for human-readable log output

## Problem

The logging was configured with `FormatterName = "json"` in Program.cs:

```csharp
builder.Logging.AddConsole(options =>
{
    options.FormatterName = "json";
});
```

This caused all console logs to output in JSON format, making them difficult to read during development.

## Solution

Changed to use the default console formatter which outputs readable log entries:

```csharp
builder.Logging.AddConsole();
```

## Test Plan

- [x] Build succeeds
- [x] Run `dotnet run` and verify logs are human-readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)