### PR TITLE
Add AGENTS.md for OpenCode configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,159 @@
+# Development Instructions
+
+This file contains instructions for working on this project.
+
+## Overview
+
+TreeAgent is a Blazor web application for managing development features and AI agents. It provides:
+- Project and feature management with hierarchical tree visualization
+- Git worktree integration for isolated feature development
+- GitHub PR synchronization
+- Claude Code agent orchestration with real-time message streaming
+- Customizable system prompts with template variables
+
+## Development Practices
+
+### Test Driven Development (TDD)
+
+Use Test Driven Development practices where possible:
+
+1. **Write tests first** - Before implementing a feature, write failing tests that define the expected behavior
+2. **Red-Green-Refactor** - Follow the TDD cycle:
+   - Red: Write a failing test
+   - Green: Write minimal code to make the test pass
+   - Refactor: Clean up the code while keeping tests green
+3. **Test naming** - Use descriptive test names that explain the scenario and expected outcome
+4. **Test coverage** - Aim for comprehensive coverage of business logic in services
+
+### Project Structure (Vertical Slice Architecture)
+
+The project follows Vertical Slice Architecture, organizing code by feature rather than technical layer. Each feature contains its own services, data models, and components.
+
+```
+src/TreeAgent.Web/
+├── Features/                    # Feature slices (all business logic)
+│   ├── Agents/                  # Claude Code agent management
+│   │   ├── Components/Pages/    # Agent UI pages
+│   │   ├── Data/                # Agent, AgentStatus, Message entities
+│   │   ├── Hubs/                # SignalR hub for real-time updates
+│   │   └── Services/            # AgentService, ClaudeCodeProcessManager, etc.
+│   ├── Commands/                # Shell command execution
+│   ├── Git/                     # Git worktree operations
+│   ├── GitHub/                  # GitHub API integration (Octokit)
+│   ├── Projects/                # Project management
+│   ├── PullRequests/            # PR workflow and data entities
+│   │   └── Data/                # Feature, Project, TreeAgentDbContext
+│   │       └── Entities/        # EF Core entities
+│   └── Roadmap/                 # Roadmap parsing and management
+├── Components/                  # Shared Blazor components
+│   ├── Layout/                  # Layout components
+│   ├── Pages/                   # Page components
+│   └── Shared/                  # Reusable components
+├── HealthChecks/                # Health check implementations
+├── Migrations/                  # EF Core migrations
+└── Program.cs                   # Application entry point
+
+tests/TreeAgent.Web.Tests/
+├── Features/                    # Tests organized by feature
+│   ├── Agents/
+│   │   ├── Services/            # Agent service unit tests
+│   │   └── Integration/         # Agent integration tests
+│   └── PullRequests/
+│       └── Services/            # GitHub service tests
+├── Integration/
+│   └── Fixtures/                # Test fixtures
+├── Models/                      # Model unit tests
+└── Services/                    # Service tests (legacy location)
+```
+
+### Feature Slices
+
+- **Agents**: Claude Code agent orchestration, process management, message streaming, system prompts
+- **Commands**: Shell command execution abstraction
+- **Git**: Git worktree creation, management, and rebase operations
+- **GitHub**: GitHub PR synchronization and API operations using Octokit
+- **Projects**: Project CRUD operations
+- **PullRequests**: PR workflow, feature management, and core data entities (Feature, Project, DbContext)
+- **Roadmap**: Roadmap file parsing and change tracking
+
+### Running the Application
+
+```bash
+cd src/TreeAgent.Web
+dotnet run
+```
+
+The application will be available at `https://localhost:5001` (or the configured port).
+
+### Running Tests
+
+```bash
+dotnet test
+```
+
+### Database
+
+- SQLite database with EF Core
+- Migrations applied automatically on startup
+- Database file: `treeagent.db` (gitignored)
+
+### Creating Migrations
+
+```bash
+cd src/TreeAgent.Web
+dotnet ef migrations add <MigrationName>
+```
+
+## Key Services
+
+### Agents (Features/Agents/)
+- **AgentService**: Agent lifecycle management with Claude Code process orchestration
+- **AgentWorkflowService**: Orchestrates agent workflow from feature creation to completion
+- **ClaudeCodeProcessManager**: Process pool management for Claude Code instances
+- **ClaudeCodeProcess**: Individual Claude Code process wrapper
+- **ClaudeCodePathResolver**: Platform-aware Claude Code executable discovery
+- **MessageParser**: JSON message parser for Claude Code output
+- **SystemPromptService**: Template processing for agent system prompts
+- **AgentHub**: SignalR hub for real-time agent updates
+
+### Commands (Features/Commands/)
+- **CommandRunner**: Shell command execution with output capture
+
+### Git (Features/Git/)
+- **GitWorktreeService**: Git worktree creation, deletion, and rebase operations
+
+### GitHub (Features/GitHub/)
+- **GitHubService**: GitHub PR synchronization using Octokit
+- **GitHubClientWrapper**: Octokit abstraction for testability
+
+### Projects (Features/Projects/)
+- **ProjectService**: CRUD operations for projects
+
+### PullRequests (Features/PullRequests/)
+- **FeatureService**: Feature management with tree structure and worktree integration
+- **PullRequestWorkflowService**: PR creation and management workflow
+- **TreeAgentDbContext**: EF Core database context
+
+### Roadmap (Features/Roadmap/)
+- **RoadmapService**: Roadmap file loading and future change calculations
+- **RoadmapParser**: YAML roadmap file parsing
+
+## Configuration
+
+Environment variables:
+- `TREEAGENT_DB_PATH`: Path to SQLite database (default: `treeagent.db`)
+- `GITHUB_TOKEN`: GitHub personal access token for PR operations
+- `TREEAGENT_VERBOSE_SQL`: Set to `true` to enable detailed EF Core SQL logging
+
+## Health Checks
+
+The application exposes a health check endpoint at `/health` that monitors:
+- Database connectivity
+- Process manager status
+
+## Real-time Updates
+
+SignalR is used for real-time updates:
+- Agent message streaming
+- Agent status changes
+- Connect to `/hubs/agent` for agent-related updates


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` file to configure the repository for OpenCode
- Content is based on the existing `CLAUDE.md` file with the same project instructions
- OpenCode uses `AGENTS.md` instead of `CLAUDE.md` for custom instructions

This enables OpenCode to understand the project structure, development practices, and key services when working on this codebase.