### PR TITLE
fix: resolve Komodo-triggered Homespun redeploy permissions

### DIFF
--- a/config/komodo/resources.toml
+++ b/config/komodo/resources.toml
@@ -20,6 +20,12 @@
 #   - HOMESPUN_TAG controls which image tag to deploy:
 #       "latest" = stable releases, "alpha" = latest alpha build,
 #       or a specific version like "0.5.2-alpha.0.4.1.1.1.1"
+#   - Host-specific Komodo variables set (auto-populated by scripts/sync-komodo-vars.sh
+#     on VM deploys; see docs/deployment/komodo-variables.md for manual setup):
+#       HOMESPUN_HOME - admin user's home directory (e.g. /home/homespun)
+#       HOST_UID      - admin user's UID (e.g. 1000)
+#       HOST_GID      - admin user's primary GID (e.g. 1000)
+#       DOCKER_GID    - host /var/run/docker.sock group GID (e.g. 999)
 
 ## ── Resource Sync (self-referential) ─────────────────────────────────
 # After the one-time manual setup, this entry keeps the sync self-managing.
@@ -55,12 +61,12 @@ WEB_IMAGE=ghcr.io/nick-boey/homespun-web:[[HOMESPUN_TAG]]
 COMPOSE_PROFILES=plg
 CONTAINER_NAME=homespun
 HOST_PORT=8080
-HOST_UID=1000
-HOST_GID=1000
-DOCKER_GID=987
-DATA_DIR=/home/azureuser/.homespun-container/data
-SSH_DIR=/home/azureuser/.ssh
-CLAUDE_CREDENTIALS=/home/azureuser/.claude/.credentials.json
+HOST_UID=[[HOST_UID]]
+HOST_GID=[[HOST_GID]]
+DOCKER_GID=[[DOCKER_GID]]
+DATA_DIR=[[HOMESPUN_HOME]]/.homespun-container/data
+SSH_DIR=[[HOMESPUN_HOME]]/.ssh
+CLAUDE_CREDENTIALS=[[HOMESPUN_HOME]]/.claude/.credentials.json
 ASPNETCORE_ENVIRONMENT=Production
 AGENT_MODE=Docker
 GITHUB_TOKEN=[[GITHUB_TOKEN]]

