### PR TITLE
docs(openspec): propose ACA multi-user, ACI execution, clone-and-push

### DIFF
--- a/openspec/changes/aci-agent-execution/.openspec.yaml
+++ b/openspec/changes/aci-agent-execution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-13

--- a/openspec/changes/aci-agent-execution/design.md
+++ b/openspec/changes/aci-agent-execution/design.md
@@ -1,0 +1,146 @@
+## Context
+
+Current execution model (Docker mode) uses Docker-outside-of-Docker: the server container calls `docker run` on the host's Docker socket to spawn per-issue worker containers, reuses them for subsequent sessions on the same issue, and mounts the workdir + `.claude` from the host filesystem. Server-worker communication is HTTP SSE to the worker's container IP.
+
+In ACA, `docker run` is not available. ACA's native `containerApp` primitive is a long-lived app with a stable URL — it's a poor fit for "server lifecycles per-issue containers." Azure Container Instances (ACI) are the right primitive: individually-addressable, per-second-billed, fast-starting containers that the server can provision and tear down at will via ARM.
+
+This change builds on `multi-user-postgres` (which establishes per-user identity + encrypted credential storage). It does NOT change the worker's workdir semantics (clone + push model) — that's a separate change (`worker-clone-and-push`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- `IAgentExecutionService` gains a second implementation (`AciAgentExecutionService`) chosen at runtime by config. Existing callers unchanged.
+- One ACI container group per `(userId, issueId)`, reused across sessions on the same issue (matches Docker mode's reuse semantics).
+- Workers attach to a VNet subnet reachable from the server's ACA environment; communication is private.
+- Per-user `~/.claude` persisted on Azure Files NFS; survives worker restarts and lets a crashed worker resume with its session history intact.
+- Credentials (GitHub PAT, Claude OAuth token, project secrets) are decrypted from Postgres at worker-launch time and injected as ACI env vars.
+- Server identity for ARM calls is a system-assigned managed identity with narrowly-scoped role assignments.
+
+**Non-Goals:**
+- Queue-based or polling-based server↔worker comms (stays HTTP SSE, same as Docker mode).
+- Warm worker pool or scale rules — server explicitly provisions and tears down per issue.
+- Changes to worker workdir semantics (separate change).
+- Changes to Docker execution mode (it coexists; no refactor).
+- Migration of Docker mode onto the factory pattern in a way that breaks existing VM deployments.
+
+## Decisions
+
+### D1: ACI over Container Apps — confirmed
+
+**Decision:** Dynamically provisioned Azure Container Instances, one container group per worker.
+
+**Rationale:** Already explored in the discovery phase. ACI matches "server-controlled lifecycle, per-issue containers" exactly. Container Apps would require either one app per issue (15–45s provisioning, ARM churn) or a warm pool (not individually addressable, requires inverting the comms model).
+
+**Trade-off:** Diverges from the `aca.likec4` sketch, which modeled worker as a Container App. The likec4 model is updated to reflect reality.
+
+### D2: Server-assigned Managed Identity + RBAC scoped to a workers resource group
+
+**Decision:**
+- Server Container App gets a system-assigned managed identity.
+- A dedicated `homespun-workers-rg` resource group holds all dynamically created container groups.
+- Server MI gets the `Contributor` role (or a narrower custom role limited to `Microsoft.ContainerInstance/*`, `Microsoft.Network/virtualNetworks/subnets/join/action`, `Microsoft.ManagedIdentity/userAssignedIdentities/assign/action`) scoped to `homespun-workers-rg`.
+- Server MI additionally gets `AcrPull` scoped to the ACR.
+
+**Rationale:** Limits blast radius. If the server is compromised, the attacker can create/destroy ACI in that RG and pull images — but cannot touch the server's own Container App, Postgres, or Key Vault.
+
+**Alternatives considered:**
+- **Subscription-scoped `Contributor`** — overly broad.
+- **User-assigned identity shared between server and workers** — simplifies secrets/ACR pulling but couples lifecycles.
+
+### D3: Worker VNet integration via subnet delegation
+
+**Decision:**
+- ACA environment is deployed with VNet injection into `aca-subnet`.
+- ACI container groups are deployed into a separate `aci-subnet` in the same VNet, delegated to `Microsoft.ContainerInstance/containerGroups`.
+- Server addresses workers at their private IP; optional Private DNS zone `workers.homespun.internal` maps `homespun-worker-{userId}-{issueId}.workers.homespun.internal` to the private IP.
+
+**Rationale:** Private-only comms; no public ingress on workers. Same VNet = no peering cost. Separate subnet because ACI delegation is subnet-exclusive.
+
+**Trade-off:** ACI in VNet-delegated subnets have slightly slower start times than public ACI (~5–10s overhead). Accepted.
+
+### D4: Azure Files Premium NFS for `~/.claude`
+
+**Decision:**
+- One Azure Files Premium share with NFS 4.1 protocol, mounted at `/mnt/homespun-claude` in every worker.
+- Per-worker mount subpath: `<share>/users/<userId>/issues/<issueId>/.claude/` → `/home/homespun/.claude/`.
+- Directory created on first worker launch for that `(user, issue)` pair.
+
+**Rationale:** NFS handles small-file workloads (Claude Code writes many small files) far better than SMB. Premium tier gives predictable low latency. Per-issue subpath keeps sessions isolated and matches Docker mode's layout.
+
+**Alternatives considered:**
+- **Standard SMB share** — works, but latency on Claude Code's many-small-file pattern was a concern in discovery.
+- **Azure Container Storage** — newer; adds infrastructure surface without clear benefit here.
+
+### D5: Credentials flow — Postgres → ARM env vars → init script → filesystem
+
+**Decision:**
+1. At worker-launch, server queries `UserGitHubToken`, `UserClaudeToken`, and `UserSecret` rows for the current user.
+2. Decrypts via `IDataProtector`.
+3. Sets these as ACI environment variables: `GITHUB_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, and each `USER_SECRET_<NAME>`.
+4. ACI env vars are marked `secureValue` so they're not returned from ARM reads after creation.
+5. Worker image `start.sh` init script reads `$CLAUDE_CODE_OAUTH_TOKEN` and writes it to `~/.claude/.credentials.json` in the standard Claude Code format, then `exec`s the worker process.
+
+**Rationale:** Matches the pattern the user confirmed in discovery. Keeps all credential material out of mounted volumes.
+
+**Alternatives considered:**
+- **Azure Key Vault CSI driver** — cleanest but requires an AKS-style CSI integration that ACI doesn't support natively; would need a per-user Key Vault which is excessive.
+- **Pre-generated `.credentials.json` on Azure Files** — couples credential rotation to file-share operations; harder to audit.
+
+### D6: Container group naming + uniqueness
+
+**Decision:**
+- Container group name: `homespun-worker-{userId}-{issueId}`.
+- `userId` is a short form (first 8 chars of GUID) to stay under ACI's 63-char name limit.
+- Before create: server queries ARM for existing container group with that name; if found and running, reuse (matches Docker mode's reuse semantics); if found and stopped, delete + recreate; if not found, create.
+
+**Rationale:** Deterministic names enable reuse without tracking state in Postgres. The reuse-or-replace decision mirrors what `DockerAgentExecutionService` does today.
+
+### D7: Server-to-worker communication stays HTTP SSE
+
+**Decision:** Server makes HTTP requests to `http://<worker-private-ip>:8000` (or `http://<fqdn>:8000`). SSE connections stream tool events back. Identical wire format to Docker mode.
+
+**Rationale:** Zero change to the worker's Hono server, to AG-UI streaming, or to SignalR broadcast path. Easiest possible port from Docker mode.
+
+**Trade-off:** If a worker is killed mid-stream, in-flight SSE is lost. Session state is in Postgres (see `session_messages`), so the next session can continue — matches Docker mode behavior.
+
+### D8: Lifecycle operations and timeouts
+
+**Decision:**
+- **Start**: server calls ARM `CreateOrUpdate` on the container group; polls provisioning state with a 60-second budget; returns the private IP once state is `Succeeded` and the worker's `/health` endpoint responds.
+- **Stop**: explicit user action or idle-eviction after N minutes of inactivity → server calls ARM `Delete`.
+- **Crash recovery**: a separate hosted service scans the workers RG every 2 minutes, removes container groups that are `Failed` or have exceeded a hard TTL (e.g. 24h).
+- **Orphan cleanup on startup**: on server startup, list container groups in the workers RG whose `(userId, issueId)` doesn't correspond to any active session; schedule them for deletion.
+
+**Rationale:** Explicit lifecycle + janitorial sweep handles the common failure modes without over-engineering.
+
+### D9: Observability
+
+**Decision:**
+- Container group created with a `LogAnalyticsWorkspaceId` property → all stdout/stderr routes to Log Analytics.
+- Each container group is tagged with `homespun.userId`, `homespun.issueId`, `homespun.projectId` for filtering in Loki/Log Analytics.
+
+**Rationale:** Matches existing log pipelines; enables per-session log queries from the UI.
+
+## Risks / Trade-offs
+
+- **[Risk] ACI start time spikes during Azure capacity pressure** → Mitigation: 60-second timeout, clear UI indicator "starting worker…", retry once on timeout, surface error if still failing.
+- **[Risk] Private IP exhaustion in `aci-subnet` under heavy load** → Mitigation: size the subnet generously (/24 = 250 workers); monitor free IPs via Azure Monitor alert.
+- **[Risk] NFS mount failure causes worker boot to hang** → Mitigation: init script has a short NFS-mount health check; if the mount fails, log and exit with a diagnostic code so ARM sees provisioning failure rather than an unresponsive container.
+- **[Risk] ARM throttling under high session churn** → Mitigation: cache recent container-group lookups client-side; batch cleanup sweeps instead of per-event deletes.
+- **[Risk] Credential leak via ARM auditing / logs** → Mitigation: env var `secureValue`, tag container groups without secrets, never log the decrypted token. Verify with a code-review checklist.
+- **[Trade-off] Two execution backends to maintain (Docker + ACI)** → Accepted. Interface is narrow (`IAgentExecutionService`); VM mode stays on Docker indefinitely.
+- **[Risk] `DockerAgentExecutionService` registration conflict if both backends register as singletons** → Mitigation: only register the active one based on `AgentExecution:Mode`. Factory does not hold both.
+
+## Migration Plan
+
+1. Ship `AciAgentExecutionService` alongside `DockerAgentExecutionService`. Default config remains Docker.
+2. In an ACA deployment, set `AgentExecution:Mode=Aci` and deploy IaC changes (subnet, Files share, MI + RBAC).
+3. Start a worker for a test issue; verify provisioning, `.claude` mount, credential injection, SSE stream.
+4. Rollback path: flip `AgentExecution:Mode=Docker` — but ACA has no Docker host. Effectively, rollback in ACA means rolling back the whole deployment. In VM, Docker mode is always the default and unaffected.
+
+## Open Questions
+
+- Do we want a user-assigned managed identity attached to each worker ACI so the worker itself can authenticate to Azure services (e.g. Azure OpenAI) without passing tokens? **Working assumption: no for now. Can add later.**
+- Should idle-eviction be per-container-group or per-session? **Working assumption: per container group — easier to reason about. Idle = no active session + no HTTP activity for N minutes.**
+- Is Log Analytics sufficient, or do workers also ship to Loki? **Working assumption: Log Analytics only in ACA mode; Loki remains VM-mode's log pipeline.**
+- What's the default CPU/memory? **Working assumption: 2 vCPU / 4 GB to match current Docker worker resource hints.**

--- a/openspec/changes/aci-agent-execution/proposal.md
+++ b/openspec/changes/aci-agent-execution/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The ACA deployment target needs a way to spawn per-issue agent worker containers. Docker-outside-of-Docker (the current mode) doesn't exist in ACA. Container Apps are too heavyweight for "one worker per issue, lifecycle controlled by the server" — provisioning takes 15–45s per app and replicas aren't individually addressable. Azure Container Instances (ACI) are purpose-built for exactly this pattern: per-second billing, ~10–30s start, individually-addressable private IPs, full image/tooling control. This change introduces an ACI-based execution service alongside the existing Docker service, selectable via configuration.
+
+## What Changes
+
+- Introduce `AciAgentExecutionService` implementing the existing `IAgentExecutionService` interface, so feature code stays agnostic of execution backend.
+- Introduce an `AgentExecutionFactory` that selects `Docker` or `Aci` based on `AgentExecution:Mode` configuration; both implementations register in DI, factory resolves the active one.
+- Server uses a system-assigned Managed Identity to call Azure Resource Manager (ARM) and create/delete ACI container groups. Each worker = one ACI container group, named `homespun-worker-{userId}-{issueId}`.
+- ACI workers attach to the same VNet subnet as the server's ACA environment; server addresses them by private IP (or private FQDN via Azure Private DNS).
+- Per-user `~/.claude` persistence via Azure Files NFS mount: `<share>/users/<userId>/issues/<issueId>/.claude`.
+- Secrets and tokens (from `multi-user-postgres`'s per-user credential store) are decrypted at worker-launch time and passed as ACI environment variables; worker init script writes `CLAUDE_CODE_OAUTH_TOKEN` into `~/.claude/.credentials.json` on startup.
+- ACR pull uses the server's managed identity (ACI supports MI-based pull) — no admin credentials in config.
+- Update `aca.likec4` model: remove `containerApp worker_app`, add dynamically-provisioned `aci worker` node with its relationships.
+- IaC updates: subnet delegation for ACI, Azure Files Premium NFS share, role assignments for server MI on the resource group, Private DNS Zone for worker FQDN resolution.
+- Session recovery on worker restart: mounted `.claude` plus restored `session_messages` from Postgres allow a resumed worker to pick up where it left off.
+
+## Capabilities
+
+### New Capabilities
+- `aci-execution`: ACI-based agent worker provisioning, lifecycle, networking, and credential injection. Selectable alongside Docker execution.
+
+### Modified Capabilities
+<!-- None. The Docker execution service is unchanged by this proposal. -->
+
+## Impact
+
+- **Backend**: New `Features/ClaudeCode/Services/AciAgentExecutionService.cs` (~similar size to `DockerAgentExecutionService`). New `AgentExecutionFactory` that resolves based on config. `Program.cs` DI branches on `AgentExecution:Mode`.
+- **Dependencies**: `Azure.ResourceManager`, `Azure.ResourceManager.ContainerInstance`, `Azure.ResourceManager.Network`, `Azure.Identity`. Optional: `Azure.ResourceManager.PrivateDns` for FQDN-based routing.
+- **IaC**: Bicep/Terraform for VNet + subnet, Azure Files Premium (NFS) share, role assignments (`Contributor` on the workers RG scope for server MI), Private DNS zone.
+- **Server-worker comms**: HTTP SSE over private IP/FQDN — same code path as Docker mode; only the hostname lookup changes.
+- **Container image**: `Dockerfile` (worker) gains a small init script that materializes `.credentials.json` from `$CLAUDE_CODE_OAUTH_TOKEN`. Otherwise the existing worker image works unchanged.
+- **Observability**: ACI containers ship logs to Log Analytics via the Log Analytics diagnostic setting on the container group.
+- **Cost**: Per-second ACI billing; typical worker ~$0.02/hour for 1 vCPU / 2GB at westus2 pricing. Azure Files Premium NFS share is flat-rate (~$0.20/GiB/month reserved).
+- **Security**: No secrets on disk in production — all flow through ACI env vars from Postgres-backed encrypted credential store. Workers have no inbound public access.
+- **Testing**: New `Homespun.Tests/Features/ClaudeCode/AciAgentExecutionServiceTests.cs` using a mocked ARM client. Integration smoke: optional live-test profile that provisions a real ACI in a scratch RG and tears it down.
+- **Depends on**: `multi-user-postgres` change (needs per-user credentials and user identity to key the worker lifecycle).

--- a/openspec/changes/aci-agent-execution/specs/aci-execution/spec.md
+++ b/openspec/changes/aci-agent-execution/specs/aci-execution/spec.md
@@ -1,0 +1,176 @@
+## ADDED Requirements
+
+### Requirement: Execution backend selectable via configuration
+
+The system SHALL select between Docker and ACI agent execution backends via `AgentExecution:Mode` configuration, with valid values `Docker` and `Aci`.
+
+#### Scenario: Docker mode selected
+- **WHEN** the server starts with `AgentExecution:Mode=Docker`
+- **THEN** the `IAgentExecutionService` resolved from DI SHALL be `DockerAgentExecutionService`
+
+#### Scenario: ACI mode selected
+- **WHEN** the server starts with `AgentExecution:Mode=Aci`
+- **THEN** the `IAgentExecutionService` resolved from DI SHALL be `AciAgentExecutionService`
+
+#### Scenario: Invalid mode fails startup
+- **WHEN** the server starts with an unrecognized `AgentExecution:Mode`
+- **THEN** the system SHALL fail startup with a clear configuration error
+
+### Requirement: Server provisions one ACI container group per (user, issue)
+
+When ACI mode is active, the system SHALL create one Azure Container Instance container group per `(userId, issueId)` pair, naming it `homespun-worker-{userIdShort}-{issueId}`.
+
+#### Scenario: First session on an issue creates a container group
+- **WHEN** a user starts an agent session for an issue with no existing worker
+- **THEN** the system SHALL call ARM to create a container group named `homespun-worker-{userIdShort}-{issueId}` in the configured workers resource group
+- **AND** the container group SHALL be configured with CPU and memory from `AgentExecution:Aci:Resources`
+
+#### Scenario: Subsequent session on the same issue reuses the container group
+- **WHEN** a user starts a second agent session for the same issue within the idle window
+- **AND** the container group for that `(userId, issueId)` exists and is `Running`
+- **THEN** the system SHALL reuse the existing container group without a new ARM create call
+
+#### Scenario: Failed container group is replaced
+- **WHEN** a new session starts AND an existing container group for that `(userId, issueId)` is in `Failed` state
+- **THEN** the system SHALL delete the failed group and create a fresh one
+
+### Requirement: VNet-attached private networking
+
+ACI worker container groups SHALL be deployed into a VNet subnet delegated to `Microsoft.ContainerInstance/containerGroups`. The server SHALL communicate with workers via private IP (or private FQDN) — no public ingress on workers.
+
+#### Scenario: Container group is created in the delegated subnet
+- **WHEN** the system creates a container group
+- **THEN** the ARM request SHALL include `SubnetIds` referencing the configured `AgentExecution:Aci:SubnetId`
+- **AND** the resulting container group SHALL have an `ipAddress.type = 'Private'`
+
+#### Scenario: Server reaches worker via private IP
+- **WHEN** a container group reports `ipAddress.ip = W.X.Y.Z`
+- **THEN** the server SHALL make HTTP requests to `http://W.X.Y.Z:8000` using the existing SSE protocol
+
+#### Scenario: No public endpoint is exposed
+- **WHEN** a container group is created
+- **THEN** the ARM request SHALL NOT include a public IP configuration
+
+### Requirement: Managed identity for ARM operations
+
+The server SHALL authenticate to ARM using a system-assigned managed identity. The MI SHALL have role assignments scoped to the workers resource group (container instance operations) and the ACR (image pull).
+
+#### Scenario: ARM calls use the server's managed identity
+- **WHEN** the system creates, reads, or deletes a container group
+- **THEN** the ARM client SHALL be constructed with `DefaultAzureCredential` or `ManagedIdentityCredential`
+- **AND** SHALL NOT use service principal secrets from configuration
+
+#### Scenario: Insufficient RBAC surfaces a clear error
+- **WHEN** the server attempts an ARM operation and receives HTTP 403
+- **THEN** the system SHALL log a clear diagnostic identifying the missing permission and fail the session start
+
+### Requirement: Azure Files NFS mount for per-user per-issue .claude state
+
+Each worker container group SHALL mount a subpath of the Azure Files NFS share at `/home/homespun/.claude`, where the subpath is `users/{userId}/issues/{issueId}/.claude`.
+
+#### Scenario: Mount path is user-and-issue scoped
+- **WHEN** a container group is created for user A on issue X
+- **THEN** the ARM request SHALL include a volume mount from `users/{userAId}/issues/{X}/.claude` on the Files share to `/home/homespun/.claude` in the container
+
+#### Scenario: Mount subpath is created if missing
+- **WHEN** a session starts for a `(userId, issueId)` pair that has no existing directory on the share
+- **THEN** the system SHALL create the subpath on the share before starting the container group
+
+#### Scenario: Claude state persists across worker restarts
+- **WHEN** a session completes, the container group is deleted, and a new session starts later on the same issue
+- **THEN** the new worker SHALL see the previous `.claude` directory contents at its mount point
+
+### Requirement: Credential injection via secure environment variables
+
+At worker launch, the system SHALL resolve the current user's GitHub token, Claude Code OAuth token, and project secrets from Postgres, decrypt them, and pass them to the ACI container group as `secureValue` environment variables.
+
+#### Scenario: Current user's tokens are injected
+- **WHEN** a worker is launched for user A on project P
+- **THEN** the ACI env `GITHUB_TOKEN` SHALL equal the decrypted value from user A's `user_github_tokens` row
+- **AND** the ACI env `CLAUDE_CODE_OAUTH_TOKEN` SHALL equal the decrypted value from user A's `user_claude_tokens` row
+
+#### Scenario: Current user's project secrets are injected
+- **WHEN** a worker is launched for user A on project P
+- **THEN** for each `UserSecret` belonging to user A and project P with name `N`, an env var `USER_SECRET_{N}` SHALL be set to its decrypted value
+
+#### Scenario: Another user's secrets are not injected
+- **WHEN** a worker is launched for user A
+- **THEN** NO secrets belonging to users other than A SHALL be set as env vars
+
+#### Scenario: Secure env values are not returned by subsequent ARM reads
+- **WHEN** the system creates a container group with secure env vars
+- **AND** later reads the container group via ARM
+- **THEN** the returned env values for secure vars SHALL be empty or redacted by Azure
+
+### Requirement: Init script materializes .credentials.json
+
+The worker container image SHALL include an entrypoint init step that, if `$CLAUDE_CODE_OAUTH_TOKEN` is set, writes a valid `.credentials.json` into `~/.claude/` before starting the worker process.
+
+#### Scenario: Credentials file is created on startup
+- **WHEN** a container starts with `CLAUDE_CODE_OAUTH_TOKEN=xyz` set
+- **THEN** `/home/homespun/.claude/.credentials.json` SHALL contain a JSON document with the token in the format expected by Claude Code
+- **AND** the file SHALL have mode 0600
+
+#### Scenario: Missing token fails startup
+- **WHEN** a container starts without `CLAUDE_CODE_OAUTH_TOKEN` set
+- **THEN** the init script SHALL exit non-zero with a diagnostic message, causing ARM provisioning to fail
+
+### Requirement: ACR pull via managed identity
+
+The worker container image SHALL be pulled from ACR using the server's managed identity, not admin credentials.
+
+#### Scenario: Container group is created with MI-based ACR pull
+- **WHEN** the system creates a container group
+- **THEN** the ARM request SHALL include `imageRegistryCredentials` referencing the server's managed identity with `identityType='SystemAssigned'`
+- **AND** SHALL NOT include a `username`/`password` pair
+
+### Requirement: Lifecycle operations
+
+The system SHALL support start, stop, and idle-eviction of ACI worker container groups.
+
+#### Scenario: Start blocks until worker is ready
+- **WHEN** the system provisions a new container group
+- **THEN** the start operation SHALL poll provisioning state until it is `Succeeded` AND the worker's `/health` endpoint returns HTTP 200
+- **AND** SHALL time out after 60 seconds with a clear error if either condition is not met
+
+#### Scenario: Stop deletes the container group
+- **WHEN** a user explicitly stops a session OR the idle timeout expires
+- **THEN** the system SHALL call ARM `Delete` on the container group
+
+#### Scenario: Orphan sweep runs on a timer
+- **WHEN** the janitor interval elapses (default 2 minutes)
+- **THEN** the system SHALL enumerate container groups in the workers resource group
+- **AND** SHALL delete any group in `Failed` state or exceeding the hard TTL
+- **AND** SHALL delete any group whose `(userId, issueId)` does not correspond to an active session
+
+#### Scenario: Startup reconciles with existing container groups
+- **WHEN** the server starts
+- **THEN** the system SHALL list existing container groups in the workers RG AND reconcile them against active sessions in Postgres, deleting any without an active session
+
+### Requirement: Observability via Log Analytics
+
+ACI container groups SHALL be created with a Log Analytics workspace diagnostic setting so that stdout/stderr ships to the configured workspace.
+
+#### Scenario: Container group is created with Log Analytics wired up
+- **WHEN** the system creates a container group
+- **THEN** the ARM request SHALL include a `diagnostics.logAnalytics` property referencing the configured workspace id and shared key
+
+#### Scenario: Container group is tagged for filtering
+- **WHEN** the system creates a container group
+- **THEN** the ARM request SHALL include tags `homespun.userId`, `homespun.issueId`, and `homespun.projectId` with the correct values
+
+### Requirement: Docker mode unchanged
+
+The existing `DockerAgentExecutionService` behavior SHALL NOT change as a result of this addition. VM deployments continue to work as before.
+
+#### Scenario: VM deployment with `AgentExecution:Mode=Docker` behaves identically
+- **WHEN** a VM deployment starts with the new code and `AgentExecution:Mode=Docker`
+- **THEN** agent sessions SHALL start and run identically to the previous release
+
+### Requirement: aca.likec4 reflects ACI topology
+
+The `docs/architecture/views/aca.likec4` model SHALL be updated to show the worker as a dynamically-provisioned ACI resource rather than a Container App.
+
+#### Scenario: ACA model includes the ACI worker node
+- **WHEN** a reader examines `docs/architecture/model/deployment-aca.likec4`
+- **THEN** the worker SHALL be represented as an `aci` (or equivalent) node attached to the `aci-subnet`, not as a `containerApp`

--- a/openspec/changes/aci-agent-execution/tasks.md
+++ b/openspec/changes/aci-agent-execution/tasks.md
@@ -1,0 +1,84 @@
+## 1. Dependencies & Configuration
+
+- [ ] 1.1 Add NuGet packages: `Azure.ResourceManager`, `Azure.ResourceManager.ContainerInstance`, `Azure.ResourceManager.Network`, `Azure.Identity` to `Homespun.Server.csproj`
+- [ ] 1.2 Add `AgentExecution:Mode` to configuration schema (`Docker` | `Aci`)
+- [ ] 1.3 Add `AgentExecution:Aci:*` options: `SubscriptionId`, `WorkersResourceGroup`, `SubnetId`, `FileShareName`, `FileShareResourceId`, `AcrLoginServer`, `WorkerImage`, `LogAnalyticsWorkspaceId`, `LogAnalyticsSharedKey`, `Resources:Cpu`, `Resources:MemoryGb`, `IdleTimeoutMinutes`, `HardTtlHours`, `JanitorIntervalMinutes`
+- [ ] 1.4 Bind options in `Program.cs` via `Configure<AciAgentExecutionOptions>`; validate on startup
+
+## 2. ACI Execution Service
+
+- [ ] 2.1 Create `Features/ClaudeCode/Services/AciAgentExecutionService.cs` implementing `IAgentExecutionService`
+- [ ] 2.2 Implement `ArmClientFactory` that builds an `ArmClient` using `DefaultAzureCredential`
+- [ ] 2.3 Implement `GetOrCreateWorkerAsync(userId, issueId, projectId, ...)`:
+  - Look up existing container group by deterministic name
+  - If `Running` → return cached worker reference
+  - If `Failed` or absent → provision fresh
+- [ ] 2.4 Implement container-group ARM payload builder: image, resources, env vars (secure), volume mount for Azure Files NFS, subnet ids, log analytics diagnostics, tags, ACR MI pull credentials
+- [ ] 2.5 Implement mount-path helper: ensure `users/{userIdShort}/issues/{issueId}/.claude` exists on the share before create
+- [ ] 2.6 Implement readiness polling: provisioning state → `/health` probe, 60s timeout
+- [ ] 2.7 Implement `StopWorkerAsync` → ARM `Delete`
+- [ ] 2.8 Reuse the existing SSE/HTTP client code from `DockerAgentExecutionService` for message streaming (refactor into a shared helper if needed, but do not change wire format)
+- [ ] 2.9 Resolve the worker's base URL from the returned private IP (optionally private FQDN)
+
+## 3. DI Factory & Registration
+
+- [ ] 3.1 Create `AgentExecutionFactory` or branch in `Program.cs` that registers `IAgentExecutionService` based on `AgentExecution:Mode`
+- [ ] 3.2 Ensure `ContainerDiscoveryService` / `ContainerRecoveryHostedService` only register in Docker mode
+- [ ] 3.3 Create `AciJanitorHostedService` (ACI mode only) that enumerates + cleans up orphaned / failed / expired container groups on a timer
+
+## 4. Credential Resolution & Injection
+
+- [ ] 4.1 Extend the credential resolution path (already user-scoped per `multi-user-postgres`) to return a `WorkerCredentials` bundle: decrypted `GITHUB_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, dict of `USER_SECRET_*`
+- [ ] 4.2 Pass the bundle into the ARM payload builder; mark all as `secureValue`
+- [ ] 4.3 Ensure no decrypted value is logged; add unit test asserting tokens are not present in any log output for the creation path
+
+## 5. Worker Image Init Script
+
+- [ ] 5.1 Update `src/Homespun.Worker/start.sh` to write `~/.claude/.credentials.json` from `$CLAUDE_CODE_OAUTH_TOKEN` (JSON shape verified against Claude Code's expected format)
+- [ ] 5.2 `chmod 0600 ~/.claude/.credentials.json`
+- [ ] 5.3 Exit non-zero with a clear message if token is missing
+- [ ] 5.4 Verify NFS mount is present at `/home/homespun/.claude`; fail fast if mount is missing or unwritable
+- [ ] 5.5 Add a test that exercises the init script in isolation (e.g. shell test + docker run)
+
+## 6. IaC — Azure Container Apps / ACI target
+
+- [ ] 6.1 Add Bicep/Terraform module for the shared VNet with two subnets: `aca-subnet` and `aci-subnet` (latter delegated to `Microsoft.ContainerInstance/containerGroups`)
+- [ ] 6.2 Provision an Azure Files Premium storage account with an NFS 4.1 share named `homespun-claude`
+- [ ] 6.3 Provision a Log Analytics workspace (or reuse existing) and expose workspace id + shared key as outputs
+- [ ] 6.4 Create a resource group `homespun-workers-rg` (or configurable name)
+- [ ] 6.5 Assign role: server MI → `Contributor` on `homespun-workers-rg` (tighten to a custom role later; document followup)
+- [ ] 6.6 Assign role: server MI → `AcrPull` on the ACR
+- [ ] 6.7 Assign role: server MI → `Storage File Data SMB Share Contributor` on the Azure Files share
+- [ ] 6.8 Optional: Private DNS zone `workers.homespun.internal` linked to the VNet
+- [ ] 6.9 Output: `AgentExecution:Aci:SubnetId`, `FileShareName`, `FileShareResourceId`, `WorkersResourceGroup`, `LogAnalyticsWorkspaceId`, `LogAnalyticsSharedKey` for injection into the server Container App
+
+## 7. Architecture Model Updates
+
+- [ ] 7.1 Update `docs/architecture/model/deployment-aca.likec4`: remove `containerApp worker_app`; add `aci worker` element attached to `aci-subnet`
+- [ ] 7.2 Update `docs/architecture/model/server-components-aca.likec4`: rename `AcaAgentExecutionService` → `AciAgentExecutionService`; update relationships
+- [ ] 7.3 Update `docs/architecture/views/aca.likec4` views as needed
+- [ ] 7.4 Run `likec4 validate` to confirm model is consistent
+
+## 8. Tests
+
+- [ ] 8.1 Unit tests: `AciAgentExecutionService` with a mocked `ArmClient` (creates expected payload; reuses on `Running`; replaces on `Failed`)
+- [ ] 8.2 Unit tests: credential bundle builder; no secrets logged; secure env markings applied
+- [ ] 8.3 Unit tests: janitor identifies orphans correctly
+- [ ] 8.4 Integration test (optional live profile): provision a real ACI in a scratch RG, verify `/health`, clean up
+- [ ] 8.5 Test: factory selects correct implementation per `AgentExecution:Mode`
+- [ ] 8.6 Test: invalid mode fails startup with a clear error
+
+## 9. Documentation
+
+- [ ] 9.1 Add `docs/aca-deployment.md` covering ACI mode: RBAC, subnet sizing, Files share sizing, observability
+- [ ] 9.2 Update `docs/AZURE_DEPLOYMENT.md` with the new IaC modules and configuration keys
+- [ ] 9.3 Document the credential flow and the init-script contract for worker images
+- [ ] 9.4 Add a troubleshooting section: "Worker failed to start" (NFS mount, ARM RBAC, image pull, missing token)
+
+## 10. Pre-PR Verification
+
+- [ ] 10.1 `dotnet test` green, including new `AciAgentExecutionService` tests
+- [ ] 10.2 `likec4 validate` passes for updated model
+- [ ] 10.3 `cd src/Homespun.Web && npm run lint:fix && npm run format:check && npm run typecheck && npm test`
+- [ ] 10.4 Manual smoke in a scratch Azure subscription: deploy IaC, start a session, observe private IP comms, confirm `.claude` persistence across session restarts, confirm logs arriving in Log Analytics
+- [ ] 10.5 Manual smoke VM mode: confirm Docker mode still works unchanged with the new factory DI

--- a/openspec/changes/multi-user-postgres/.openspec.yaml
+++ b/openspec/changes/multi-user-postgres/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-13

--- a/openspec/changes/multi-user-postgres/design.md
+++ b/openspec/changes/multi-user-postgres/design.md
@@ -1,0 +1,150 @@
+## Context
+
+Today Homespun persists state in three places on disk:
+
+1. `~/.homespun/homespun-data.json` — projects, pull requests, agent prompts, favorite models, user email (via `JsonDataStore`).
+2. `secrets.env` files next to each project clone (via `SecretsService`).
+3. `~/.homespun/session-metadata.json` + `sessions/*.jsonl` under the data directory (via `SessionMetadataStore` and `MessageCacheStore`).
+
+Deployments are single-user-per-instance by design: one `.env`, one `GITHUB_TOKEN`, one `CLAUDE_CODE_OAUTH_TOKEN`, no authentication. To run a shared instance (the eventual ACA target, and for multi-developer VM use), we need per-user identity and a concurrency-safe data store that survives container restarts.
+
+This change is the foundation for two subsequent changes — `aci-agent-execution` (replaces the Docker execution path) and `worker-clone-and-push` (changes worker workdir semantics). Those are intentionally out of scope here.
+
+## Goals / Non-Goals
+
+**Goals:**
+- All persistent state moves to Postgres (except `.fleece/` which stays in git, and `~/.claude/` which remains a filesystem store for Claude Code's native session state).
+- First-class `User` entity with OIDC identity; every owned record (project, prompt, secret, token, PR) attributes an owner.
+- Per-project visibility: `private` vs `public`. Simple enum — no per-user ACLs.
+- Per-user credentials (GitHub PAT, Claude OAuth token, project secrets) stored encrypted with ASP.NET DataProtection.
+- Admin seeding via declarative config; first login of a seeded email becomes admin.
+- Same code path for VM and ACA modes, different auth providers.
+- Fresh-start deployments — no migration from `homespun-data.json` is supported.
+
+**Non-Goals:**
+- Agent execution changes (Docker mode stays intact; ACI work is a separate change).
+- Fleece storage changes — Fleece remains git-based.
+- Worker workdir/clone changes — separate change.
+- Multi-tenant or org-level separation — one Postgres database per Homespun instance.
+- Rich RBAC — only `is_admin` flag + project visibility. No role tables, no per-project member lists.
+- Data migration tooling from the legacy JSON store.
+
+## Decisions
+
+### D1: EF Core 10 + Npgsql, single `HomespunDbContext`
+
+**Decision:** Use Entity Framework Core 10 with the Npgsql provider. One `DbContext` covering all entities (users, projects, pull requests, agent prompts, favorite models, secrets, user credentials, session metadata, session messages).
+
+**Rationale:** The project already targets .NET 10. EF Core is the idiomatic choice; LINQ-based repositories drop in cleanly where `IDataStore` methods live today. A single context keeps transactions simple (e.g. "delete project cascades PRs and prompts"). Npgsql has mature jsonb support, which we exploit for `session_messages.payload`.
+
+**Alternatives considered:**
+- **Dapper + hand-written SQL** — lighter weight, but migration story is manual and the current codebase has no SQL infrastructure.
+- **Marten (document DB on Postgres)** — good fit for append-only message cache but overkill for the relational data we have.
+- **Multiple bounded contexts** — premature; we don't have the scale or module boundaries that justify it.
+
+### D2: Authentication — Microsoft.Identity.Web on ACA, dev-mode shim on VM
+
+**Decision:**
+- ACA build: `Microsoft.Identity.Web` (Entra ID OIDC), standard JwtBearer for API, cookie auth for the SPA redirect flow.
+- VM build: auth is disabled (`Authentication:Mode=None`). A startup-created "Local Developer" user record is returned for all requests. Rationale: VM mode is explicitly stated as a development-only deployment.
+- Controllers use `[Authorize]` + a `CurrentUserAccessor` that resolves to the JWT subject on ACA and to the seeded local user on VM.
+
+**Rationale:** Uniform controller code regardless of mode. The VM shim is a trivial middleware that injects a `ClaimsPrincipal` with a synthetic subject. No extra identity provider to deploy in VM mode.
+
+**Alternatives considered:**
+- **Keycloak sidecar on VM** — too much operational surface for "it's only me, on my VM." Can be added later without breaking anything.
+- **Basic auth on VM** — worse UX than no-auth for a solo developer, same security posture (network-level).
+
+### D3: Per-user secrets + credentials use ASP.NET DataProtection with Postgres-backed key storage
+
+**Decision:** All secret-like columns (`user_github_tokens.token`, `user_claude_tokens.token`, `user_secrets.value`) are encrypted at rest via `IDataProtector`. DataProtection keys are stored in Postgres (`data_protection_keys` table) via a small custom `IXmlRepository` implementation — **not** on disk. This ensures encrypted columns are readable after a container restart.
+
+**Rationale:** ASP.NET DataProtection is battle-tested, key rotation is automatic, and keeping keys in the same DB as the ciphertext keeps the ACA deployment stateless. Key material is still separable via the DataProtection key ring encryption (KEK via Azure Key Vault in future — flagged as a followup).
+
+**Alternatives considered:**
+- **Azure Key Vault direct** — ideal eventual state, but adds an Azure dependency to VM mode. Followup.
+- **Filesystem-persisted keys** — current pattern, but breaks statelessness for ACA.
+- **Column-level PG encryption (pgcrypto)** — requires key management outside the app, duplicates what DataProtection already does well.
+
+### D4: Project visibility is a single enum on `projects.visibility`
+
+**Decision:** `projects.visibility IN ('private', 'public')`. `owner_user_id` is always set. Queries filter with `WHERE visibility = 'public' OR owner_user_id = @currentUser`.
+
+**Rationale:** Matches the stated requirement ("shared = visible to all users on the instance") with minimum schema complexity. Upgrading to a `project_members` ACL table later is additive — no breaking change if/when needed.
+
+**Trade-off:** No "shared with Alice and Bob but not Charlie" mode. Accepted — out of scope.
+
+### D5: Admin seeding via config, with explicit UI-driven demotion
+
+**Decision:**
+- `Admin:Emails` or `Admin:ExternalIds` in config lists seeded admins.
+- On OIDC login, if the identifying claim matches and the user doesn't exist yet, create them with `is_admin=true`. If they already exist, promote them on next login.
+- Removing an entry from the list does **not** auto-demote — this requires a UI action by another admin.
+- Empty config list on a production build fails startup with a clear error unless `Admin:AllowUnseededStart=true` is set.
+
+**Rationale:** Config is bootstrap, not runtime policy. Stops a misconfigured deploy from leaving an instance admin-less. Matches the user's explicit request for "specific admin seeding."
+
+### D6: Session messages as an append-only Postgres table
+
+**Decision:**
+```sql
+session_messages (
+  id           bigserial PRIMARY KEY,
+  session_id   text NOT NULL,
+  seq          int NOT NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  kind         text NOT NULL,         -- 'system', 'user', 'assistant', 'result', etc.
+  payload      jsonb NOT NULL,
+  UNIQUE (session_id, seq)
+)
+```
+Reads are `WHERE session_id = ? ORDER BY seq`. Streaming live is via LISTEN/NOTIFY or polling-on-seq — TBD in the ACI execution change. For now, `MessageCacheStore` is re-implemented with this table; no external streaming.
+
+**Rationale:** Append-only + ordered sequence = identical semantics to the current JSONL file. jsonb avoids schema churn when SDK message formats evolve. Postgres handles the "many concurrent sessions" write pattern far better than per-session files would with ephemeral containers.
+
+**Trade-off:** Slightly more storage vs. flat files. Negligible.
+
+### D7: Fresh-start upgrade, documented as breaking
+
+**Decision:** On first startup against a Postgres DB, EF Core migrations run. No import from `homespun-data.json`. Upgrade docs tell existing users to note their projects and re-create them.
+
+**Rationale:** The data store shape is changing enough (per-user scoping, encrypted secrets) that a migration tool is comparable work to a manual re-creation for the small existing user base. Keeps scope tight.
+
+### D8: VM deployment adds a Postgres container to `docker-compose.yml`
+
+**Decision:** Add a `postgres:17` service with a named volume. Connection string read from `ConnectionStrings:Homespun`. Data volume persists across container restarts.
+
+**Rationale:** One file to change; matches how Loki/Grafana are already composed. No extra operational load in VM mode.
+
+### D9: Test harness uses Testcontainers for integration tests, in-memory SQLite for fast unit tests
+
+**Decision:**
+- `Homespun.Api.Tests` (integration): Testcontainers-Postgres, real migrations.
+- `Homespun.Tests` (unit): SQLite in-memory (`Microsoft.Data.Sqlite.SqliteConnection("Filename=:memory:")`) with EF Core — fast, and sufficient for repository-level logic that isn't Postgres-specific.
+- Anywhere `MockDataStore` is used today, swap for an in-memory-backed DbContext.
+
+**Rationale:** Testcontainers catches Postgres-specific issues (jsonb, `ON CONFLICT`, enum handling) but is slow. SQLite keeps unit tests snappy. Document: any repository using Postgres-specific features (jsonb, LISTEN/NOTIFY) needs a Testcontainers integration test, not a SQLite unit test.
+
+## Risks / Trade-offs
+
+- **[Risk] EF Core migration churn during development** → Mitigation: Enforce "one migration per PR" in contributing guidelines; CI fails if `dotnet ef migrations add` would produce diffs. Squash migrations before final release of this change.
+- **[Risk] DataProtection key rotation loses access to old encrypted columns if keys expire** → Mitigation: Configure non-expiring keys for Homespun's use case; document recovery procedure (key export/import).
+- **[Risk] Public projects inadvertently expose secrets or PR data** → Mitigation: `user_secrets` always user-scoped, never project-scoped regardless of visibility. PRs remain project-scoped; a public project's PR list is visible to all users on the instance (explicitly part of "public" semantics).
+- **[Risk] VM-mode no-auth shim gets accidentally used in production** → Mitigation: Refuse to start with `ASPNETCORE_ENVIRONMENT=Production` AND `Authentication:Mode=None` unless `Authentication:AllowNoAuthInProduction=true` (intentional foot-gun with an on-ramp for edge cases).
+- **[Trade-off] Testcontainers in CI adds ~15s per test run** → Accepted; alternative is diverging behavior between unit and prod.
+- **[Trade-off] jsonb payloads are not queryable by domain fields** → Accepted; we access by `session_id` + `seq` only.
+- **[Risk] First-deploy admin-less instance** → Mitigation: D5 startup guard.
+- **[Risk] Ordering of EF migrations vs. hosted services on startup** → Mitigation: Run migrations in an `IHostedService` with `StartupOrder=0`, block subsequent services until complete.
+
+## Migration Plan
+
+1. Add Postgres to `docker-compose.yml`; provision Azure Database for PostgreSQL Flexible Server in ACA IaC.
+2. Deploy a build that runs EF migrations but still reads from the legacy JSON store (optional safety net during a canary — may skip given "fresh start" mandate).
+3. Cut over: set `Storage:Mode=Postgres`, redeploy. Existing JSON files are ignored (documented).
+4. Rollback: redeploy previous build; JSON files still on disk. Users re-enter anything created during the window.
+
+## Open Questions
+
+- Should the Claude OAuth token ever be shared across users, or is it strictly per-user? (Working assumption: strictly per-user, matching user's spec.)
+- Do we want a "service account" user for automated system actions (e.g. GitHub sync polling)? (Working assumption: yes, a `system` user seeded at migration, non-admin, can't log in.)
+- DataProtection KEK in Azure Key Vault — followup ticket, not blocking this change.

--- a/openspec/changes/multi-user-postgres/proposal.md
+++ b/openspec/changes/multi-user-postgres/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+Homespun is currently single-user-per-instance: every deployment has one GitHub identity, one set of credentials, and a JSON file (`homespun-data.json`) as its sole data store. To support a shared ACA deployment (and to make VM deployments usable by more than one developer), we need a real user model, per-user credentials, and a concurrency-safe data store. This change establishes that foundation — everything downstream (ACI-based workers, clone-and-push execution) depends on having per-user identity and a shared relational store.
+
+## What Changes
+
+- **BREAKING**: Replace `JsonDataStore` (`homespun-data.json`) with a Postgres-backed store accessed via EF Core 10.
+- **BREAKING**: Replace `secrets.env` per-project files with per-user secrets stored (encrypted) in Postgres.
+- **BREAKING**: Move `session-metadata.json` and `.sessions/*.jsonl` message cache to Postgres tables.
+- **BREAKING**: Introduce explicit user identity on every owned resource (projects, prompts, pull requests, secrets) — existing deployments start fresh, no data migration.
+- Introduce a `User` entity with OIDC-sourced identity (Entra ID on ACA; optional OIDC / no-auth single-user shim on VM).
+- Introduce project visibility: `private` (visible only to creator) or `public` (visible to all users on the instance). Configurable per project.
+- Store per-user GitHub tokens and Claude Code OAuth tokens (encrypted, ASP.NET DataProtection).
+- Admin users seeded via config (`Admin:Emails` / `Admin:ExternalIds`); first matching login becomes admin. Demotion requires explicit UI action, not config removal.
+- Bundle a Postgres container in the VM deployment (`docker-compose.yml`); use Azure Database for PostgreSQL Flexible Server in the ACA deployment.
+- Fleece issue data remains in `.fleece/` inside git (unchanged). DataProtection key persistence moves to Postgres-backed key storage to survive container restarts.
+- Ships with Docker-mode agent execution unchanged — only the data plane and auth plane change in this phase.
+
+## Capabilities
+
+### New Capabilities
+- `user-identity`: User accounts, OIDC authentication, admin seeding, per-user context on requests.
+- `project-visibility`: Private vs public project scoping, access checks on project-owned resources (prompts, PRs, secrets).
+- `persistent-data-store`: EF Core + Postgres as the canonical store for projects, pull requests, agent prompts, favorite models, session metadata, session messages.
+- `user-credentials`: Per-user storage of GitHub tokens, Claude Code OAuth tokens, and project secrets, encrypted at rest.
+
+### Modified Capabilities
+<!-- No existing specs in openspec/specs/ — this change creates the first capabilities. -->
+
+## Impact
+
+- **Backend**: Every service that injects `IDataStore` today (~20 files across `Features/*`) migrates to EF Core repositories or `DbContext` access. `SecretsService` loses its file-based implementation and becomes DB-backed. `SessionMetadataStore` and `MessageCacheStore` become EF-backed.
+- **Auth surface**: New `Microsoft.Identity.Web` pipeline on ACA builds; a development `no-auth` shim for VM mode that treats the single local developer as User #1.
+- **API**: All controllers gain implicit user scoping via `ClaimsPrincipal`. Public endpoints for login, admin user management, and per-user credential CRUD are added.
+- **Frontend**: MSAL React integration for ACA builds; login screen, current-user indicator, per-user settings page (tokens, secrets), project visibility toggle.
+- **Deployment**: New Postgres service in `docker-compose.yml`; Bicep/Terraform for Azure Database for PostgreSQL Flexible Server in ACA. EF Core migrations run on startup.
+- **Fresh-start deployments**: Existing single-user instances must back up and re-create projects/prompts/PRs after upgrade. Documented as a breaking change.
+- **Dependencies added**: `Npgsql.EntityFrameworkCore.PostgreSQL`, `Microsoft.EntityFrameworkCore.Design`, `Microsoft.Identity.Web`, `@azure/msal-browser`, `@azure/msal-react`.
+- **Dependencies removed**: None immediately; `JsonDataStore` kept only for test fixtures during transition.
+- **Testing**: Test harness switches to Testcontainers-Postgres or an in-memory Postgres (Npgsql + ephemeral DB). Existing `MockDataStore` replaced with an in-memory `DbContext` variant.

--- a/openspec/changes/multi-user-postgres/specs/persistent-data-store/spec.md
+++ b/openspec/changes/multi-user-postgres/specs/persistent-data-store/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Postgres as canonical data store
+
+The system SHALL persist all structured application data (users, projects, pull requests, agent prompts, favorite models, session metadata, session messages) in a Postgres database accessed via EF Core 10.
+
+#### Scenario: Server starts against a configured Postgres instance
+- **WHEN** the server starts with a valid `ConnectionStrings:Homespun` pointing to a Postgres database
+- **THEN** the system SHALL connect, run pending EF Core migrations, and begin serving requests
+
+#### Scenario: Server refuses to start without a connection string
+- **WHEN** the server starts without `ConnectionStrings:Homespun` set (outside of mock mode)
+- **THEN** the system SHALL fail startup with a fatal configuration error
+
+### Requirement: EF Core migrations run on startup
+
+The system SHALL apply pending EF Core migrations before serving any request.
+
+#### Scenario: Fresh database is migrated to current schema
+- **WHEN** the server starts against an empty database
+- **THEN** all migrations SHALL run to completion before the HTTP listener accepts requests
+
+#### Scenario: Already-migrated database starts normally
+- **WHEN** the server starts against a database at the current schema version
+- **THEN** no migrations SHALL be applied and startup SHALL proceed without delay
+
+### Requirement: JsonDataStore removal
+
+The system SHALL NOT read from or write to `homespun-data.json` for application data after this change. The `JsonDataStore` class SHALL be removed from production DI registration.
+
+#### Scenario: Legacy JSON file is ignored
+- **WHEN** a `homespun-data.json` file exists on disk at server startup
+- **THEN** the system SHALL NOT read it; all state comes from Postgres
+
+### Requirement: Session metadata in Postgres
+
+The system SHALL store the mapping of Claude Code session ids to issue/PR entities in a Postgres table, replacing `session-metadata.json`.
+
+#### Scenario: Session metadata survives container restart
+- **WHEN** a session metadata record is written
+- **AND** the server container is restarted
+- **THEN** a subsequent lookup by session id SHALL return the same metadata
+
+### Requirement: Session messages in append-only table
+
+The system SHALL store per-session agent messages in a Postgres `session_messages` table with columns `(id, session_id, seq, created_at, kind, payload jsonb)` and a uniqueness constraint on `(session_id, seq)`.
+
+#### Scenario: Message is appended with next sequence number
+- **WHEN** a new message arrives for `session_id = X`
+- **THEN** the system SHALL assign `seq = (max(seq) + 1)` for that session and insert the row
+
+#### Scenario: Messages are retrieved in order
+- **WHEN** a caller reads all messages for a session
+- **THEN** the system SHALL return rows ordered ascending by `seq`
+
+#### Scenario: Duplicate sequence number is rejected
+- **WHEN** two writers attempt to insert with the same `(session_id, seq)`
+- **THEN** the later writer SHALL receive a uniqueness violation and retry with the next `seq`
+
+### Requirement: VM deployment bundles Postgres
+
+The system's VM deployment (`docker-compose.yml`) SHALL include a Postgres service with a named data volume that persists across container restarts.
+
+#### Scenario: VM deploy includes postgres service
+- **WHEN** a user runs the VM deployment script
+- **THEN** the resulting compose stack SHALL include a `postgres` service with a volume mount for `/var/lib/postgresql/data`
+
+### Requirement: ACA deployment uses Azure Database for PostgreSQL
+
+The system's ACA deployment (IaC) SHALL provision an Azure Database for PostgreSQL Flexible Server and inject its connection string into the server Container App via secret reference.
+
+#### Scenario: ACA IaC creates a Flexible Server instance
+- **WHEN** the ACA IaC is applied
+- **THEN** an `Microsoft.DBforPostgreSQL/flexibleServers` resource SHALL exist and be reachable from the ACA environment's subnet
+
+### Requirement: DataProtection key storage in Postgres
+
+The system SHALL store ASP.NET DataProtection keys in a Postgres `data_protection_keys` table via a custom `IXmlRepository`, replacing the filesystem-based key storage used today.
+
+#### Scenario: Keys persist across container restarts
+- **WHEN** an encrypted value is written
+- **AND** the container is restarted
+- **THEN** the value SHALL be successfully decryptable using keys read from Postgres
+
+### Requirement: Integration tests use real Postgres
+
+Integration tests in `Homespun.Api.Tests` SHALL run against a real Postgres instance provisioned via Testcontainers.
+
+#### Scenario: API test fixture provisions a Postgres container
+- **WHEN** the API test suite runs
+- **THEN** the fixture SHALL start a Postgres 17 container, apply migrations, and tear it down at suite end
+
+### Requirement: Fleece and .claude remain filesystem-based
+
+The system SHALL NOT move `.fleece/` issue data or `~/.claude/` session state into Postgres. These remain git-tracked and filesystem-persistent respectively.
+
+#### Scenario: Fleece CLI continues to work against .fleece/ folder
+- **WHEN** a fleece issue is created
+- **THEN** the system SHALL write to the project's `.fleece/` folder exactly as it does today

--- a/openspec/changes/multi-user-postgres/specs/project-visibility/spec.md
+++ b/openspec/changes/multi-user-postgres/specs/project-visibility/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Project ownership
+
+Every project SHALL have an `owner_user_id` referencing the `User` that created it. The owner SHALL always have read and write access to the project regardless of visibility.
+
+#### Scenario: Owner is set on project creation
+- **WHEN** a user creates a new project
+- **THEN** the system SHALL set `owner_user_id` to the creating user's id
+
+#### Scenario: Owner can always access their project
+- **WHEN** the owner requests a project they created
+- **THEN** the system SHALL return the project regardless of its `visibility` setting
+
+### Requirement: Project visibility
+
+Each project SHALL have a `visibility` property with allowed values `private` or `public`. Default SHALL be `private`.
+
+#### Scenario: Default visibility is private
+- **WHEN** a user creates a project without specifying visibility
+- **THEN** the project SHALL be created with `visibility = 'private'`
+
+#### Scenario: Private project invisible to non-owners
+- **WHEN** user B requests a project owned by user A with `visibility = 'private'`
+- **THEN** the system SHALL respond with HTTP 404 (treat as not-found to avoid existence leaks)
+
+#### Scenario: Public project visible to all users on the instance
+- **WHEN** any authenticated user lists projects
+- **THEN** the response SHALL include projects where `visibility = 'public'` OR `owner_user_id` equals the requesting user
+
+#### Scenario: Owner can change visibility
+- **WHEN** the project owner updates `visibility` from `'private'` to `'public'` (or vice versa)
+- **THEN** the system SHALL persist the new value
+
+#### Scenario: Non-owner cannot change visibility
+- **WHEN** a non-owner non-admin user attempts to change a project's visibility
+- **THEN** the system SHALL respond with HTTP 403
+
+### Requirement: Project-scoped resource access
+
+Resources owned by a project (pull requests, agent prompts, project-scoped views) SHALL inherit the project's visibility rules.
+
+#### Scenario: Pull requests for a public project are visible to all users
+- **WHEN** an authenticated user lists pull requests for a `public` project
+- **THEN** the system SHALL return all pull requests for that project
+
+#### Scenario: Pull requests for a private project are visible only to the owner
+- **WHEN** a non-owner authenticated user lists pull requests for a `private` project
+- **THEN** the system SHALL respond with HTTP 404
+
+#### Scenario: Agent prompts scoped to a public project are visible to all users
+- **WHEN** an authenticated user lists agent prompts for a `public` project
+- **THEN** the system SHALL return the prompts
+
+### Requirement: Secrets are never subject to project visibility
+
+Per-user secrets SHALL remain strictly user-scoped regardless of any project's visibility setting.
+
+#### Scenario: User's secrets are not visible to other users via a shared project
+- **WHEN** user A sets a secret usable in a `public` project
+- **AND** user B queries secrets for that project
+- **THEN** the system SHALL return only user B's own secrets
+
+### Requirement: Admin override
+
+Users with `is_admin = true` SHALL have read access to all projects regardless of visibility, but admin status SHALL NOT grant write access to projects they do not own.
+
+#### Scenario: Admin can read a private project
+- **WHEN** an admin requests a private project owned by another user
+- **THEN** the system SHALL return the project
+
+#### Scenario: Admin cannot edit another user's project without being owner
+- **WHEN** an admin who is not the owner attempts to update project fields
+- **THEN** the system SHALL respond with HTTP 403

--- a/openspec/changes/multi-user-postgres/specs/user-credentials/spec.md
+++ b/openspec/changes/multi-user-postgres/specs/user-credentials/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Per-user GitHub token storage
+
+The system SHALL store each user's GitHub Personal Access Token encrypted in a `user_github_tokens` table keyed by `user_id`. No GitHub token SHALL be shared across users.
+
+#### Scenario: User sets their GitHub token
+- **WHEN** an authenticated user submits `POST /api/users/me/github-token` with a token value
+- **THEN** the system SHALL encrypt the value via `IDataProtector` and upsert the row for that user
+- **AND** the raw token SHALL NOT be persisted in plaintext anywhere
+
+#### Scenario: User retrieves their own token status
+- **WHEN** an authenticated user calls `GET /api/users/me/github-token`
+- **THEN** the system SHALL return a status payload indicating whether a token is present, its last-updated timestamp, and a masked preview — but NOT the decrypted value
+
+#### Scenario: GitHub operations use the current user's token
+- **WHEN** a service performs a GitHub API or git-push operation on behalf of a user
+- **THEN** the system SHALL decrypt that user's token and use it for authentication
+- **AND** SHALL NOT fall back to any instance-wide `GITHUB_TOKEN` environment variable in production
+
+### Requirement: Per-user Claude Code OAuth token storage
+
+The system SHALL store each user's Claude Code OAuth token encrypted in a `user_claude_tokens` table keyed by `user_id`.
+
+#### Scenario: User sets their Claude Code token
+- **WHEN** an authenticated user submits `POST /api/users/me/claude-token` with a token value
+- **THEN** the system SHALL encrypt the value via `IDataProtector` and upsert the row for that user
+
+#### Scenario: User's token is used when launching their agent workers
+- **WHEN** a worker is started for a user's session
+- **THEN** the system SHALL decrypt that user's Claude Code token and provide it to the worker via environment variable
+
+### Requirement: Per-user project secrets
+
+The system SHALL store project secrets in a `user_secrets` table keyed by `(user_id, project_id, name)`. Values SHALL be encrypted via `IDataProtector`.
+
+#### Scenario: User sets a secret for one of their projects
+- **WHEN** an authenticated user submits `PUT /api/projects/{id}/secrets/{name}` with a value
+- **THEN** the system SHALL upsert a row with `(user_id, project_id, name)` and the encrypted value
+
+#### Scenario: Secrets are not visible to other users on a public project
+- **WHEN** user A sets secret `FOO` on public project P
+- **AND** user B (not A) queries secrets for P
+- **THEN** the system SHALL return only user B's own secrets for P, NOT user A's
+
+#### Scenario: Secrets injected when agent runs on behalf of user
+- **WHEN** an agent worker starts for user A on project P
+- **THEN** the system SHALL decrypt and inject user A's secrets for project P as environment variables
+- **AND** SHALL NOT inject secrets belonging to other users
+
+### Requirement: secrets.env file removal
+
+The system SHALL NOT read secrets from `secrets.env` files on disk after this change.
+
+#### Scenario: Legacy secrets.env file is ignored
+- **WHEN** a `secrets.env` file exists in a project's folder on disk
+- **THEN** the system SHALL NOT read it when resolving secrets for an agent worker
+
+### Requirement: Credential deletion
+
+The system SHALL allow a user to delete their own stored credentials and secrets.
+
+#### Scenario: User deletes their GitHub token
+- **WHEN** an authenticated user calls `DELETE /api/users/me/github-token`
+- **THEN** the system SHALL remove the row; subsequent GitHub operations on behalf of that user SHALL fail with a clear "no token configured" error rather than using a fallback
+
+#### Scenario: User deletes a project secret
+- **WHEN** an authenticated user calls `DELETE /api/projects/{id}/secrets/{name}`
+- **THEN** the system SHALL remove the row scoped to `(current_user, project_id, name)`
+
+### Requirement: Credential encryption
+
+All credential and secret values SHALL be encrypted at rest using ASP.NET DataProtection. Raw values SHALL NOT appear in database columns.
+
+#### Scenario: Stored ciphertext is not plaintext-readable
+- **WHEN** a stored credential row is read directly from Postgres (e.g. via `psql`)
+- **THEN** the value column SHALL contain ciphertext unreadable without the DataProtection key ring
+
+### Requirement: Key ring survives restarts
+
+The system's DataProtection key ring SHALL be stored in Postgres so that encrypted credentials remain decryptable across container restarts.
+
+#### Scenario: Credentials decrypt after full restart
+- **WHEN** a user stores a credential
+- **AND** all Homespun containers are fully restarted (keys not in memory)
+- **THEN** the system SHALL successfully decrypt the stored credential using keys loaded from Postgres

--- a/openspec/changes/multi-user-postgres/specs/user-identity/spec.md
+++ b/openspec/changes/multi-user-postgres/specs/user-identity/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: User entity
+
+The system SHALL represent each authenticated principal as a `User` record with `id`, `external_id`, `email`, `display_name`, `is_admin`, `created_at`, and `last_login_at` columns.
+
+#### Scenario: New user created on first OIDC login
+- **WHEN** an OIDC-authenticated request arrives with a `sub` claim that has no matching `external_id` in the `users` table
+- **THEN** the system SHALL create a new `User` row with `external_id = sub`, `email` and `display_name` populated from token claims, `is_admin = false` (unless seeded — see admin seeding), and `created_at = now()`
+- **AND** the request SHALL be processed under the new user's identity
+
+#### Scenario: Existing user resolved on subsequent login
+- **WHEN** an OIDC-authenticated request arrives with a `sub` claim matching an existing `external_id`
+- **THEN** the system SHALL load that `User`, update `email`, `display_name`, and `last_login_at`, and process the request under that user
+
+### Requirement: OIDC authentication on ACA builds
+
+The system SHALL authenticate API requests on ACA deployments using Microsoft.Identity.Web against a configured Entra ID tenant.
+
+#### Scenario: Unauthenticated API request is rejected
+- **WHEN** a request to a `[Authorize]`-decorated endpoint arrives without a valid bearer token
+- **THEN** the system SHALL respond with HTTP 401
+
+#### Scenario: Valid Entra ID token is accepted
+- **WHEN** a request arrives with a valid JWT signed by the configured Entra ID tenant
+- **THEN** the system SHALL populate `HttpContext.User` with claims from the token and process the request
+
+### Requirement: VM-mode no-auth development shim
+
+The system SHALL support a no-authentication mode for VM/development deployments in which a single local user record is resolved for every request.
+
+#### Scenario: No-auth mode returns the seeded local user
+- **WHEN** the server is started with `Authentication:Mode=None`
+- **THEN** the system SHALL ensure a `User` row exists with `external_id='local'`, `is_admin=true`, `email='local@homespun.localhost'`
+- **AND** `HttpContext.User` for every request SHALL resolve to that user
+
+#### Scenario: No-auth mode is refused in production without explicit opt-in
+- **WHEN** the server is started with `ASPNETCORE_ENVIRONMENT=Production` AND `Authentication:Mode=None`
+- **AND** `Authentication:AllowNoAuthInProduction` is not `true`
+- **THEN** the system SHALL fail to start and log a fatal configuration error
+
+### Requirement: Admin seeding via configuration
+
+The system SHALL allow declarative seeding of admin users via `Admin:Emails` or `Admin:ExternalIds` configuration keys.
+
+#### Scenario: Seeded email becomes admin on first login
+- **WHEN** a new user logs in and their `email` claim matches an entry in `Admin:Emails`
+- **THEN** the `User` row SHALL be created with `is_admin=true`
+
+#### Scenario: Existing user is promoted if seeded after creation
+- **WHEN** an existing user's `email` or `external_id` matches an admin seed entry
+- **AND** the user logs in
+- **THEN** the system SHALL set `is_admin=true` on that user if not already set
+
+#### Scenario: Removing a seed entry does not demote
+- **WHEN** an admin user's entry is removed from the config list
+- **AND** that user logs in
+- **THEN** the system SHALL NOT change `is_admin`; demotion requires explicit UI action by another admin
+
+#### Scenario: Empty admin list in production fails startup
+- **WHEN** the server is started in production with an empty `Admin:Emails` AND empty `Admin:ExternalIds`
+- **AND** `Admin:AllowUnseededStart` is not `true`
+- **THEN** the system SHALL fail to start with a fatal configuration error
+
+### Requirement: Admin-only user management API
+
+The system SHALL expose endpoints for admins to list users, promote users to admin, and demote admins.
+
+#### Scenario: Non-admin cannot list users
+- **WHEN** a non-admin authenticated user calls `GET /api/users`
+- **THEN** the system SHALL respond with HTTP 403
+
+#### Scenario: Admin demotes another admin
+- **WHEN** an admin calls `DELETE /api/users/{id}/admin` targeting another admin user
+- **THEN** the system SHALL set `is_admin=false` on the target user
+
+#### Scenario: Admin cannot demote the last admin
+- **WHEN** an admin calls `DELETE /api/users/{id}/admin` AND only one admin remains (the target)
+- **THEN** the system SHALL respond with HTTP 409 and leave `is_admin` unchanged
+
+### Requirement: Current-user accessor
+
+The system SHALL provide an `ICurrentUserAccessor` service that returns the current request's `User` record.
+
+#### Scenario: Accessor resolves to authenticated user
+- **WHEN** a service calls `ICurrentUserAccessor.GetCurrentUserAsync()` during an authenticated request
+- **THEN** the method SHALL return the `User` row matching `HttpContext.User`'s subject claim

--- a/openspec/changes/multi-user-postgres/tasks.md
+++ b/openspec/changes/multi-user-postgres/tasks.md
@@ -1,0 +1,140 @@
+## 1. Scaffolding & Dependencies
+
+- [ ] 1.1 Add NuGet packages: `Npgsql.EntityFrameworkCore.PostgreSQL`, `Microsoft.EntityFrameworkCore.Design`, `Microsoft.Identity.Web`, `Microsoft.Identity.Web.UI` to `Homespun.Server.csproj`
+- [ ] 1.2 Add `postgres:17` service to `docker-compose.yml` with a `postgres-data` named volume and a bootstrap env block (`POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`)
+- [ ] 1.3 Wire `ConnectionStrings:Homespun` through `appsettings.json`, `.env.example`, and the `run.sh`/`run.ps1` launch scripts
+- [ ] 1.4 Add `dotnet ef` tool installation step to `Dockerfile.base` for migration generation in CI
+- [ ] 1.5 Create a new `Homespun.Server/Features/Data` folder for the `DbContext`, entities, and configurations
+
+## 2. DbContext & Entity Model
+
+- [ ] 2.1 Create `HomespunDbContext : DbContext` with `DbSet<>` properties for `Users`, `Projects`, `PullRequests`, `AgentPrompts`, `FavoriteModels`, `UserGitHubTokens`, `UserClaudeTokens`, `UserSecrets`, `SessionMetadata`, `SessionMessages`, `DataProtectionKeys`
+- [ ] 2.2 Port existing `Project`, `PullRequest`, `AgentPrompt` models to EF-friendly entities under `Features/Data/Entities` (add navigation properties, remove JSON-serialization-only shapes)
+- [ ] 2.3 Add new `User` entity with `Id`, `ExternalId`, `Email`, `DisplayName`, `IsAdmin`, `CreatedAt`, `LastLoginAt`; unique index on `ExternalId`
+- [ ] 2.4 Add `owner_user_id` FK and `visibility` enum column to `Project` entity
+- [ ] 2.5 Add `UserGitHubToken`, `UserClaudeToken`, `UserSecret` entities with encrypted `Value` columns (string, ciphertext)
+- [ ] 2.6 Add `SessionMetadata` entity replacing `session-metadata.json` structure
+- [ ] 2.7 Add `SessionMessage` entity with `(SessionId, Seq)` unique index, `Payload` as `jsonb` via `HasColumnType("jsonb")`
+- [ ] 2.8 Add `DataProtectionKey` entity matching `IXmlRepository` contract
+- [ ] 2.9 Write `IEntityTypeConfiguration` classes for each entity under `Features/Data/Configurations`
+- [ ] 2.10 Generate initial EF migration `InitialSchema` and verify `dotnet ef migrations script` output for sanity
+- [ ] 2.11 Register `HomespunDbContext` in `Program.cs` with `AddDbContext<HomespunDbContext>(options => options.UseNpgsql(...))` scoped
+
+## 3. Migration Runner
+
+- [ ] 3.1 Implement `DatabaseMigrationHostedService : IHostedService` that runs `dbContext.Database.MigrateAsync()` before other hosted services start (use `IHostLifetime` ordering or `StartupOrder=0` pattern)
+- [ ] 3.2 Add startup guard: refuse to start when `ConnectionStrings:Homespun` is absent outside mock mode
+- [ ] 3.3 Write integration test: fresh database → migrated schema → server serves requests
+
+## 4. Repository / Data Access Layer
+
+- [ ] 4.1 Create repository interfaces (`IProjectRepository`, `IPullRequestRepository`, etc.) mapping the narrow operations currently on `IDataStore`
+- [ ] 4.2 Implement EF-backed repositories for each; ensure project queries filter by visibility + current user
+- [ ] 4.3 Delete `JsonDataStore` from production DI registration; remove `IDataStore` singleton registration from `Program.cs`
+- [ ] 4.4 Replace all injections of `IDataStore` in feature services with appropriate repository interfaces (~20 files)
+- [ ] 4.5 Update `MockDataStore` → `InMemoryHomespunDbContext` fixture for mock mode and unit tests
+
+## 5. DataProtection
+
+- [ ] 5.1 Implement `PostgresXmlRepository : IXmlRepository` that stores key XML blobs in `data_protection_keys` table
+- [ ] 5.2 Register DataProtection with `.PersistKeysToCustomStore<PostgresXmlRepository>()` and `.SetApplicationName("Homespun")`
+- [ ] 5.3 Configure non-expiring keys and document rotation procedure in `docs/`
+- [ ] 5.4 Remove filesystem-based key persistence from `Program.cs`
+- [ ] 5.5 Write integration test: encrypt value, restart `DbContext` + service provider, decrypt successfully
+
+## 6. User Identity & Authentication
+
+- [ ] 6.1 Create `Features/Auth` folder with `AuthenticationMode` enum (`Entra`, `None`), options binding from `Authentication:*`
+- [ ] 6.2 Implement `ICurrentUserAccessor` and its default implementation that resolves `HttpContext.User` → `User` row (caches for the request lifetime via `IHttpContextAccessor`)
+- [ ] 6.3 Add Entra ID registration path: `builder.Services.AddAuthentication(...).AddMicrosoftIdentityWebApi(...)` gated on `Authentication:Mode=Entra`
+- [ ] 6.4 Add no-auth shim: middleware that injects a synthetic `ClaimsPrincipal` with `external_id='local'` when `Authentication:Mode=None`
+- [ ] 6.5 Add production-guard: refuse startup if `ASPNETCORE_ENVIRONMENT=Production` AND `Authentication:Mode=None` AND `Authentication:AllowNoAuthInProduction != true`
+- [ ] 6.6 Implement `UserLifecycleService.ResolveOrCreateAsync(ClaimsPrincipal)` that upserts a `User` row on OIDC login
+- [ ] 6.7 Decorate controllers with `[Authorize]` globally via a fallback policy; allow anonymous on `/health`, `/api/auth/*`, OIDC callback
+- [ ] 6.8 Unit test: valid token → user resolved, updates `last_login_at`; missing user → created
+- [ ] 6.9 Integration test: unauthenticated request → 401; authenticated → 200; no-auth mode → local user
+
+## 7. Admin Seeding
+
+- [ ] 7.1 Bind `Admin:Emails` and `Admin:ExternalIds` options
+- [ ] 7.2 Extend `UserLifecycleService.ResolveOrCreateAsync` to promote newly-created or existing users matching any seed entry
+- [ ] 7.3 Add startup guard: production + empty admin seeds → fail unless `Admin:AllowUnseededStart=true`
+- [ ] 7.4 Implement `POST /api/users/{id}/admin` and `DELETE /api/users/{id}/admin` (admin-only)
+- [ ] 7.5 Enforce "cannot demote last admin" in the delete endpoint
+- [ ] 7.6 Integration tests: seeded email → admin on first login; seeded ExternalId → admin; demote last admin rejected with 409
+
+## 8. Project Visibility
+
+- [ ] 8.1 Add `ProjectVisibility` enum (`Private`, `Public`) and column on `Project` with default `Private`
+- [ ] 8.2 Update `ProjectService.CreateAsync` / `CreateLocalAsync` to set `owner_user_id = currentUser.Id` and default visibility
+- [ ] 8.3 Update project queries to apply `WHERE visibility = Public OR owner_user_id = current_user_id`
+- [ ] 8.4 Add `PATCH /api/projects/{id}/visibility` (owner-only)
+- [ ] 8.5 Apply visibility filter to PR list and agent prompt list endpoints
+- [ ] 8.6 Verify secrets queries are always user-scoped (never leak across users even on public projects)
+- [ ] 8.7 Unit tests: private project invisible to non-owner; public visible; non-owner cannot change visibility
+- [ ] 8.8 Admin override tests: admin can read private projects owned by others but cannot edit
+
+## 9. Per-User Credentials
+
+- [ ] 9.1 Rebuild `SecretsService` to read/write from `UserSecret` table instead of `secrets.env`
+- [ ] 9.2 Add `UserGitHubTokenService` with encrypt/decrypt via `IDataProtector`
+- [ ] 9.3 Add `UserClaudeTokenService` mirroring GitHub token pattern
+- [ ] 9.4 Implement controllers:
+  - `GET/POST/DELETE /api/users/me/github-token`
+  - `GET/POST/DELETE /api/users/me/claude-token`
+  - `GET/PUT/DELETE /api/projects/{id}/secrets/{name}`
+  - `GET /api/projects/{id}/secrets` (list names, user-scoped)
+- [ ] 9.5 Update `DockerAgentExecutionService` to fetch GitHub + Claude tokens and secrets from the current user's records when launching a worker; remove fallback to env-var tokens in production paths
+- [ ] 9.6 Update `GitHubClientWrapper` / `GitHubService` to take the caller's token from `ICurrentUserAccessor` rather than `GITHUB_TOKEN` env
+- [ ] 9.7 Unit tests: encrypted at rest; masked on GET; deletion clears access
+- [ ] 9.8 Integration test: user A's secret not visible to user B even on a public project
+
+## 10. Session Metadata & Message Cache
+
+- [ ] 10.1 Rebuild `SessionMetadataStore` as an EF-backed repository over `SessionMetadata` entity
+- [ ] 10.2 Rebuild `MessageCacheStore` as an EF-backed repository over `SessionMessage` entity; sequence number allocation via transactional `max(seq)+1` with retry on unique-violation
+- [ ] 10.3 Remove JSONL filesystem writer from production DI; keep an in-memory fixture for tests
+- [ ] 10.4 Integration test: survive container restart; seq uniqueness under concurrent writes; messages retrieved ordered
+
+## 11. ACA Deployment IaC
+
+- [ ] 11.1 Add `Microsoft.DBforPostgreSQL/flexibleServers` resource to the ACA Bicep/Terraform (VNet-integrated, private DNS)
+- [ ] 11.2 Store admin password in Key Vault; wire connection string as a Container App secret
+- [ ] 11.3 Update `aca.likec4` model with the Postgres node and its relationships
+- [ ] 11.4 Document provisioning flow in `docs/AZURE_DEPLOYMENT.md`
+
+## 12. Frontend (React)
+
+- [ ] 12.1 Install `@azure/msal-browser` and `@azure/msal-react`
+- [ ] 12.2 Wrap the app in `MsalProvider` when `VITE_AUTH_MODE=entra`; provide a no-auth stub provider otherwise
+- [ ] 12.3 Build `/login` route + unauthenticated redirect
+- [ ] 12.4 Add `CurrentUser` indicator in the header with sign-out
+- [ ] 12.5 Add Settings page sections: GitHub token, Claude Code token, per-project secrets
+- [ ] 12.6 Add project visibility toggle on the project detail page (owner-only)
+- [ ] 12.7 Add `/admin/users` page (admin-only) with list + promote/demote actions
+- [ ] 12.8 Regenerate OpenAPI client (`npm run generate:api:fetch`) after backend routes land
+- [ ] 12.9 E2E test (Playwright): login flow in Entra mode via mock IdP; no-auth mode skips login
+
+## 13. Testing Infrastructure
+
+- [ ] 13.1 Add Testcontainers.PostgreSql to `Homespun.Api.Tests` fixture
+- [ ] 13.2 Replace all uses of `HomespunWebApplicationFactory`'s in-memory data store with a fixture-scoped Postgres container
+- [ ] 13.3 Add a SQLite-in-memory fixture for unit tests that don't need Postgres-specific features
+- [ ] 13.4 Update `tests/Homespun.Tests` to use the SQLite fixture for repository tests
+- [ ] 13.5 Ensure existing tests pass against the new stack (delete/port tests that relied on JsonDataStore directly)
+
+## 14. Documentation
+
+- [ ] 14.1 Update `docs/multi-user.md` to reflect real multi-user support (replace single-user-per-instance framing)
+- [ ] 14.2 Write `docs/database.md` covering connection string setup, migrations, backup, DataProtection key recovery
+- [ ] 14.3 Update `docs/AZURE_DEPLOYMENT.md` with Postgres provisioning steps
+- [ ] 14.4 Update `docs/installation.md` with Postgres requirements for VM mode
+- [ ] 14.5 Update `README.md` breaking-change callout and upgrade notes for existing single-user installations (manual re-creation required)
+- [ ] 14.6 Add a `docs/authentication.md` covering Entra ID registration, admin seeding, and the no-auth dev shim
+
+## 15. Pre-PR Verification
+
+- [ ] 15.1 `dotnet test` — all backend and API tests green
+- [ ] 15.2 `cd src/Homespun.Web && npm run lint:fix && npm run format:check && npm run typecheck && npm test && npm run test:e2e`
+- [ ] 15.3 Manual smoke: fresh VM deploy, create admin, create private + public project, set secrets, launch an agent session (Docker mode still works)
+- [ ] 15.4 Manual smoke: restart Homespun container — encrypted values still decryptable, sessions resumable from DB

--- a/openspec/changes/worker-clone-and-push/.openspec.yaml
+++ b/openspec/changes/worker-clone-and-push/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-13

--- a/openspec/changes/worker-clone-and-push/design.md
+++ b/openspec/changes/worker-clone-and-push/design.md
@@ -1,0 +1,125 @@
+## Context
+
+Current (Docker mode): `IssueWorkspaceService` creates a `main/` clone and per-issue `issues/{id}/src` clone on the host. The server and the worker share these paths via bind-mounts — server reads file trees and diffs directly from the filesystem; worker edits them in place. When the agent eventually pushes, it pushes the work branch to `origin`.
+
+With ACI, there is no shared host filesystem. The server is in ACA, the worker is an ACI container group, and they only share a VNet. Mounting the workdir over Azure Files works but is a poor fit: Claude Code writes hundreds of tiny files (especially via edit tools), and SMB/NFS latency compounds; concurrent-writer semantics between server UI previews and worker tool edits are fraught; and rebuilds of the tree for diff views would be slow.
+
+The alternative (this change): worker does its own clone, server doesn't need to read the worker's workdir directly. Git pushes are the source of truth. Two branches per session:
+
+- **Work branch** — clean, agent-driven commits. What becomes the PR.
+- **`tmp/wip/<branch>`** — snapshot of uncommitted workdir state, pushed by a background service for crash recovery only. Orthogonal history from the work branch; force-pushed on every update.
+
+## Goals / Non-Goals
+
+**Goals:**
+- ACI workers clone fresh on start, work ephemerally, and push frequently enough that a container crash loses only seconds of uncommitted work.
+- Server can serve the "what does the repo look like right now on this issue?" view without reading the worker's filesystem — just `git fetch` against the main clone + optionally the `tmp/wip` branch.
+- Snapshot mechanism does not interfere with the agent's own commits or branch state.
+- Bounded branch clutter: `tmp/wip/*` branches clean up automatically.
+
+**Non-Goals:**
+- Changing Docker mode's workdir behavior.
+- Moving `.fleece/` off disk (it remains in git — Last-Write-Wins handled by `Fleece.Core`).
+- Real-time preview of in-progress worker edits in the UI (nice-to-have via `tmp/wip` reads; out of MVP).
+- Tracking branch pushes to a non-origin remote (user confirmed: same repo, `tmp/` prefix).
+
+## Decisions
+
+### D1: Ephemeral workdir inside the ACI container
+
+**Decision:** The worker clones to `/workspace/src` (inside the container's ephemeral disk) on start. No persistent mount for the workdir.
+
+**Rationale:** Fast local filesystem; no cross-container contention; container crash → container is disposable, restart re-clones.
+
+**Trade-off:** Initial clone adds ~5–30s to worker start depending on repo size. Accepted — the user explicitly preferred this over continuous-restart cloning overhead (which is why we're on Container Instances reused across sessions, not Jobs).
+
+### D2: Two branches per session — work branch and `tmp/wip/<branch>`
+
+**Decision:**
+- Work branch name comes from Fleece (issue-scoped, unique). Agent commits and pushes to it on its own cadence.
+- Snapshot branch name: `tmp/wip/<workBranch>`. Independent lineage from the work branch.
+
+**Rationale:** Keeps a clean agent-written history on the work branch. Snapshot branch can be force-pushed freely without touching PR lineage. Separate name space is easy to filter in workflow configs.
+
+**Open concern:** If two users work on the same issue in a shared project, their Fleece branch names would collide. This is a pre-existing concern inherited from Fleece/IssueWorkspaceService (the workspace path collides too). We accept this limitation for now; if it becomes a problem, the fix is at the Fleece / branch-id layer, not here.
+
+### D3: Snapshot mechanics — `write-tree` + `commit-tree` + `update-ref`
+
+**Decision:** The snapshot service runs **inside the worker container** and uses git plumbing commands rather than `git add -A && git commit`:
+
+```bash
+# Compose a commit from the current workdir index without disturbing HEAD
+git -C /workspace/src add -A --intent-to-add      # noop for tracked; stages untracked for hashing
+tree=$(git -C /workspace/src write-tree)
+parent=$(git -C /workspace/src rev-parse --quiet --verify refs/heads/tmp/wip/$BRANCH || echo "")
+msg="wip snapshot $(date -u +%FT%TZ)"
+if [ -n "$parent" ]; then
+  commit=$(git -C /workspace/src commit-tree "$tree" -p "$parent" -m "$msg")
+else
+  commit=$(git -C /workspace/src commit-tree "$tree" -m "$msg")
+fi
+git -C /workspace/src update-ref refs/heads/tmp/wip/$BRANCH "$commit"
+git -C /workspace/src push origin "refs/heads/tmp/wip/$BRANCH" --force-with-lease
+```
+
+**Rationale:** `write-tree` captures staged content including untracked files (after `add --intent-to-add`) without moving HEAD or touching the working tree. The work branch and index stay untouched. `--force-with-lease` is safe against stale refs.
+
+**Alternatives considered:**
+- `git stash` + separate worktree on `tmp/wip`: more moving parts, risk of stash/unstash sequencing bugs.
+- Plain `git add -A && git commit` on the work branch: pollutes agent's PR history with "wip" commits.
+
+### D4: Snapshot cadence — event-driven, debounced
+
+**Decision:** The worker's message processing fires a `WipSnapshotTrigger` signal after every Claude tool-use completion AND on "session idle" (no tool use for 10s). A debouncer coalesces rapid triggers, pushing at most once every 10 seconds. If the session has been idle for >60s, no snapshot is pushed (steady state).
+
+**Rationale:** Bounds push frequency to ~6/minute per active worker in the busy case, zero in the idle case. Matches the earlier "max every 10s + on idle" guidance.
+
+**Trade-off:** In bursty tool-heavy sessions, the worst case loses ~10s of edits on crash. Accepted.
+
+### D5: Auth for snapshot pushes
+
+**Decision:** Same `GITHUB_TOKEN` env var used for the real push. Git configured with `credential.helper=store` against a `.git-credentials` file written by the init script (existing pattern) or via `GIT_ASKPASS` helper. No separate token.
+
+**Rationale:** The user already has push rights to the repo; snapshots are just more pushes. No additional permissions needed.
+
+### D6: Branch cleanup
+
+**Decision:**
+- On PR merge webhook (or server-side poll detecting PR merged): server calls GitHub API to delete `tmp/wip/<workBranch>`.
+- On session cleanup (worker container deleted, session ended): server deletes `tmp/wip/<workBranch>` immediately.
+- Orphan sweep: a server-side hosted service enumerates `tmp/wip/*` refs weekly, deletes any older than `WipSnapshotTtlDays` (default 7) with no matching active session.
+
+**Rationale:** Keeps the branch list clean. Worst case, orphans linger up to 7 days — bounded.
+
+### D7: Server remains read-only against main clone
+
+**Decision:** Server's `IssueWorkspaceService` behavior in ACI mode:
+- `EnsureProjectSetupAsync` creates a single `<dataBaseDir>/projects/<projectName>/main` clone on the server's filesystem (ephemeral to the server container — restored from git on server restart).
+- No per-issue `src/` path on the server side.
+- Any server-side operations that previously read from `issues/{id}/src/` now either `git fetch` then read from `main/` at the PR's target commit, OR fetch `tmp/wip/<branch>` for preview (nice-to-have, post-MVP).
+
+**Rationale:** Server only needs authoritative main + git fetch for everything else. Eliminates the coupled `issues/{id}/src/` state.
+
+**Trade-off:** "Live preview of worker edits before the agent commits" requires reading `tmp/wip/<branch>`. Defer to a followup; not in scope for this change.
+
+### D8: Docker mode untouched
+
+**Decision:** The existing `IssueWorkspaceService` remains registered in Docker mode. In ACI mode, a new `AciIssueWorkspaceService` is registered that drops the per-issue `src/` path and drops the clone-on-demand semantics (the worker clones itself).
+
+**Rationale:** Avoid churning the VM deployment. Introduce the new behavior only where new containers need it.
+
+## Risks / Trade-offs
+
+- **[Risk] CI workflows run on `tmp/wip/*` pushes, multiplying Actions cost** → Mitigation: update `README.md` and `docs/` to require `branches-ignore: ['tmp/**']`; additionally, avoid pushing if the tree has not changed since the last snapshot.
+- **[Risk] GitHub rate limit with frequent pushes** → Mitigation: 10-second debounce floor caps push rate; monitor `x-ratelimit-remaining` in push responses and back off on 403 rate-limit errors.
+- **[Risk] Orphan branches accumulate if cleanup races** → Mitigation: orphan sweep in addition to event-driven deletes; TTL is a safety net.
+- **[Risk] Two users on the same issue (shared project) collide on branch names** → Mitigation: documented limitation; if it becomes real, add `userId` to Fleece branch id scheme (out of scope here).
+- **[Risk] Snapshot includes secrets written to workdir (e.g. credential files)** → Mitigation: workers already operate with a `.gitignore` for common secret paths; any new secret-writing pattern must add to `.gitignore`; documented contributor checklist.
+- **[Trade-off] Losing live-preview of uncommitted worker state in ACI mode's UI** → Accepted for MVP; followup to read `tmp/wip/<branch>` for preview.
+- **[Trade-off] Extra ~5–30s worker startup time for clone** → Accepted; user confirmed.
+
+## Open Questions
+
+- Should the snapshot mechanism also include `.fleece/` edits in flight, or let Fleece's own persistence cover that? **Working assumption: Fleece writes to disk synchronously on edit, so `write-tree` captures it. No special handling needed.**
+- When the work branch is force-pushed (rebase onto main), do we also force-push `tmp/wip/<branch>` to match? **Working assumption: no — `tmp/wip` lineage is orthogonal. The next snapshot starts a fresh lineage if the parent ref is gone.**
+- Does the server need to `git fetch` the `tmp/wip` branches proactively, or only on demand? **Working assumption: on demand only (post-MVP preview feature).**

--- a/openspec/changes/worker-clone-and-push/proposal.md
+++ b/openspec/changes/worker-clone-and-push/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+In Docker mode today, the server and worker share a single cloned workspace per issue via bind-mounts. The server sees worker edits immediately in the local filesystem, which is cheap and fast, but it tightly couples server and worker to the same host filesystem. In ACA/ACI mode, the worker is a remote container with no shared filesystem. Rather than replicate the bind-mount model via Azure Files (high latency, shared-write hazards on the workdir, couples to a file-share topology), this change gives the ACI worker its own ephemeral git clone and makes the server read-only against a main-branch clone. Agent progress is durable via git pushes: the work branch (clean history) to origin and a tmp/ snapshot branch (crash recovery) debounced on significant events.
+
+## What Changes
+
+- ACI worker containers perform a fresh `git clone` into an ephemeral workdir on start. No mount of the working directory from Azure Files.
+- Worker owns its branch for the lifetime of the session. Server is read-only against a separate main-branch clone (used for serving diffs, gitgraph, file tree, etc.).
+- A lightweight non-agentic `WipSnapshotService` runs inside the worker. On significant events (e.g. after each Claude tool-use completion), debounced to at most once every N seconds, it pushes a snapshot of the current workdir state to `tmp/wip/<branchName>` on `origin` via git's plumbing (`write-tree` + `commit-tree` + `update-ref` + `push --force-with-lease`). This captures uncommitted edits without disturbing the worker's work branch.
+- Snapshot pushes use the current user's GitHub token (same token that pushes the real branch).
+- Cleanup: `tmp/wip/<branchName>` is auto-deleted when the corresponding pull request is merged or explicitly closed; an orphan sweep deletes any `tmp/wip/*` branches not linked to an active session older than a configurable TTL.
+- Last-Write-Wins merge semantics for Fleece issues continue to apply (already handled by `Fleece.Core`); this change does not affect Fleece.
+- Docker mode (VM) is UNCHANGED — continues bind-mounted workdir + shared workspace.
+- `IssueWorkspaceService` gains an ACI variant that does not maintain a main-branch clone per issue (only the server's read-only main clone is needed).
+- Documentation: instruct users to add `branches-ignore: ['tmp/**']` to their GitHub Actions workflows, and note that force-pushes to `tmp/` branches are expected.
+
+## Capabilities
+
+### New Capabilities
+- `worker-clone-push`: ACI worker clone-and-push lifecycle, WIP snapshot branch mechanics, cleanup, and server read-only access to main.
+
+### Modified Capabilities
+<!-- None. `IssueWorkspaceService` is extended with an ACI-specific variant, not a behavior change to the existing Docker path. -->
+
+## Impact
+
+- **Backend**: New `AciIssueWorkspaceService` (implements `IIssueWorkspaceService`) for ACI mode. New `WipSnapshotService` running inside the worker as a background task. Server-side code for serving "live view" of worker state shifts from filesystem reads to git reads against the server's main clone (unchanged) plus optional `tmp/wip/*` reads for diff previews (nice-to-have, not in MVP).
+- **Worker image**: Add a small process that listens for events (tool-use completion signals) and triggers the debounced push. Could be part of the existing Hono server or a sidecar process in the same container group (single-container ACI is simpler).
+- **API surface**: No new public endpoints. Internal `WipSnapshotTrigger` signal hooks into `MessageProcessingService` → worker.
+- **GitHub repo**: Each active session adds a `tmp/wip/<branch>` ref; bounded by active sessions × debounce cadence.
+- **CI cost impact**: Documented — users must add `branches-ignore: ['tmp/**']` to avoid redundant workflow runs on every snapshot.
+- **Docker/VM mode**: Unaffected.
+- **Depends on**: `aci-agent-execution` (needs the ACI execution path in place) and transitively `multi-user-postgres` (needs per-user tokens).

--- a/openspec/changes/worker-clone-and-push/specs/worker-clone-push/spec.md
+++ b/openspec/changes/worker-clone-and-push/specs/worker-clone-push/spec.md
@@ -1,0 +1,107 @@
+## ADDED Requirements
+
+### Requirement: ACI workers clone fresh on start
+
+When an ACI worker container starts, it SHALL perform a fresh `git clone` of the project repository into an ephemeral workdir inside the container. No persistent mount SHALL be used for the workdir.
+
+#### Scenario: Worker clones on first launch
+- **WHEN** an ACI worker container starts for `(userId, issueId)` with no prior workdir
+- **THEN** the init sequence SHALL clone the project's repository to `/workspace/src` using the user's GitHub token
+- **AND** SHALL check out the Fleece-assigned branch (creating it from the default branch if it does not exist on origin)
+
+#### Scenario: Worker re-clones on restart
+- **WHEN** an ACI worker container is restarted after a crash or stop/start cycle
+- **THEN** the new container SHALL perform a fresh clone rather than reusing any prior workdir state
+
+### Requirement: Worker owns its branch
+
+During a session, the worker SHALL be the sole committer to the work branch. The server SHALL NOT write to the worker's branch.
+
+#### Scenario: Server does not mutate worker branch
+- **WHEN** any server-side operation reads information about the worker's branch
+- **THEN** the operation SHALL use `git fetch` against a read-only main clone or call the GitHub API — it SHALL NOT perform writes to the branch
+
+### Requirement: Server operates read-only against a main clone
+
+In ACI mode, the server SHALL maintain only a single read-only clone per project (at `<dataBaseDir>/projects/<projectName>/main`) for serving diffs, file trees, and gitgraph. Per-issue `src/` clones SHALL NOT be created on the server side.
+
+#### Scenario: Server creates main clone on project setup
+- **WHEN** a project is first registered in ACI mode
+- **THEN** the server SHALL clone the repository to `<dataBaseDir>/projects/<projectName>/main` and set the remote
+- **AND** SHALL NOT create any per-issue `src/` directory
+
+#### Scenario: Server refreshes main clone on demand
+- **WHEN** the server needs an up-to-date view of main
+- **THEN** the server SHALL perform `git fetch origin` (or a targeted fetch) against the main clone
+
+### Requirement: WIP snapshot service
+
+The worker SHALL include a background service that pushes a snapshot of the current workdir state to `tmp/wip/<workBranch>` on `origin`, debounced and event-triggered.
+
+#### Scenario: Snapshot triggered after tool use
+- **WHEN** the agent completes a Claude tool-use
+- **THEN** the snapshot service SHALL receive a trigger signal
+
+#### Scenario: Debounced to at most once per 10 seconds
+- **WHEN** the snapshot service receives a trigger
+- **AND** the previous push was less than 10 seconds ago
+- **THEN** the service SHALL defer until the debounce window elapses and coalesce further triggers within the window
+
+#### Scenario: Snapshot uses git plumbing
+- **WHEN** the snapshot service pushes
+- **THEN** it SHALL compose a commit via `write-tree` + `commit-tree` + `update-ref` on `refs/heads/tmp/wip/<workBranch>`
+- **AND** SHALL push via `git push origin refs/heads/tmp/wip/<workBranch> --force-with-lease`
+- **AND** SHALL NOT modify the working tree, the index, or the work branch
+
+#### Scenario: Skip push when tree unchanged
+- **WHEN** the computed tree hash equals the tree hash of the last successful snapshot push
+- **THEN** the service SHALL skip the push
+
+#### Scenario: Idle beyond threshold stops snapshots
+- **WHEN** no trigger has arrived for longer than the configured idle threshold (default 60 seconds)
+- **THEN** the service SHALL NOT generate periodic snapshots; only event-driven triggers resume pushes
+
+### Requirement: Snapshot pushes use current user's GitHub token
+
+Snapshot pushes SHALL authenticate using the same `GITHUB_TOKEN` injected into the worker for the user — no separate token.
+
+#### Scenario: Push uses user's token
+- **WHEN** the snapshot service performs a push
+- **THEN** the push SHALL use the token available at `$GITHUB_TOKEN` (same token used for the real work-branch push)
+
+### Requirement: Tmp branch cleanup on PR merge
+
+When a pull request for the work branch is merged or closed, the system SHALL delete the corresponding `tmp/wip/<workBranch>` ref.
+
+#### Scenario: PR merge triggers tmp branch deletion
+- **WHEN** the server detects a pull request for `workBranch` has been merged (via webhook or poll)
+- **THEN** the server SHALL call the GitHub API to delete `refs/heads/tmp/wip/<workBranch>`
+
+#### Scenario: Session cleanup also triggers tmp branch deletion
+- **WHEN** a session is explicitly ended and its worker container is deleted
+- **THEN** the server SHALL delete `refs/heads/tmp/wip/<workBranch>` if it exists
+
+### Requirement: Orphan tmp branch sweep
+
+The server SHALL run a periodic sweep that deletes `tmp/wip/*` branches that have no active session and exceed a configurable age.
+
+#### Scenario: Orphan sweep runs on a timer
+- **WHEN** the orphan sweep interval elapses (default weekly)
+- **THEN** the server SHALL enumerate `tmp/wip/*` branches via the GitHub API
+- **AND** SHALL delete any branch older than `WipSnapshotTtlDays` (default 7) with no active session
+
+### Requirement: Docker mode unchanged
+
+The worker clone-and-push model SHALL apply only to ACI mode. Docker mode SHALL continue using the existing bind-mounted shared workdir.
+
+#### Scenario: VM Docker deploy behavior preserved
+- **WHEN** a VM deployment is running with `AgentExecution:Mode=Docker`
+- **THEN** workspaces SHALL be created via the existing `IssueWorkspaceService` (per-issue `src/` clone bind-mounted into the worker), unchanged
+
+### Requirement: Documentation for downstream CI
+
+The project documentation SHALL instruct users to ignore `tmp/**` branches in their GitHub Actions workflows.
+
+#### Scenario: README and docs include branches-ignore guidance
+- **WHEN** a reader consults the documentation on GitHub Actions integration
+- **THEN** the documentation SHALL include a recommendation to add `branches-ignore: ['tmp/**']` to workflows that would otherwise trigger on these pushes

--- a/openspec/changes/worker-clone-and-push/tasks.md
+++ b/openspec/changes/worker-clone-and-push/tasks.md
@@ -1,0 +1,71 @@
+## 1. Server-Side Workspace Refactor (ACI Mode)
+
+- [ ] 1.1 Create `Features/ClaudeCode/Services/AciIssueWorkspaceService.cs` implementing `IIssueWorkspaceService`
+- [ ] 1.2 Implement `EnsureProjectSetupAsync` — clones/pulls `<dataBaseDir>/projects/<projectName>/main` on the server (same as Docker path)
+- [ ] 1.3 Implement `EnsureIssueWorkspaceAsync` — in ACI mode, returns a logical `IssueWorkspace` pointing at the main clone for server-side reads only; `sourcePath` is not populated
+- [ ] 1.4 Implement `CleanupIssueWorkspaceAsync` — no-op for per-issue source (there is no server-side per-issue clone); retain cleanup for any per-issue scratch state if introduced later
+- [ ] 1.5 Register `AciIssueWorkspaceService` in DI when `AgentExecution:Mode=Aci`; keep existing `IssueWorkspaceService` for Docker mode
+
+## 2. Worker-Side Clone Bootstrap
+
+- [ ] 2.1 Extend `src/Homespun.Worker/start.sh` (or an adjacent `clone.sh`) to perform `git clone <repoUrl> /workspace/src` on first start, using `$GITHUB_TOKEN`
+- [ ] 2.2 Configure `git config user.email` and `user.name` from env vars (`GIT_AUTHOR_EMAIL`, `GIT_AUTHOR_NAME` — populated per-user from Postgres)
+- [ ] 2.3 Checkout the Fleece-assigned branch, creating from default branch if needed
+- [ ] 2.4 Expose `WORKDIR=/workspace/src` env var for the worker process
+- [ ] 2.5 Ensure re-run tolerance (idempotent) in case the init script re-executes
+
+## 3. WIP Snapshot Service (Inside Worker)
+
+- [ ] 3.1 Add a `WipSnapshotService` module to `src/Homespun.Worker/src/` (TypeScript, same process as the Hono server for simplicity)
+- [ ] 3.2 Expose a `trigger()` method; internally implement a 10s debouncer and a 60s idle-skip rule
+- [ ] 3.3 On trigger: run the plumbing sequence:
+  - `git add -A --intent-to-add`
+  - `tree=$(git write-tree)`
+  - If `tree` equals the last-pushed tree hash → skip
+  - `parent=$(git rev-parse --quiet --verify refs/heads/tmp/wip/<branch>)` (may be empty)
+  - `commit=$(git commit-tree $tree [-p $parent] -m "wip snapshot <timestamp>")`
+  - `git update-ref refs/heads/tmp/wip/<branch> $commit`
+  - `git push origin refs/heads/tmp/wip/<branch> --force-with-lease`
+- [ ] 3.4 Hook `WipSnapshotService.trigger()` into the worker's message/tool-use completion pipeline
+- [ ] 3.5 Emit a SignalR/log event on each push (for observability — "wip snapshot pushed at <sha>")
+- [ ] 3.6 Handle push failures (rate limit, network) with exponential backoff; do not retry if tree hasn't changed
+
+## 4. Cleanup Mechanics
+
+- [ ] 4.1 Add `TmpBranchCleanupService` (server-side) with a GitHub API-based delete helper for `refs/heads/tmp/wip/<branch>`
+- [ ] 4.2 Wire `TmpBranchCleanupService.Delete` into the existing PR merge detection (`GitHubSyncPollingService` or equivalent)
+- [ ] 4.3 Wire `TmpBranchCleanupService.Delete` into session-end handling (when a worker is torn down via `AciAgentExecutionService.StopWorkerAsync`)
+- [ ] 4.4 Add `TmpBranchOrphanSweepHostedService` that runs weekly:
+  - Lists branches matching `tmp/wip/*` via GitHub API
+  - For each, checks if a corresponding session is active (Postgres query)
+  - Deletes branches with no active session older than `WipSnapshotTtlDays` (default 7)
+- [ ] 4.5 Add configuration: `WipSnapshot:TtlDays`, `WipSnapshot:SweepIntervalHours`
+
+## 5. DI & Configuration
+
+- [ ] 5.1 Add `AgentExecution:Aci:WipSnapshot:IdleThresholdSeconds` (default 60), `:DebounceSeconds` (default 10)
+- [ ] 5.2 Propagate these values into the worker via ACI env vars on container group creation (in `AciAgentExecutionService`)
+- [ ] 5.3 Ensure `AciIssueWorkspaceService` registers only in ACI mode; verify Docker mode behavior is untouched
+
+## 6. Tests
+
+- [ ] 6.1 Unit tests (TypeScript, worker): debouncer coalesces rapid triggers; skips push when tree unchanged; respects idle threshold
+- [ ] 6.2 Integration test (shell): initialize a local git repo, run the snapshot sequence, verify `tmp/wip/<branch>` contains the workdir state including untracked files
+- [ ] 6.3 Unit tests (C#, server): `TmpBranchCleanupService.Delete` invokes the right GitHub API; orphan sweep correctly identifies stale branches
+- [ ] 6.4 Integration test (C#): PR merge webhook triggers branch deletion via a mocked GitHub client
+- [ ] 6.5 Manual smoke: simulate container crash mid-session; start a new session; verify `tmp/wip/<branch>` contains the mid-session state
+
+## 7. Documentation
+
+- [ ] 7.1 Add `docs/worker-clone-push.md` explaining the ACI-mode workflow, branch naming, cleanup, and CI implications
+- [ ] 7.2 Update `README.md` with a call-out: "If you enable Homespun on this repo, add `branches-ignore: ['tmp/**']` to your GitHub Actions workflows"
+- [ ] 7.3 Update `docs/multi-user.md` (or wherever shared-project semantics live) noting the known limitation: two users working the same issue in a shared project share a branch name
+- [ ] 7.4 Update `docs/architecture/model/server-components-aca.likec4` if the workspace service needs a new component node
+
+## 8. Pre-PR Verification
+
+- [ ] 8.1 `dotnet test` green for server-side tests
+- [ ] 8.2 Worker vitest suite green for WIP snapshot service tests
+- [ ] 8.3 `cd src/Homespun.Web && npm run lint:fix && npm run format:check && npm run typecheck && npm test`
+- [ ] 8.4 Manual smoke in a scratch ACA/ACI deploy: start a session, perform tool edits, verify `tmp/wip/<branch>` appears and updates; end session, verify cleanup; trigger simulated orphan, verify sweep deletes it
+- [ ] 8.5 Manual smoke VM Docker mode: confirm workspace service behavior unchanged


### PR DESCRIPTION
## Summary

Three OpenSpec change proposals that together carve out the Azure Container Apps deployment path. **Proposals only — no code changes.** Each change is apply-ready (proposal + design + specs + tasks) and can be implemented independently in sequence.

### Proposed changes

- **[`multi-user-postgres`](./openspec/changes/multi-user-postgres)** (92 tasks) — foundational.
  - Postgres + EF Core 10 replaces `homespun-data.json`, `secrets.env`, `session-metadata.json`, and the `.sessions/` JSONL cache.
  - First-class `User` entity via Entra ID OIDC on ACA; network-trust + no-auth dev shim on VM.
  - Per-user encrypted credentials (GitHub PAT, Claude OAuth token, project secrets) via ASP.NET DataProtection with Postgres-backed key ring.
  - Project visibility (`private` / `public`), configurable per project. Owner-only writes; public = visible to all users on the instance.
  - Admin seeding via config (`Admin:Emails` / `Admin:ExternalIds`) with startup guards for empty lists and no-auth-in-production.
  - **BREAKING**: fresh-start upgrade — no migration from the legacy JSON store.

- **[`aci-agent-execution`](./openspec/changes/aci-agent-execution)** (52 tasks) — ACI-backed workers.
  - `AciAgentExecutionService` alongside `DockerAgentExecutionService`; factory selects via `AgentExecution:Mode`.
  - Server uses a system-assigned managed identity to ARM-provision one ACI container group per `(userId, issueId)` in a VNet-delegated subnet.
  - Azure Files Premium NFS share mounted at `~/.claude/` with per-user-per-issue subpaths.
  - Credentials injected as `secureValue` env vars; worker init script materializes `.credentials.json`.
  - ACR pull via MI, Log Analytics diagnostics, tagged container groups.
  - Docker mode untouched; VM deployments unaffected.
  - Updates `docs/architecture/model/deployment-aca.likec4` to reflect ACI topology.

- **[`worker-clone-and-push`](./openspec/changes/worker-clone-and-push)** (38 tasks) — ACI worker workdir semantics.
  - Workers clone fresh into ephemeral workdir on start. Server read-only against a main-branch clone.
  - Background `WipSnapshotService` pushes crash-recovery snapshots to `tmp/wip/<branch>` via git plumbing (`write-tree` + `commit-tree` + `update-ref` + `--force-with-lease`) — work branch stays clean.
  - Event-driven (tool-use completion) + 10s debounce + 60s idle-skip.
  - Auto-cleanup on PR merge + weekly orphan sweep.
  - Docker/VM mode untouched.

### Sequencing

```
multi-user-postgres  →  aci-agent-execution  →  worker-clone-and-push
    (foundation)          (Azure infra)         (behavioral refinement)
```

Each builds on its predecessor. Docker/VM mode remains intact across all three.

### Notable decisions worth a second opinion

- **ACI over Container Apps** for workers — matches "server-controlled lifecycle, per-issue containers" exactly; per-second billing; individually addressable.
- **Per-user secrets via ASP.NET DataProtection** with key ring in Postgres (not Key Vault) — flagged as a followup to move KEK to Key Vault.
- **`tmp/wip/<branch>` on the same repo** — cheap, uses existing creds, needs docs on `branches-ignore` for CI workflows.
- **VM mode stays on no-auth dev shim** — explicitly scoped to local-dev use; production guard refuses startup without opt-in.

## Test plan

This PR is proposals-only; no code runs yet. Review plan:

- [ ] Read `proposal.md` for each change — confirm motivation and scope boundaries
- [ ] Read `design.md` for each — push back on decisions / open questions before implementation starts
- [ ] Skim `specs/**/spec.md` for any spec-level requirements that feel under- or over-constrained
- [ ] Skim `tasks.md` for any missing tasks or obvious sequencing issues
- [ ] Confirm sequencing is right (foundation → infra → behavior)
- [ ] When approved, implement via `/opsx:apply multi-user-postgres` first

🤖 Generated with [Claude Code](https://claude.com/claude-code)