### PR TITLE
Create database directory if it doesn't exist

### DIFF
--- a/src/TreeAgent.Web/Program.cs
+++ b/src/TreeAgent.Web/Program.cs
@@ -16,6 +16,14 @@ builder.Logging.AddConsole(options =>
 
 // Add services to the container.
 var dbPath = builder.Configuration["TREEAGENT_DB_PATH"] ?? "treeagent.db";
+
+// Ensure the database directory exists
+var dbDirectory = Path.GetDirectoryName(dbPath);
+if (!string.IsNullOrEmpty(dbDirectory) && !Directory.Exists(dbDirectory))
+{
+    Directory.CreateDirectory(dbDirectory);
+}
+
 builder.Services.AddDbContext<TreeAgentDbContext>(options =>
     options.UseSqlite($"Data Source={dbPath}"));
 


### PR DESCRIPTION
## Summary

- Ensures the database directory is created before attempting to initialize the SQLite database

## Problem

When `TREEAGENT_DB_PATH` is set to a path where the parent directory doesn't exist (e.g., `C:\Users\nboey\.treeagent\treeagent.db`), the application fails with:

```
fail: Microsoft.EntityFrameworkCore.Database.Connection[20004]
      An error occurred using the connection to database 'main' on server 'C:\Users\nboey\.treeagent\treeagent.db'.
```

This happens because SQLite can create the database file but cannot create parent directories.

## Solution

Added directory creation before database initialization:

```csharp
var dbDirectory = Path.GetDirectoryName(dbPath);
if (!string.IsNullOrEmpty(dbDirectory) && !Directory.Exists(dbDirectory))
{
    Directory.CreateDirectory(dbDirectory);
}
```

## Test Plan

- [x] Build succeeds
- [x] Set `TREEAGENT_DB_PATH` to a new directory path and verify the app creates it

🤖 Generated with [Claude Code](https://claude.com/claude-code)