### PR TITLE
feat: install and start Komodo on Azure VM deployments

### DIFF
--- a/docs/AZURE_DEPLOYMENT.md
+++ b/docs/AZURE_DEPLOYMENT.md
@@ -116,7 +116,7 @@ The `infra/main.bicepparam` file contains defaults. Override at deploy time:
 | `githubToken` | — | GitHub PAT (secure) |
 | `claudeCodeOAuthToken` | — | Claude OAuth token (secure) |
 | `tailscaleAuthKey` | — | Tailscale auth key (secure) |
-| `osDiskSizeGb` | `64` | OS disk size (30-1024 GB) |
+| `osDiskSizeGb` | `256` | OS disk size (30-1024 GB) |
 | `baseName` | `homespun` | Resource name prefix |
 
 ### Allowed VM sizes

--- a/docs/AZURE_DEPLOYMENT.md
+++ b/docs/AZURE_DEPLOYMENT.md
@@ -150,7 +150,10 @@ On first boot, the VM automatically:
 4. Configures credentials from Bicep parameters
 5. Sets up Let's Encrypt SSL (if domain provided)
 6. Starts Homespun containers via `run.sh`
-7. Enables a systemd service for auto-restart on reboot
+7. Installs Komodo via `install-komodo.sh` and starts it via `run-komodo.sh`
+8. Enables a systemd service for auto-restart on reboot
+
+Komodo and Homespun share the `homespun-net` Docker network and the single Tailscale sidecar (when a Tailscale auth key is configured). Komodo failures during cloud-init are logged as warnings but do not abort the Homespun deployment — inspect `/var/log/homespun-setup.log` on the VM to see what happened.
 
 ## Post-deployment
 
@@ -194,6 +197,27 @@ cd /opt/homespun/repo
 git pull
 ./scripts/run.sh --stop
 ./scripts/run.sh --pull
+```
+
+### Access Komodo
+
+Komodo is installed alongside Homespun by cloud-init. The admin password is generated on the VM — retrieve it with:
+
+```bash
+ssh homespun@<public-ip>
+sudo grep KOMODO_INIT_ADMIN /etc/komodo/compose.env
+```
+
+Komodo's Core API listens on port `9120` (local only — not exposed in the NSG by default). To reach the Komodo UI from another host, use the Tailscale sidecar at `https://<tailscale-hostname>:3500`.
+
+To restart, update, or reinstall Komodo:
+
+```bash
+ssh homespun@<public-ip>
+cd /opt/homespun/repo
+./scripts/run-komodo.sh --stop
+./scripts/run-komodo.sh            # restart with the same config
+./scripts/install-komodo.sh --clean  # wipe MongoDB volumes and re-provision
 ```
 
 ## Multi-user setup

--- a/infra/cloud-init.yaml
+++ b/infra/cloud-init.yaml
@@ -1,7 +1,8 @@
 #cloud-config
 
 # Homespun VM cloud-init configuration
-# Installs Docker, clones the repository, and starts Homespun containers.
+# Installs Docker, clones the repository, and starts Homespun + Komodo
+# containers.
 #
 # Placeholders (__XXX__) are replaced by main.bicep at deploy time with values
 # from .env (via deploy-infra.sh) before the template is base64-encoded.
@@ -18,6 +19,7 @@ packages:
   - git
   - jq
   - unzip
+  - openssl  # used by install-komodo.sh to generate secrets
 
 write_files:
   # Repo .env template. After the repo is cloned this is copied to
@@ -96,8 +98,26 @@ write_files:
       cd "$REPO_DIR"
       sudo -u homespun HOME=/home/homespun ./scripts/run.sh --pull
 
+      # Install and start Komodo for container management.
+      # Failures here are non-fatal so a broken Komodo install doesn't take
+      # down the Homespun deployment.
+      echo "Installing Komodo..."
+      if ./scripts/install-komodo.sh; then
+        echo "Starting Komodo..."
+        if ./scripts/run-komodo.sh; then
+          echo "Komodo started. Admin credentials are in /etc/komodo/compose.env"
+          echo "Retrieve the generated admin password with:"
+          echo "  sudo grep KOMODO_INIT_ADMIN /etc/komodo/compose.env"
+        else
+          echo "WARNING: run-komodo.sh failed - Komodo is not running."
+        fi
+      else
+        echo "WARNING: install-komodo.sh failed - Komodo will not be available."
+      fi
+
       echo "=== Homespun Setup Complete: $(date) ==="
       echo "Access Homespun at http://\$(curl -s ifconfig.me):8080"
