### PR TITLE
fix: add effectiveStatus and logging to diagnose plan status issues

### DIFF
--- a/src/Homespun.Worker/src/types/index.ts
+++ b/src/Homespun.Worker/src/types/index.ts
@@ -61,6 +61,7 @@ export interface SessionInfo {
   model: string;
   permissionMode: string;
   status: 'idle' | 'streaming' | 'closed';
+  effectiveStatus: 'idle' | 'working' | 'plan_pending' | 'question_pending' | 'completed' | 'failed';
   createdAt: string;
   lastActivityAt: string;
 }
@@ -89,6 +90,7 @@ export interface ActiveSessionResponse {
   mode?: string;
   model?: string;
   permissionMode?: string;
+  effectiveStatus?: 'idle' | 'working' | 'plan_pending' | 'question_pending' | 'completed' | 'failed';
   hasPendingQuestion?: boolean;
   hasPendingPlanApproval?: boolean;
   lastActivityAt?: string;


### PR DESCRIPTION
## Summary

- Adds `effectiveStatus` field to the worker's SessionManager as the single source of truth for worker status, derived from A2A events being emitted
- Adds Information-level logging for all status transitions on both the worker and server sides
- Updates the server to use `effectiveStatus` as the primary source when mapping worker session status

## Key Changes

1. **Worker: session-manager.ts**
   - Added `EffectiveStatus` type with states: `idle`, `working`, `plan_pending`, `question_pending`, `completed`, `failed`
   - Added `setEffectiveStatus()` with logging: "Worker status changed: from='X', to='Y'"
   - Updates status when resolving pending questions/plans

2. **Worker: sse-writer.ts**
   - Sets effective status when emitting A2A events
   - Logs each A2A event: "A2A event emitted: kind='X', sessionId='Y'"
   - Override pending states to 'working' when message events arrive

3. **Worker: routes/sessions.ts**
   - Returns `effectiveStatus` from `/api/sessions/active`
   - Derives `hasPendingQuestion` and `hasPendingPlanApproval` from `effectiveStatus` for backwards compatibility
   - Logs each status query

4. **Server: DockerAgentExecutionService.cs**
   - Uses `effectiveStatus` as primary source in `MapWorkerSessionStatus()`
   - Falls back to legacy `hasPending*` fields for backwards compatibility
   - Logs status mapping: "MapWorkerSessionStatus: effectiveStatus='X' -> 'Y'"

5. **Server: ClaudeSessionService.cs**
   - Added `SetSessionStatusAsync()` helper with transition logging
   - Logs: "Session status changed: sessionId='X', from='Y', to='Z', reason='W'"

## Test plan

- [ ] Build succeeds (`dotnet build` - verified)
- [ ] All tests pass (`dotnet test` - verified, 533 tests passed)
- [ ] TypeScript compiles (`npm run build` - verified)
- [ ] Start an agent session and verify logs show status transitions
- [ ] Create a plan and verify logs show `plan_pending` status
- [ ] Approve plan and verify logs show transition to `working`

🤖 Generated with [Claude Code](https://claude.com/claude-code)