--- a/docs/AZURE_DEPLOYMENT.md
+++ b/docs/AZURE_DEPLOYMENT.md
@@ -9,6 +9,7 @@ Deploy Homespun to an Azure VM using Bicep Infrastructure as Code templates. Thi
 - [Parameters](#parameters)
 - [What gets deployed](#what-gets-deployed)
 - [Post-deployment](#post-deployment)
+- [Komodo variables](#komodo-variables)
 - [Multi-user setup](#multi-user-setup)
 - [SSL and domain setup](#ssl-and-domain-setup)
 - [Teardown](#teardown)
@@ -218,6 +219,77 @@ cd /opt/homespun/repo
 ./scripts/run-komodo.sh --stop
 ./scripts/run-komodo.sh            # restart with the same config
 ./scripts/install-komodo.sh --clean  # wipe MongoDB volumes and re-provision
+```
+
+## Komodo variables
+
+When you click **Deploy** in the Komodo UI, Komodo reads `config/komodo/resources.toml` from the GitHub repo to learn how to run the Homespun stack. Some values in that file are host-specific — they aren't known at author time, so the TOML references them as `[[PLACEHOLDER]]` entries resolved from Komodo's Variable store.
+
+The host-specific values are:
+
+| Variable | Purpose | How it's detected |
+|---|---|---|
+| `HOMESPUN_HOME` | Admin user's home directory — used as the base for `DATA_DIR`, `SSH_DIR`, and `CLAUDE_CREDENTIALS` bind mounts | `getent passwd $ADMIN_USERNAME` |
+| `HOST_UID` | Admin user's UID — the Homespun container runs as this user | `id -u $ADMIN_USERNAME` |
+| `HOST_GID` | Admin user's primary GID | `id -g $ADMIN_USERNAME` |
+| `DOCKER_GID` | GID of the host `/var/run/docker.sock` group — added to the Homespun container's supplementary groups so it can spawn agent containers (DooD) | `stat -c '%g' /var/run/docker.sock` |
+
+If `DATA_DIR` points at a directory that doesn't exist on the host, Docker auto-creates it as `root:root`, and the Homespun container (running as `HOST_UID`) fails with `UnauthorizedAccessException: Access to the path '/data/DataProtection-Keys' is denied` on startup. Keeping these four variables accurate prevents that.
+
+### Automatic sync
+
+On every VM deploy, cloud-init runs `scripts/install-komodo.sh`, which detects the correct values and writes them to `/etc/komodo/homespun-vars.env`. Then `scripts/run-komodo.sh` invokes `scripts/sync-komodo-vars.sh` after starting Komodo Core — this logs in as the admin user and pushes the four values into Komodo via its write API.
+
+You don't normally need to do anything manually.
+
+### Re-syncing after a change
+
+If you change the admin user or the VM's Docker group GID shifts (rare, but possible after a Docker package upgrade), re-sync the variables:
+
+```bash
+ssh homespun@<public-ip>
+sudo /opt/homespun/repo/scripts/install-komodo.sh   # re-detects values into homespun-vars.env
+sudo /opt/homespun/repo/scripts/sync-komodo-vars.sh # pushes them to Komodo
+```
+
+To force a specific admin user (e.g., after changing `--admin-username`):
+
+```bash
+sudo ADMIN_USERNAME=alice /opt/homespun/repo/scripts/install-komodo.sh
+sudo /opt/homespun/repo/scripts/sync-komodo-vars.sh
+```
+
+Then click **Deploy** again on the `homespun` stack in the Komodo UI.
+
+### Manual fallback
+
+If the automatic sync fails (Komodo Core unreachable, admin password changed, etc.), `sync-komodo-vars.sh` prints the values and exits 0 so Komodo itself still comes up. Set the variables manually via the Komodo UI:
+
+1. Log in to Komodo and open **Settings → Variables**.
+2. Create or update these four entries. Use the values printed by `sudo cat /etc/komodo/homespun-vars.env` on the VM:
+   - `HOMESPUN_HOME`
+   - `HOST_UID`
+   - `HOST_GID`
+   - `DOCKER_GID`
+3. Open the **homespun** stack and click **Deploy**.
+
+Or push them via `curl` directly:
+
+```bash
+ssh homespun@<public-ip>
+# Source values + admin credentials
+sudo cat /etc/komodo/homespun-vars.env
+sudo grep KOMODO_INIT_ADMIN /etc/komodo/compose.env
+
+# Then from anywhere with access to port 9120:
+JWT=$(curl -sX POST http://localhost:9120/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"type":"LoginLocalUser","params":{"username":"admin","password":"<admin-pass>"}}' \
+  | jq -r .data.jwt)
+
+curl -X POST http://localhost:9120/write/UpdateVariableValue \
+  -H "Authorization: $JWT" -H 'Content-Type: application/json' \
+  -d '{"name":"DOCKER_GID","value":"999"}'
 ```
 
 ## Multi-user setup

--- a/infra/cloud-init.yaml
+++ b/infra/cloud-init.yaml
@@ -43,6 +43,11 @@ write_files:
 
       echo "=== Homespun Setup Started: $(date) ==="
 
+      # Admin username is substituted by main.bicep from the adminUsername param.
+      # Cloud-init runs as root; all user-facing resources are owned by this user.
+      ADMIN_USERNAME="__ADMIN_USERNAME__"
+      ADMIN_HOME="/home/$ADMIN_USERNAME"
+
       # Install Docker
       echo "Installing Docker..."
       curl -fsSL https://get.docker.com | sh
@@ -50,11 +55,12 @@ write_files:
       echo "Docker version: $(docker --version)"
       echo "Docker Compose version: $(docker compose version)"
 
-      # Create homespun user if not exists
-      if ! id -u homespun &>/dev/null; then
-        useradd --create-home --shell /bin/bash homespun
+      # Ensure admin user exists (Azure provisioning already creates it, but
+      # fall back to useradd so the script works on non-Azure hosts too).
+      if ! id -u "$ADMIN_USERNAME" &>/dev/null; then
+        useradd --create-home --shell /bin/bash "$ADMIN_USERNAME"
       fi
-      usermod -aG docker homespun
+      usermod -aG docker "$ADMIN_USERNAME"
 
       # Clone repository
       echo "Cloning Homespun repository..."
@@ -64,20 +70,35 @@ write_files:
       else
         cd "$REPO_DIR" && git pull
       fi
-      chown -R homespun:homespun "$REPO_DIR"
+      chown -R "$ADMIN_USERNAME:$ADMIN_USERNAME" "$REPO_DIR"
 
       # Materialize the repo .env from the template written by cloud-init.
       # This is the single configuration source for run.sh on the VM.
-      install -o homespun -g homespun -m 600 \
+      install -o "$ADMIN_USERNAME" -g "$ADMIN_USERNAME" -m 600 \
         /opt/homespun/.env-template \
         "$REPO_DIR/.env"
 
       # Create Docker network
       docker network create homespun-net 2>/dev/null || true
 
-      # Create data directories
-      mkdir -p /home/homespun/.homespun-container/data
-      chown -R homespun:homespun /home/homespun/.homespun-container
+      # Pre-create all host paths that docker-compose.yml bind-mounts into the
+      # Homespun container, owned by the admin user. This is critical for
+      # Komodo-triggered redeploys: Komodo reads DATA_DIR/SSH_DIR/CLAUDE_CREDENTIALS
+      # from Komodo Variables and mounts them. If a path doesn't exist,
+      # Docker creates it as root:root and the container (running as the
+      # admin user's UID) cannot write to it.
+      install -d -o "$ADMIN_USERNAME" -g "$ADMIN_USERNAME" -m 755 \
+        "$ADMIN_HOME/.homespun-container" \
+        "$ADMIN_HOME/.homespun-container/data"
+      install -d -o "$ADMIN_USERNAME" -g "$ADMIN_USERNAME" -m 700 \
+        "$ADMIN_HOME/.ssh" \
+        "$ADMIN_HOME/.claude"
+      # Touch a placeholder credentials file so the :ro bind mount attaches
+      # to a real file. Replace the contents later if using Claude OAuth.
+      if [ ! -e "$ADMIN_HOME/.claude/.credentials.json" ]; then
+        install -o "$ADMIN_USERNAME" -g "$ADMIN_USERNAME" -m 600 /dev/null \
+          "$ADMIN_HOME/.claude/.credentials.json"
+      fi
 
       # Set up SSL with Let's Encrypt if domain is configured
       DOMAIN_NAME="__DOMAIN_NAME__"
@@ -96,12 +117,15 @@ write_files:
       # Start Homespun using run.sh - it reads $REPO_DIR/.env itself
       echo "Starting Homespun..."
       cd "$REPO_DIR"
-      sudo -u homespun HOME=/home/homespun ./scripts/run.sh --pull
+      sudo -u "$ADMIN_USERNAME" HOME="$ADMIN_HOME" ./scripts/run.sh --pull
 
       # Install and start Komodo for container management.
+      # ADMIN_USERNAME is exported so install-komodo.sh can detect the correct
+      # HOMESPUN_HOME / HOST_UID / HOST_GID for the Komodo-driven redeploys.
       # Failures here are non-fatal so a broken Komodo install doesn't take
       # down the Homespun deployment.
       echo "Installing Komodo..."
+      export ADMIN_USERNAME
       if ./scripts/install-komodo.sh; then
         echo "Starting Komodo..."
         if ./scripts/run-komodo.sh; then
@@ -130,7 +154,7 @@ write_files:
       [Service]
       Type=oneshot
       RemainAfterExit=yes
-      User=homespun
+      User=__ADMIN_USERNAME__
       WorkingDirectory=/opt/homespun/repo
       ExecStart=/opt/homespun/repo/scripts/run.sh --pull
       ExecStop=/opt/homespun/repo/scripts/run.sh --stop

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -79,10 +79,12 @@ var cloudInitConfig = loadTextContent('cloud-init.yaml')
 var cloudInitWithSecrets = replace(
   replace(
     replace(
-      replace(cloudInitConfig, '__GITHUB_TOKEN__', githubToken),
-      '__CLAUDE_CODE_OAUTH_TOKEN__', claudeCodeOAuthToken),
-    '__TAILSCALE_AUTH_KEY__', tailscaleAuthKey),
-  '__DOMAIN_NAME__', domainName)
+      replace(
+        replace(cloudInitConfig, '__GITHUB_TOKEN__', githubToken),
+        '__CLAUDE_CODE_OAUTH_TOKEN__', claudeCodeOAuthToken),
+      '__TAILSCALE_AUTH_KEY__', tailscaleAuthKey),
+    '__DOMAIN_NAME__', domainName),
+  '__ADMIN_USERNAME__', adminUsername)
 
 // Virtual Machine
 module vm 'modules/vm.bicep' = {

--- a/scripts/install-komodo.sh
+++ b/scripts/install-komodo.sh
@@ -222,6 +222,55 @@ EOF
 sudo chmod 600 "$KOMODO_DIR/compose.env"
 log_success "      Generated configuration at $KOMODO_DIR/compose.env"
 
+# Step 3b: Detect and persist host-specific values for Komodo Variables.
+# These are consumed by scripts/sync-komodo-vars.sh (run by run-komodo.sh once
+# Komodo Core is healthy) to populate the [[HOMESPUN_HOME]], [[HOST_UID]],
+# [[HOST_GID]], [[DOCKER_GID]] placeholders referenced in
+# config/komodo/resources.toml.
+log_info "      Detecting host-specific values..."
+
+# Admin username: set by cloud-init; falls back to the current invoker when
+# run manually on an existing VM.
+DETECTED_ADMIN_USERNAME="${ADMIN_USERNAME:-${SUDO_USER:-$(id -un)}}"
+
+if ! id -u "$DETECTED_ADMIN_USERNAME" &>/dev/null; then
+    log_error "      Admin user '$DETECTED_ADMIN_USERNAME' does not exist."
+    log_error "      Set ADMIN_USERNAME=<user> and re-run this script."
+    exit 1
+fi
+
+DETECTED_HOMESPUN_HOME="$(getent passwd "$DETECTED_ADMIN_USERNAME" | cut -d: -f6)"
+DETECTED_HOST_UID="$(id -u "$DETECTED_ADMIN_USERNAME")"
+DETECTED_HOST_GID="$(id -g "$DETECTED_ADMIN_USERNAME")"
+
+if [ -S /var/run/docker.sock ]; then
+    DETECTED_DOCKER_GID="$(stat -c '%g' /var/run/docker.sock)"
+else
+    log_warn "      /var/run/docker.sock not found; falling back to docker group GID."
+    DETECTED_DOCKER_GID="$(getent group docker | cut -d: -f3 || echo 999)"
+fi
+
+log_success "      ADMIN_USERNAME=$DETECTED_ADMIN_USERNAME"
+log_success "      HOMESPUN_HOME=$DETECTED_HOMESPUN_HOME"
+log_success "      HOST_UID=$DETECTED_HOST_UID"
+log_success "      HOST_GID=$DETECTED_HOST_GID"
+log_success "      DOCKER_GID=$DETECTED_DOCKER_GID"
+
+# Persist for sync-komodo-vars.sh. These are NOT secrets (UIDs and a path),
+# but we keep the file mode tight to match the rest of $KOMODO_DIR.
+sudo tee "$KOMODO_DIR/homespun-vars.env" > /dev/null << EOF
+# Host-specific values pushed into Komodo Variables by sync-komodo-vars.sh.
+# Regenerated every time install-komodo.sh runs. Safe to edit manually and
+# re-run sync-komodo-vars.sh to push updates.
+ADMIN_USERNAME=$DETECTED_ADMIN_USERNAME
+HOMESPUN_HOME=$DETECTED_HOMESPUN_HOME
+HOST_UID=$DETECTED_HOST_UID
+HOST_GID=$DETECTED_HOST_GID
+DOCKER_GID=$DETECTED_DOCKER_GID
+EOF
+sudo chmod 644 "$KOMODO_DIR/homespun-vars.env"
+log_success "      Persisted to $KOMODO_DIR/homespun-vars.env"
+
 # Step 4: Copy compose files
 log_info "[4/4] Installing compose files..."
 

--- a/scripts/run-komodo.sh
+++ b/scripts/run-komodo.sh
@@ -192,6 +192,18 @@ if [ "$DETACHED" = true ]; then
         fi
     fi
 
+    # Push host-specific Komodo Variables so stack redeploys from the UI can
+    # resolve [[HOMESPUN_HOME]], [[HOST_UID]], [[HOST_GID]], [[DOCKER_GID]].
+    # Non-fatal: if Core isn't healthy in time, the sync script logs manual-
+    # repair steps and exits 0 without blocking Komodo from running.
+    SYNC_SCRIPT="$SCRIPT_DIR/sync-komodo-vars.sh"
+    if [ -x "$SYNC_SCRIPT" ]; then
+        log_info "Syncing host-specific Komodo Variables..."
+        "$SYNC_SCRIPT" || log_warn "Variable sync returned non-zero (continuing)."
+    else
+        log_warn "$SYNC_SCRIPT not found or not executable; skipping variable sync."
+    fi
+
     echo
     log_success "Komodo started successfully!"
     echo

--- a/scripts/sync-komodo-vars.sh
+++ b/scripts/sync-komodo-vars.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================================
+# Komodo Variables Sync
+# ============================================================================
+#
+# Pushes host-specific values into Komodo Core's Variable store so that
+# config/komodo/resources.toml can reference them via [[HOMESPUN_HOME]],
+# [[HOST_UID]], [[HOST_GID]], [[DOCKER_GID]] placeholders during stack
+# redeploys from the Komodo UI.
+#
+# Source values from /etc/komodo/homespun-vars.env (written by install-komodo.sh)
+# and admin credentials from /etc/komodo/compose.env. Called automatically by
+# run-komodo.sh after Core becomes healthy; safe to re-run manually.
+#
+# Usage:
+#   sudo ./scripts/sync-komodo-vars.sh              # Sync using defaults
+#   sudo ADMIN_USERNAME=foo ./scripts/sync-komodo-vars.sh   # Override admin user
+#
+# Exits non-zero only on hard configuration errors (missing files, bad
+# credentials). Transient API failures log manual-repair instructions and
+# exit 0 so a redeploy can still proceed.
+# ============================================================================
+
+CYAN='\033[0;36m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log_info() { echo -e "${CYAN}$1${NC}"; }
+log_success() { echo -e "${GREEN}$1${NC}"; }
+log_warn() { echo -e "${YELLOW}$1${NC}"; }
+log_error() { echo -e "${RED}$1${NC}"; }
+
+KOMODO_DIR="/etc/komodo"
+VARS_FILE="$KOMODO_DIR/homespun-vars.env"
+COMPOSE_ENV="$KOMODO_DIR/compose.env"
+KOMODO_CORE_URL="${KOMODO_CORE_URL:-http://localhost:9120}"
+
+echo
+log_info "=== Komodo Variables Sync ==="
+echo
+
+if [ ! -f "$VARS_FILE" ]; then
+    log_error "Variables file not found: $VARS_FILE"
+    log_error "Run install-komodo.sh first."
+    exit 1
+fi
+
+if [ ! -f "$COMPOSE_ENV" ]; then
+    log_error "Komodo compose env not found: $COMPOSE_ENV"
+    log_error "Run install-komodo.sh first."
+    exit 1
+fi
+
+# Load detected values (HOMESPUN_HOME, HOST_UID, HOST_GID, DOCKER_GID)
+# shellcheck disable=SC1090
+source "$VARS_FILE"
+
+# Load admin credentials from compose.env. These lines are shell-compatible
+# KEY=VALUE pairs, so sourcing is safe.
+# shellcheck disable=SC1090
+source "$COMPOSE_ENV"
+
+ADMIN_USER="${KOMODO_INIT_ADMIN_USERNAME:-}"
+ADMIN_PASS="${KOMODO_INIT_ADMIN_PASSWORD:-}"
+
+if [ -z "$ADMIN_USER" ] || [ -z "$ADMIN_PASS" ]; then
+    log_error "Admin credentials not found in $COMPOSE_ENV"
+    log_error "Expected KOMODO_INIT_ADMIN_USERNAME and KOMODO_INIT_ADMIN_PASSWORD."
+    exit 1
+fi
+
+# Wait for Komodo Core to be reachable (up to ~90s)
+log_info "[1/3] Waiting for Komodo Core at $KOMODO_CORE_URL..."
+for _ in $(seq 1 45); do
+    if curl -sf -o /dev/null "$KOMODO_CORE_URL/"; then
+        log_success "      Core is reachable."
+        break
+    fi
+    sleep 2
+done
+
+if ! curl -sf -o /dev/null "$KOMODO_CORE_URL/"; then
+    log_warn "      Core did not respond within timeout."
+    log_warn "      Skipping variable sync. Re-run this script after Core is up:"
+    log_warn "        sudo $0"
+    exit 0
+fi
+
+# Log in as admin to obtain a JWT
+log_info "[2/3] Authenticating as admin '$ADMIN_USER'..."
+LOGIN_BODY=$(jq -nc --arg u "$ADMIN_USER" --arg p "$ADMIN_PASS" \
+    '{type:"LoginLocalUser",params:{username:$u,password:$p}}')
+
+LOGIN_RESP=$(curl -sS -X POST "$KOMODO_CORE_URL/auth/login" \
+    -H "Content-Type: application/json" \
+    -d "$LOGIN_BODY") || {
+    log_warn "      Login request failed. Skipping variable sync."
+    log_warn "      Set variables manually in Komodo UI (see docs/deployment/komodo-variables.md)."
+    exit 0
+}
+
+JWT=$(echo "$LOGIN_RESP" | jq -r '.data.jwt // empty')
+if [ -z "$JWT" ]; then
+    log_warn "      Login did not return a JWT. Response: $LOGIN_RESP"
+    log_warn "      Set variables manually in Komodo UI (see docs/deployment/komodo-variables.md)."
+    exit 0
+fi
+log_success "      Authenticated."
+
+# Push each variable via CreateVariable; on duplicate, fall back to
+# UpdateVariableValue. Komodo's CreateVariable returns 4xx when a variable
+# already exists, so try create first then update.
+push_variable() {
+    local name="$1"
+    local value="$2"
+    local description="$3"
+
+    local create_body
+    create_body=$(jq -nc \
+        --arg n "$name" \
+        --arg v "$value" \
+        --arg d "$description" \
+        '{name:$n, value:$v, description:$d, is_secret:false}')
+
+    local http_code
+    http_code=$(curl -sS -o /tmp/komodo-sync-resp.txt -w '%{http_code}' \
+        -X POST "$KOMODO_CORE_URL/write/CreateVariable" \
+        -H "Authorization: $JWT" \
+        -H "Content-Type: application/json" \
+        -d "$create_body") || http_code="000"
+
+    if [ "$http_code" = "200" ]; then
+        log_success "      Created $name=$value"
+        return 0
+    fi
+
+    # Any non-200 response on create -> try update
+    local update_body
+    update_body=$(jq -nc --arg n "$name" --arg v "$value" \
+        '{name:$n, value:$v}')
+
+    http_code=$(curl -sS -o /tmp/komodo-sync-resp.txt -w '%{http_code}' \
+        -X POST "$KOMODO_CORE_URL/write/UpdateVariableValue" \
+        -H "Authorization: $JWT" \
+        -H "Content-Type: application/json" \
+        -d "$update_body") || http_code="000"
+
+    if [ "$http_code" = "200" ]; then
+        log_success "      Updated $name=$value"
+        return 0
+    fi
+
+    log_warn "      Failed to sync $name (HTTP $http_code)"
+    log_warn "      Response: $(cat /tmp/komodo-sync-resp.txt 2>/dev/null | head -c 200)"
+    return 1
+}
+
+log_info "[3/3] Pushing host-specific variables to Komodo..."
+FAILED=0
+push_variable "HOMESPUN_HOME" "$HOMESPUN_HOME" \
+    "Admin user's home directory (auto-detected from $VARS_FILE)." || FAILED=$((FAILED+1))
+push_variable "HOST_UID" "$HOST_UID" \
+    "Admin user's UID for Homespun container (auto-detected from $VARS_FILE)." || FAILED=$((FAILED+1))
+push_variable "HOST_GID" "$HOST_GID" \
+    "Admin user's primary GID for Homespun container (auto-detected from $VARS_FILE)." || FAILED=$((FAILED+1))
+push_variable "DOCKER_GID" "$DOCKER_GID" \
+    "GID of the host /var/run/docker.sock group (auto-detected from $VARS_FILE)." || FAILED=$((FAILED+1))
+
+rm -f /tmp/komodo-sync-resp.txt
+
+echo
+if [ "$FAILED" -eq 0 ]; then
+    log_success "All Komodo Variables synced successfully."
+else
+    log_warn "$FAILED variable(s) failed to sync."
+    log_warn "To repair manually, log in to the Komodo UI and open:"
+    log_warn "  Settings -> Variables"
+    log_warn "Set these four entries to the values shown above, then redeploy the Homespun stack."
+fi
+echo


### PR DESCRIPTION
## Summary

- Fixes `UnauthorizedAccessException: Access to the path '/data/DataProtection-Keys' is denied` when redeploying the Homespun stack from the Komodo UI on Azure VM deployments.
- Moves host-specific values in `config/komodo/resources.toml` (`HOMESPUN_HOME`, `HOST_UID`, `HOST_GID`, `DOCKER_GID`) out of literals into Komodo Variables, detected at install time and pushed into Komodo via its write API.
- Parameterizes the admin username in cloud-init and pre-creates every bind-mount source with admin-user ownership so Docker never auto-creates them as root.

## Root cause

`resources.toml` hardcoded `/home/azureuser/.homespun-container/data` etc., but cloud-init creates the admin user as `homespun` (per `deploy-infra.sh`'s `ADMIN_USERNAME` default). When Komodo runs `docker compose up`, Docker auto-creates the missing `/home/azureuser/...` paths as `root:root`, and the Homespun container (`user: ${HOST_UID}:${HOST_GID}` = 1000:1000) cannot write to them. `scripts/run.sh` didn't hit this because it computes `HOST_UID`/`HOST_GID`/`DOCKER_GID` dynamically (`scripts/run.sh:297`) and uses `$HOME/.homespun-container/data`, which cloud-init already pre-creates with correct ownership.

Secondary: `DOCKER_GID=987` was hardcoded, but Docker CE on Ubuntu 22.04 creates the group at GID 999. Even after fixing the paths, the Homespun container's DooD calls would fail.

## Changes

| File | Change |
|---|---|
| `config/komodo/resources.toml` | Use `[[HOMESPUN_HOME]]`, `[[HOST_UID]]`, `[[HOST_GID]]`, `[[DOCKER_GID]]` placeholders (same pattern as existing `[[GITHUB_TOKEN]]` etc.) |
| `infra/main.bicep` | Substitute new `__ADMIN_USERNAME__` placeholder from the existing `adminUsername` param |
| `infra/cloud-init.yaml` | Parameterize admin user throughout `setup.sh`; pre-create `~/.homespun-container/data`, `~/.ssh`, `~/.claude/.credentials.json` with admin ownership |
| `scripts/install-komodo.sh` | Detect `HOMESPUN_HOME`/`HOST_UID`/`HOST_GID`/`DOCKER_GID` from the running host; persist to `/etc/komodo/homespun-vars.env` |
| `scripts/sync-komodo-vars.sh` (new) | Authenticate to Komodo Core (`POST /auth/login`, type `LoginLocalUser`), push the four values via `POST /write/CreateVariable` with `UpdateVariableValue` fallback; non-fatal with manual-repair instructions on any API failure |
| `scripts/run-komodo.sh` | Invoke `sync-komodo-vars.sh` after `docker compose up` so every restart re-syncs |
| `docs/AZURE_DEPLOYMENT.md` | New **Komodo variables** section covering auto-sync, re-sync after changes, and manual UI/`curl` fallback |

Komodo API shape was verified against `demo.komo.do` before wiring it in: `POST /auth/login` with `{"type":"LoginLocalUser","params":{"username":"…","password":"…"}}` returns JWT at `.data.jwt`; write requests use `Authorization: <jwt>` header with raw params as body at `/write/<Type>`.

## Test plan

- [ ] Fresh `./scripts/deploy-infra.sh` against a clean resource group — SSH in and confirm `ls -la /home/homespun/.homespun-container/data` shows UID/GID 1000, `/home/homespun/.claude/.credentials.json` exists.
- [ ] `cat /etc/komodo/homespun-vars.env` shows detected values; `DOCKER_GID` matches `stat -c '%g' /var/run/docker.sock`.
- [ ] Komodo UI → **Settings → Variables**: all four variables present with matching values.
- [ ] Komodo UI → **Stacks → homespun → Deploy** (the exact operation that was failing) — container reaches healthy state without `UnauthorizedAccessException`.
- [ ] `docker exec homespun id` shows UID 1000 + supplementary group matching host docker-socket GID.
- [ ] `docker exec homespun touch /data/sentinel && rm /data/sentinel` succeeds.
- [ ] DooD smoke test: trigger an agent spawn from the Homespun UI — sibling agent container starts.
- [ ] Idempotency: re-run `sudo ./scripts/sync-komodo-vars.sh` — all four variables report as updated, no errors.
- [ ] Regression: first-boot `scripts/run.sh` path still works (verify `docker logs homespun` before any Komodo redeploy).

## Applying to an existing broken VM

After this is merged to `main`:

```bash
ssh homespun@<vm-ip>
cd /opt/homespun/repo && git pull
sudo ./scripts/install-komodo.sh
sudo ./scripts/sync-komodo-vars.sh
```

Then trigger the `homespun-resources` Resource Sync in the Komodo UI so it picks up the new `resources.toml`, and redeploy the `homespun` stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)