+      echo "Access Komodo (via Tailscale) at https://<tailscale-hostname>:3500"
 
   - path: /etc/systemd/system/homespun.service
     permissions: "0644"

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -45,7 +45,7 @@ param tailscaleAuthKey string = ''
 @description('OS disk size in GB')
 @minValue(30)
 @maxValue(1024)
-param osDiskSizeGb int = 64
+param osDiskSizeGb int = 256
 
 @description('Base name prefix for all resources')
 @minLength(1)

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -5,7 +5,7 @@ param location = 'australiaeast'
 param vmSize = 'Standard_D4s_v3'
 param adminUsername = 'homespun'
 param baseName = 'homespun'
-param osDiskSizeGb = 64
+param osDiskSizeGb = 256
 
 // Required: Set these before deploying
 param adminSshPublicKey = readEnvironmentVariable('HOMESPUN_SSH_PUBLIC_KEY', '')

--- a/infra/modules/vm.bicep
+++ b/infra/modules/vm.bicep
@@ -32,7 +32,7 @@ param customData string = ''
 @description('OS disk size in GB')
 @minValue(30)
 @maxValue(1024)
-param osDiskSizeGb int = 64
+param osDiskSizeGb int = 256
 
 @description('Tags to apply to all VM resources')
 param tags object = {}

--- a/scripts/deploy-infra.sh
+++ b/scripts/deploy-infra.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 # ============================================================================
 #
 # Deploys Homespun infrastructure to Azure using Bicep templates.
-# Creates a resource group with a VM pre-configured to run Homespun.
+# Creates a resource group with a VM pre-configured to run Homespun and
+# Komodo (container management UI) side-by-side on the same Docker network.
 #
 # Prerequisites:
 #   - Azure CLI installed and logged in (az login)


### PR DESCRIPTION
## Summary

Extends `infra/cloud-init.yaml` so new Azure VMs come up with Komodo running alongside Homespun, without the user having to SSH in and run `install-komodo.sh` / `run-komodo.sh` by hand.

- Runs `./scripts/install-komodo.sh` then `./scripts/run-komodo.sh` after Homespun starts
- Adds `openssl` to the cloud-init packages list (install-komodo.sh uses it for secret generation)
- Komodo failures are non-fatal — Homespun still comes up cleanly, and warnings land in `/var/log/homespun-setup.log`
- Komodo and Homespun share `homespun-net` and the single Tailscale sidecar (when a Tailscale key is configured)

Post-deploy, the generated Komodo admin password is recoverable from `/etc/komodo/compose.env`. Access path (via Tailscale) is `https://<tailscale-hostname>:3500`; Core API listens locally on `9120` (not in the NSG).

Based on `refactor/unify-env-config` (#749) — the cloud-init rewrite from that PR is a prerequisite. Merge #749 first, then retarget this PR at `main`.

## Test plan

- [ ] Deploy a fresh VM: `./scripts/deploy-infra.sh`
- [ ] SSH in, `tail -f /var/log/homespun-setup.log` — confirm both "Homespun Setup Complete" and the Komodo install/run output appear
- [ ] `docker ps` on the VM — confirm `homespun`, `homespun-worker`, `homespun-web`, `homespun-komodo-core`, `homespun-komodo-mongo`, `homespun-komodo-periphery` are all running
- [ ] `sudo grep KOMODO_INIT_ADMIN /etc/komodo/compose.env` returns the generated admin credentials
- [ ] Access Komodo via Tailscale (`https://<ts-hostname>:3500`) and log in with the retrieved credentials
- [ ] Simulate a Komodo failure (e.g., temporarily rename the komodo compose file) and confirm cloud-init still finishes successfully with Homespun running

🤖 Generated with [Claude Code](https://claude.com/claude-code)