### PR TITLE
refactor(worker): simplify session-manager and enable Agent Skills

### DIFF
--- a/openspec/changes/simplify-worker-session-manager/.openspec.yaml
+++ b/openspec/changes/simplify-worker-session-manager/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/simplify-worker-session-manager/design.md
+++ b/openspec/changes/simplify-worker-session-manager/design.md
@@ -1,0 +1,144 @@
+## Context
+
+The worker's `SessionManager` (`src/Homespun.Worker/src/services/session-manager.ts`) was built early in the claude-agent-sessions lifecycle, before the TypeScript Agent SDK exposed mid-session primitives. It currently layers four independent workarounds on top of the SDK:
+
+1. **Close-and-resume per turn** — on every `result` message the code closes the `InputController`, which makes the CLI process exit. Subsequent sends call `query()` again with `resume: conversationId`. This duplicates ~80 lines of setup and makes `setPermissionMode` / `setModel` unusable after the first turn (guarded away because the CLI has exited).
+2. **Custom `InputController`** — a single-consumer async queue reimplementing `q.streamInput()`.
+3. **1000-entry in-memory message history** on `OutputChannel` for server-restart replay, exposed via `GET /sessions/:id/messages`. The server already has `Features/ClaudeCode/Services/MessageCacheStore.cs` persisting messages durably.
+4. **220-line `canUseTool` if-ladder** handling four special-cased tools (`AskUserQuestion`, `ExitPlanMode`, `WorkflowComplete`, `workflow_signal`) with two parallel pending-state maps for the first two.
+
+The SDK exposes `q.streamInput()`, `q.setPermissionMode()`, `q.setModel()`, and a well-defined `canUseTool` contract. The worker is short-lived per user-session, so there is no operational need for the in-memory history. Removing these workarounds is expected to take the file from ~1396 → ~600 lines.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Keep a single `query()` alive for the full worker lifetime of a session; follow-up messages use `q.streamInput()`.
+- Remove the `InputController` class.
+- Remove the `OutputChannel` message-history ring buffer and the `/sessions/:id/messages` worker endpoint.
+- Replace the `canUseTool` ladder with a small handler registry keyed by tool name, with two handler shapes (interactive, signal).
+- Unify the two pending-state maps into one generic `PendingInteraction<T>`.
+- Preserve the public API of `SessionManager` and the SSE event contract (control event shapes and ordering).
+- Preserve `status`, `lastMessageType`, and `lastMessageSubtype` semantics exactly.
+- Add targeted unit tests for the simplified paths.
+
+**Non-Goals:**
+- Changing the AG-UI/SSE event vocabulary consumed by the server.
+- Simplifying or renaming `status` / `lastMessageType` values exposed to callers.
+- Reworking `session-inventory.ts`, `session-discovery.ts`, `sse-writer.ts`, or `a2a-translator.ts`. These may receive tiny call-site updates but their logic is out of scope.
+- Changing how workflow-context tools (`WorkflowComplete`, `workflow_signal`) are gated — still required to have `workflowContext`, still validated the same way.
+- Touching the C# server's `MessageCacheStore` (this change only removes a worker-side duplicate).
+
+## Decisions
+
+### Single long-lived `query()` per session
+
+Today, each turn after the first is a brand-new `query({ prompt, options: { resume: conversationId, ... }})`. After the refactor, `create()` starts one `query()` and every `send()` calls `q.streamInput(onceIterator(text))` to push the next user message into it. Tools continue to execute via the same `canUseTool` callback inside that single CLI process.
+
+**Why**: The SDK documents `streamInput()` as the idiomatic primitive for multi-turn streaming input mode. The existing close-and-resume pattern was a workaround that the SDK has since obsoleted. One query eliminates ~80 lines of rebuild code, removes the `resultReceived` flag and all its downstream guards, and restores the ability to use `setPermissionMode` / `setModel` at any point.
+
+**Alternatives considered**:
+- *Status quo* — rejected; the complexity it creates is not justified by any remaining SDK limitation.
+- *Force a fresh `query()` per turn with `resume`* — rejected; it would keep ~80 lines of duplication and still require `resultReceived` gating.
+
+**Validation before landing**: A spike task (Phase 0) explicitly runs a query, idles for ≥10 minutes, then sends a follow-up via `streamInput` to confirm no silent CLI timeout.
+
+### Handler registry for `canUseTool`
+
+Replace the if-ladder with:
+
+```ts
+type InteractiveHandler = (input, session, ctx) => Promise<PermissionResult>; // awaits user
+type SignalHandler      = (input, session, ctx) => Promise<PermissionResult>; // emits + allows
+
+const handlers: Record<string, InteractiveHandler | SignalHandler> = {
+  AskUserQuestion:  askUserQuestionHandler,   // interactive
+  ExitPlanMode:     exitPlanModeHandler,      // interactive
+  WorkflowComplete: workflowCompleteHandler,  // signal
+  workflow_signal:  workflowSignalHandler,    // signal
+};
+```
+
+Each handler is a small self-contained function that receives the session and shared context (logger, pending-map, output channel). The dispatch becomes two lines.
+
+**Why**: Four structurally-independent concerns are currently interleaved in a 220-line function. Separation makes each handler testable in isolation and makes the list of special-cased tools visible at a glance.
+
+**Alternatives considered**:
+- *Class hierarchy* — rejected as over-engineered for four handlers.
+- *Separate files per handler* — deferred; a single `tool-handlers.ts` is sufficient at this count.
+
+### Generic `PendingInteraction<T>`
+
+```ts
+type PendingKind = "question" | "plan";
+interface PendingInteraction<T> {
+  data: T;
+  resolve: (result: PermissionResult) => void;
+  reject:  (err: Error) => void;
+}
+
+private pending = new Map<string, Map<PendingKind, PendingInteraction<unknown>>>();
+```
+
+Public manager methods become:
+- `resolvePending(sessionId, kind, payload)` (one method, dispatches per kind)
+- `hasPending(sessionId, kind)`
+- `getPendingData(sessionId, kind)`
+
+The route layer's two endpoints (`/answer`, `/approve-plan`) stay — they just call the unified manager API with different kinds.
+
+**Why**: The two existing maps have identical shapes and lifecycles. Unifying removes three pairs of near-duplicate methods.
+
+**Alternatives considered**:
+- *Keep two maps but share a base type* — rejected; same code savings, worse clarity.
+
+### Retain `OutputChannel` minus history
+
+`OutputChannel` stays as the merged stream where SDK messages and worker-emitted control events converge. It loses:
+- `history: MessageHistoryEntry[]`
+- `maxHistorySize`
+- `getMessagesSince`
+- `getAllMessages`
+
+The async-iterator half is fine as-is and reads naturally.
+
+**Why**: Two concerns in one class. The async queue is load-bearing; the history is duplication with `MessageCacheStore`.
+
+### Worker `/messages` endpoint removal (BREAKING)
+
+`GET /sessions/:id/messages` is deleted from `src/Homespun.Worker/src/routes/sessions.ts`. Any C# server-side code that calls this worker endpoint is removed as part of the same change. The server's own `MessageCacheStore` already persists all messages; full-session replay uses that.
+
+**Why**: Zero-value duplication, and only a single caller pattern to fix.
+
+### Debug-log watcher extraction
+
+Extract the `/home/homespun/.claude/debug/claude_sdk_debug.log` watcher + `FileMonitor` setup into `attachDebugLogStreaming(sessionId): { cleanup: () => void }` inside a new small helper (or co-located in `session-manager.ts` near `runQueryForwarder`). Called once per session lifetime, not per turn.
+
+### Preserving observable state
+
+`status`, `mode`, `permissionMode`, `lastMessageType`, `lastMessageSubtype`, `lastActivityAt`, `createdAt`, `conversationId` stay exactly as they are today on the `Session` type and in `SessionInfo`. `logStatusChange` stays. These are surfaced by `/sessions/active` and `/sessions/:id` and consumed by the server and UI.
+
+## Risks / Trade-offs
+
+- **[Risk]** SDK CLI self-terminates on long idle → follow-up `streamInput` hangs. **Mitigation**: Phase 0 spike explicitly measures idle tolerance at 10+ min. If there is a limit, add a keep-alive turn or fall back to selective resume only when idle threshold is crossed. If no limit, proceed without mitigation.
+- **[Risk]** `setPermissionMode` / `setModel` behave differently when called in a live query vs the currently-guarded "after result" path. **Mitigation**: covered by unit tests exercising both "mid-turn" and "between-turns" transitions.
+- **[Risk]** An SSE consumer somewhere relies on the history endpoint for reconnect. **Mitigation**: grep the server for worker `/messages` callers before deletion; if any exist, migrate them to `MessageCacheStore` in the same change.
+- **[Trade-off]** Unit-test coverage is added specifically for the simplified paths. Existing HTTP-level tests still gate end-to-end behavior, but they don't discriminate between the old and new code shapes — hence the new unit tests.
+- **[Trade-off]** Control-event ordering is preserved by construction (same call sites emit before awaiting the pending promise). No behavioral deviation expected.
+
+## Migration Plan
+
+The change ships as a single atomic refactor — no feature flag, no two-phase rollout. The worker is short-lived per session; the next session to spin up uses the new code, and old sessions naturally finish under the old build. Rollback is a standard git revert if issues surface in staging.
+
+Order of implementation (see tasks.md):
+
+1. **Spike** — verify SDK idle tolerance before touching production code.
+2. **Catalog server callers** of the worker's `/messages` endpoint so their removal ships atomically.
+3. **Refactor session-manager.ts** bottom-up: handler registry → pending unification → drop InputController → drop history → drop close-and-resume → drop guards.
+4. **Delete `/messages` endpoint + server callers**.
+5. **Add unit tests** alongside each refactor step (TDD: red → green per the project's conventions).
+
+## Open Questions
+
+- Should the handler registry live in a new file (`src/services/tool-handlers.ts`) or remain inline in `session-manager.ts`? Deferred to implementation — preference is inline unless it pushes the file back over 700 lines.
+- Does the worker need to expose any equivalent of the removed `/messages` endpoint for operator diagnostics (e.g. `/sessions/:id/debug`)? No known consumer today; leave out unless a need surfaces.
+- Idle tolerance spike script at `src/Homespun.Worker/scripts/spike-idle-tolerance.ts` — run manually before landing the refactor; keep-alive task to be added if it fails.

--- a/openspec/changes/simplify-worker-session-manager/proposal.md
+++ b/openspec/changes/simplify-worker-session-manager/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+`src/Homespun.Worker/src/services/session-manager.ts` has grown to ~1400 lines and is difficult to reason about. Much of the complexity is historical workarounds layered on top of the Claude Agent SDK — most notably rebuilding a fresh `query()` with `resume: conversationId` after every turn, a custom `InputController` that reimplements `q.streamInput()`, an in-memory message-history ring buffer that duplicates the server's `MessageCacheStore`, and a 220-line `canUseTool` branch ladder. The SDK now provides idiomatic primitives (`streamInput`, `setPermissionMode`, `setModel`) that make these workarounds unnecessary. Simplifying now pays off before `aci-agent-execution` and `worker-clone-and-push` add more surface area on top.
+
+## What Changes
+
+- Replace per-turn `query()` + `resume` rebuild with a single long-lived `query()` per session; follow-up messages go through `q.streamInput()`.
+- Remove the `InputController` class entirely.
+- Remove the 1000-entry `MessageHistoryEntry` ring buffer on `OutputChannel`; rely on the server-side `MessageCacheStore` for full-session replay.
+- **BREAKING**: Remove the worker's `GET /sessions/:id/messages` endpoint (`getMessageHistory`) and any server-side callers of it.
+- Replace the `canUseTool` if-ladder with a small handler registry splitting tool handlers into two classes: **interactive** (`AskUserQuestion`, `ExitPlanMode` — emit control event, await human) and **signal** (`WorkflowComplete`, `workflow_signal` — emit event, allow).
+- Unify `pendingQuestions` and `pendingPlanApprovals` into a single `Map<sessionId, Map<PendingKind, PendingInteraction>>` with a generic resolver.
+- Extract the debug-log file watcher setup into a helper so it is not duplicated across `create()` and the `send()` resume branch (which is itself being removed).
+- Drop the `resultReceived` flag and the `if (!ws.resultReceived && ws.query.setPermissionMode)` guards in `send()` / `setMode()` — no longer needed when the CLI stays alive across turns.
+- Add unit tests covering `send`/`streamInput`, `canUseTool` dispatch for all four special-cased tools, pending resolution lifecycle, and `setMode`/`setModel` pass-through.
+- Add a small spike task to verify the SDK CLI does not self-terminate during long idle periods (≥10 min) between turns.
+
+Behavior kept identical in this change:
+- Public API of `SessionManager` (method names, signatures, semantics from the route layer's perspective).
+- SSE event stream contents (control events `question_pending`, `plan_pending`, `status_resumed`, `workflow_complete`, `workflow_signal`).
+- `status` field values and `lastMessageType`/`lastMessageSubtype` tracking exposed via `/sessions/active` and `/sessions/:id`.
+- Plan-mode tool allow-list.
+
+## Capabilities
+
+### New Capabilities
+<!-- None — this is internal refactoring of an existing capability. -->
+
+### Modified Capabilities
+- `claude-agent-sessions`: Worker internal session runtime is simplified. No externally observable requirement changes except the removal of the `/sessions/:id/messages` worker endpoint (message replay now comes exclusively from the server-side cache).
+
+## Impact
+
+- **Worker**: `src/Homespun.Worker/src/services/session-manager.ts` — target reduction ~1396 → ~600 lines. `src/Homespun.Worker/src/routes/sessions.ts` — remove the `/messages` handler.
+- **Server**: any C# callers of the worker's `/sessions/:id/messages` endpoint in `Features/ClaudeCode/` (to be located during the first task). Server-side replay continues via `MessageCacheStore`.
+- **Tests**: new `session-manager.test.ts` (unit). Existing HTTP-level tests should continue to pass unchanged.
+- **Risk**: SDK idle-timeout behavior is unverified — addressed by a dedicated spike task before the refactor lands.
+- **Dependencies**: none. Changes are self-contained in the worker plus one small server cleanup.

--- a/openspec/changes/simplify-worker-session-manager/specs/claude-agent-sessions/spec.md
+++ b/openspec/changes/simplify-worker-session-manager/specs/claude-agent-sessions/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Single authoritative source for session message replay
+
+Full-session message replay SHALL be served exclusively by the server-side `MessageCacheStore`. The worker SHALL NOT maintain an in-memory message history, and SHALL NOT expose a replay endpoint.
+
+#### Scenario: Replay request after worker restart
+- **WHEN** a client requests message history for a session whose worker has been restarted
+- **THEN** the server SHALL serve the replay from `MessageCacheStore`
+- **AND** no fallback to the worker SHALL be attempted
+
+#### Scenario: Worker has no replay endpoint
+- **WHEN** any caller issues `GET /sessions/:id/messages` against the worker
+- **THEN** the request SHALL receive a 404 response
+
+### Requirement: Worker session uses a single long-lived SDK query per session
+
+A worker session SHALL back its entire lifetime with a single `query()` invocation; follow-up user messages SHALL be delivered via the SDK's streaming-input primitive without tearing down and rebuilding the query.
+
+#### Scenario: Follow-up message reuses the existing query
+- **WHEN** a user sends a follow-up message to a session that has already produced a `result`
+- **THEN** the worker SHALL push the message into the existing query via streaming input
+- **AND** the SDK CLI process SHALL NOT be restarted for that turn
+- **AND** the conversation SHALL continue under the same `conversationId`
+
+#### Scenario: Mid-session mode switch applies to the live query
+- **WHEN** `setMode` is invoked on a session that has produced a prior `result`
+- **THEN** the new permission mode SHALL be applied to the live query without restarting it
+
+#### Scenario: Mid-session model switch applies to the live query
+- **WHEN** `setModel` is invoked on a session that has produced a prior `result`
+- **THEN** the new model SHALL take effect on the next turn without restarting the query
+
+## REMOVED Requirements
+
+### Requirement: Worker-provided message history replay
+
+**Reason**: Duplicated by the server-side `MessageCacheStore`, which is the durable source of truth. The worker's in-memory ring buffer does not survive worker restarts and provides no unique value.
+
+**Migration**: Consumers of `GET /sessions/:id/messages` on the worker SHALL move to the server's message cache endpoints (backed by `MessageCacheStore`). Any C# server code calling the worker's `/messages` endpoint is removed as part of this change.

--- a/openspec/changes/simplify-worker-session-manager/tasks.md
+++ b/openspec/changes/simplify-worker-session-manager/tasks.md
@@ -1,0 +1,103 @@
+## 1. Spike: verify SDK idle tolerance
+
+- [x] 1.1 Write a throwaway script that creates a `query()` with streaming input, idles for ≥10 minutes after the first `result`, then calls `q.streamInput()` with a follow-up message
+      (Script written at `src/Homespun.Worker/scripts/spike-idle-tolerance.ts`; requires manual execution with `ANTHROPIC_API_KEY` set.)
+- [ ] 1.2 Confirm the follow-up produces a response and no silent CLI exit occurs; record the finding in `design.md` under Open Questions
+      (Pending manual run — not reproducible inside this refactor session; see open-questions entry for the command.)
+- [ ] 1.3 If the CLI self-terminates, document the observed timeout and add a keep-alive task to this file before proceeding
+      (Conditional on 1.2.)
+
+## 2. Catalog existing callers to be removed
+
+- [x] 2.1 Grep `src/Homespun.Server/` for any C# code that issues `GET /sessions/{id}/messages` against the worker, list each file:line
+      (None found. `DockerAgentExecutionService` calls `/api/sessions` and `/message` against the worker but not `/messages`.)
+- [x] 2.2 Grep the worker and server codebases for uses of `getMessageHistory` / `MessageHistoryEntry` / `getAllMessages` / `getMessagesSince` and confirm only worker-internal
+- [x] 2.3 Confirm no client (web or otherwise) calls the worker's `/messages` endpoint directly
+
+## 3. Unit test scaffolding (TDD red phase)
+
+- [x] 3.1 Create `src/Homespun.Worker/src/services/session-manager.test.ts` with Vitest setup and shared fixtures for a fake `Query` (async-iterable of SDK messages with stubbed `streamInput`, `setPermissionMode`, `setModel`, `interrupt`)
+      (Worker tests live under `tests/Homespun.Worker/services/` per `vitest.config.ts`; `streamInput` and `close` added to the shared mock helper.)
+- [x] 3.2 Add failing test: `send()` after a `result` message delivers the new user message via `q.streamInput()` and does NOT call `query()` a second time
+- [x] 3.3 Add failing test: `setMode()` calls `q.setPermissionMode()` when the session has already received a `result`
+- [x] 3.4 Add failing test: `setModel()` updates the session model and is callable after a prior `result`
+- [x] 3.5 Add failing test: `canUseTool("AskUserQuestion", ...)` emits a `question_pending` control event and awaits `resolvePending(id, "question", answers)`
+- [x] 3.6 Add failing test: `canUseTool("ExitPlanMode", ...)` emits `plan_pending` and resolves via `resolvePending(id, "plan", { approved, keepContext, feedback })`
+- [x] 3.7 Add failing test: `canUseTool("WorkflowComplete", ...)` with workflow context emits `workflow_complete` and returns `allow`; without workflow context returns `deny`
+- [x] 3.8 Add failing test: `canUseTool("workflow_signal", ...)` with workflow context emits `workflow_signal` and returns `allow`; without returns `deny`
+- [x] 3.9 Add failing test: `close()` rejects any outstanding pending interactions for the session
+
+## 4. Introduce tool-handler registry
+
+- [x] 4.1 Extract `AskUserQuestion` branch from `canUseTool` into an interactive handler function taking `(input, session, ctx)`
+- [x] 4.2 Extract `ExitPlanMode` branch into an interactive handler function
+- [x] 4.3 Extract `WorkflowComplete` branch into a signal handler function
+- [x] 4.4 Extract `workflow_signal` branch into a signal handler function
+- [x] 4.5 Replace the if-ladder with a `Record<string, Handler>` lookup and default `{ behavior: "allow", updatedInput: input }` fallback
+- [x] 4.6 Run tests 3.5 – 3.8; confirm they pass
+
+## 5. Unify pending-interaction state
+
+- [x] 5.1 Define `type PendingKind = "question" | "plan"` and `interface PendingInteraction<T> { data: T; resolve; reject }`
+- [x] 5.2 Replace `pendingQuestions` and `pendingPlanApprovals` with a single `Map<string, Map<PendingKind, PendingInteraction<unknown>>>`
+- [x] 5.3 Replace `resolvePendingQuestion` / `resolvePendingPlanApproval` with `resolvePending(sessionId, kind, payload)` that dispatches per kind (question → build answers; plan → build `PermissionResult` from `{ approved, keepContext, feedback }`)
+- [x] 5.4 Replace `hasPendingQuestion` / `hasPendingPlanApproval` / `getPendingQuestions` with `hasPending(sessionId, kind)` and `getPendingData(sessionId, kind)`
+- [x] 5.5 Update `routes/sessions.ts` `/answer` and `/approve-plan` handlers to call the unified API
+- [x] 5.6 Update `close()` to reject both kinds in one pass
+- [x] 5.7 Run tests 3.5 – 3.6 and 3.9; confirm they pass
+
+## 6. Replace InputController with `q.streamInput()`
+
+- [x] 6.1 Delete the `InputController` class and the `createInputStream` / `createResumeInputStream` helpers
+- [x] 6.2 In `create()`, build the query with the initial prompt as a simple string (or single-message async iterable) — no controller
+- [x] 6.3 In `send()`, replace `ws.inputController.send(message)` with `await ws.query.streamInput(onceIterator({ type: "user", ... }))`, where `onceIterator` yields one message and returns
+- [x] 6.4 Remove `inputController` field from `WorkerSession`
+- [x] 6.5 Update `close()` to call `ws.query.close?.()` instead of `inputController.close()`
+- [x] 6.6 Run test 3.2; confirm it passes
+
+## 7. Remove message-history ring buffer
+
+- [x] 7.1 Remove `history`, `maxHistorySize`, `MessageHistoryEntry`, `getMessagesSince`, `getAllMessages` from `OutputChannel`
+- [x] 7.2 Remove `getMessageHistory` from `SessionManager`
+- [x] 7.3 Delete `GET /sessions/:id/messages` handler from `src/Homespun.Worker/src/routes/sessions.ts`
+- [x] 7.4 Remove any server-side C# callers identified in task 2.1
+      (None existed — verified in 2.1. No C# changes needed.)
+- [x] 7.5 Remove unused imports exposed by the deletions
+
+## 8. Remove close-and-resume workaround
+
+- [x] 8.1 Delete the `if (msg.type === 'result') { ... inputController.close(); }` block in `runQueryForwarder`
+- [x] 8.2 Delete the `if (ws.resultReceived) { ... }` branch in `send()` that rebuilds a new `query()` with `resume`
+- [x] 8.3 In `send()`, always push the message via `q.streamInput()` (the single path from task 6.3)
+- [x] 8.4 Remove `resultReceived` field from `WorkerSession`
+- [x] 8.5 Remove `!ws.resultReceived && ...` guards in `send()` and `setMode()` — call `setPermissionMode`/`setModel` unconditionally when provided
+- [x] 8.6 Run tests 3.2, 3.3, 3.4; confirm they pass
+
+## 9. Extract debug-log watcher helper
+
+- [x] 9.1 Create `attachDebugLogStreaming(sessionId): { cleanup: () => void }` that encapsulates the `watch()` + `FileMonitor` setup and line-emission
+- [x] 9.2 Call it once from `create()`; call `cleanup()` from `runQueryForwarder`'s `finally` block
+- [x] 9.3 Remove the duplicated inline watcher code
+
+## 10. Clean-up and verification
+
+- [x] 10.1 Remove unused types: `InputController`, `MessageHistoryEntry`, and any now-dead exports
+- [ ] 10.2 Run `npm run lint:fix` in `src/Homespun.Worker`
+      (No `lint:fix` script exists in `src/Homespun.Worker/package.json`; linting is not configured for the worker package. Skipped as N/A.)
+- [x] 10.3 Run `npm run typecheck` in `src/Homespun.Worker`
+      (Ran `npx tsc --noEmit`; clean.)
+- [x] 10.4 Run `npm test` in `src/Homespun.Worker`; confirm all new tests pass
+      (173/173 worker tests pass. One unrelated pre-existing failure in `session-inventory.test.ts` from an ajv package-path import issue — also fails on main before these changes.)
+- [x] 10.5 Run `dotnet test` from repo root; confirm no regressions after server-caller removal
+      (2302/2302 non-Live tests pass, 0 failures, 7 skipped — ran with `--filter "TestCategory!=Live"`. One `[Category("Live")]` test, `DockerAgentExecutionServiceLiveTests.FollowUpPrompts_SameSession_BothComplete`, fails both pre-refactor and post-refactor with the same `Expected completed status-update for first prompt` assertion — the failure is reproducible against the unchanged old worker image, and the container logs of the post-refactor run show the new code paths (inventory event=create, SDK init, result, `working → completed` A2A transition). Pre-existing flaky Live test, not caused by this change.)
+- [x] 10.6 Run `./scripts/mock.sh` and exercise: new session → send → plan mode → approve plan → ask question → answer → switch model → switch mode → close (via Playwright MCP, or manually)
+      (`mock.sh` runs the ASP.NET server in `HOMESPUN_MOCK_MODE=true` which replaces all Claude services with in-memory mocks (`AddMockServices` in `Program.cs:90`) — the real worker is never spawned, so mock.sh does not exercise the refactor. Instead, validated the refactor via:
+      1. Rebuilt `homespun-worker:local` Docker image from this branch.
+      2. Ran the single existing Live integration test against the rebuilt image — container logs confirm the new code paths (no more `"Result received, input closed for clean CLI exit"`; `inventory event=create` emitted once; clean `working → completed` A2A transition on result).
+      3. Direct `curl` POST to `/api/sessions` on the rebuilt container produced the expected SSE event stream, including `"final":false` on the working status-update and `"final":true` on the terminal status-update — proving the SSE contract is preserved.
+      4. All 173 worker-side unit tests (Vitest) pass, including the 8 new TDD tests for send-via-streamInput, setMode-after-result, setModel-after-result, the four `canUseTool` handlers, and close-rejects-pending.
+      A complete UI flow exercise (plan/approve/question/answer/switch-model/switch-mode/close) still requires a manual end-to-end pass against the real worker in the Homespun UI; that is a pre-merge step noted for the PR description.)
+- [ ] 10.7 Verify target line count on `src/Homespun.Worker/src/services/session-manager.ts` — expected ≤ ~650 lines
+      (Actual: 1214 lines — above the ~650 aspirational target. All substantive simplifications from the proposal landed; the remaining length is dominated by the synthetic-error-result push in `runQueryForwarder`, verbose session-create logging, and the four tool handlers. Further reduction would require separate files or trimmed logging and is out of scope for this change.)
+- [x] 10.8 Run `openspec verify simplify-worker-session-manager` and resolve any issues
+      (CLI has no `verify` command; ran `openspec validate simplify-worker-session-manager` — passes.)

--- a/src/Homespun.Worker/scripts/spike-idle-tolerance.ts
+++ b/src/Homespun.Worker/scripts/spike-idle-tolerance.ts
@@ -1,0 +1,116 @@
+/**
+ * spike-idle-tolerance.ts — OpenSpec `simplify-worker-session-manager`, tasks 1.1–1.3
+ *
+ * Verifies that one long-lived `query()` from `@anthropic-ai/claude-agent-sdk`
+ * does not self-terminate during long idle periods in streaming-input mode.
+ *
+ * Flow: start query -> drain until first `result` -> idle IDLE_SECONDS seconds
+ * (default 600) -> push a follow-up via `q.streamInput(asyncIterableOfOne(msg))`
+ * -> drain until a second `result`. Prints FOLLOW-UP SUCCESS or FAILURE.
+ *
+ * Run from `src/Homespun.Worker` (requires ANTHROPIC_API_KEY):
+ *   ANTHROPIC_API_KEY=sk-ant-... IDLE_SECONDS=600 npx tsx scripts/spike-idle-tolerance.ts
+ * If `claude: not found`, run inside the worker container so the CLI resolves.
+ *
+ * Pass criteria: "FIRST RESULT" arrives; no mid-idle errors; after idle the
+ * follow-up echoes assistant text then "FOLLOW-UP SUCCESS".
+ *
+ * If it fails (streamInput throws or stream ends with no 2nd result):
+ *   - add a keep-alive task to tasks.md (synthetic no-op under the observed
+ *     timeout) BEFORE landing the refactor; or
+ *   - fall back to "selective resume": close-and-resume only when idle crosses
+ *     the observed threshold.
+ * Record the observed tolerance in design.md under Open Questions.
+ */
+
+import {
+  query,
+  type PermissionResult,
+  type SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+
+const IDLE_SECONDS = Number.parseInt(process.env.IDLE_SECONDS ?? "600", 10);
+const MODEL = "claude-haiku-4-5-20251001";
+
+const allowAll = async (
+  toolName: string,
+  input: Record<string, unknown>,
+): Promise<PermissionResult> => ({
+  behavior: "allow",
+  updatedInput: input,
+});
+
+function userMessage(text: string): SDKUserMessage {
+  return {
+    type: "user",
+    session_id: "",
+    parent_tool_use_id: null,
+    message: { role: "user", content: [{ type: "text", text }] },
+  };
+}
+
+async function* once(msg: SDKUserMessage): AsyncGenerator<SDKUserMessage> {
+  yield msg;
+}
+
+async function drainUntilResult(
+  q: AsyncIterable<unknown>,
+  label: string,
+): Promise<void> {
+  for await (const msg of q) {
+    const m = msg as { type?: string; subtype?: string };
+    console.log(`[${label}] msg type=${m.type}${m.subtype ? ` subtype=${m.subtype}` : ""}`);
+    if (m.type === "result") {
+      console.log(`[${label}] got result — returning`);
+      return;
+    }
+  }
+  throw new Error(`[${label}] stream ended before a result message arrived`);
+}
+
+async function main() {
+  console.log(`spike-idle-tolerance: IDLE_SECONDS=${IDLE_SECONDS}, model=${MODEL}`);
+
+  const q = query({
+    prompt: once(userMessage("Say hi in one short sentence.")),
+    options: {
+      model: MODEL,
+      permissionMode: "default",
+      canUseTool: allowAll,
+      includePartialMessages: false,
+    },
+  });
+
+  console.log("waiting for FIRST RESULT...");
+  await drainUntilResult(q, "turn1");
+  console.log("FIRST RESULT received");
+
+  const idleMs = IDLE_SECONDS * 1000;
+  const startedAt = Date.now();
+  console.log(`idling for ${IDLE_SECONDS}s...`);
+  await new Promise<void>((resolve) => setTimeout(resolve, idleMs));
+  console.log(`idle complete after ${Math.round((Date.now() - startedAt) / 1000)}s`);
+
+  try {
+    await q.streamInput(once(userMessage("Respond with the single word 'alive'.")));
+    console.log("streamInput accepted; waiting for SECOND RESULT...");
+    await drainUntilResult(q, "turn2");
+    console.log("FOLLOW-UP SUCCESS");
+  } catch (err) {
+    const msg = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+    console.error(`FOLLOW-UP FAILURE: ${msg}`);
+    if (err instanceof Error && err.stack) console.error(err.stack);
+    process.exitCode = 1;
+  } finally {
+    try {
+      await (q as unknown as { return?: () => Promise<unknown> }).return?.();
+    } catch {
+      /* ignore cleanup errors */
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error("spike crashed:", err);
+  process.exit(1);
+});

--- a/src/Homespun.Worker/src/routes/sessions.ts
+++ b/src/Homespun.Worker/src/routes/sessions.ts
@@ -42,8 +42,8 @@ export function createSessionsRoute(sessionManager: SessionManager) {
       mode: active.mode,
       model: active.model,
       permissionMode: active.permissionMode,
-      hasPendingQuestion: sessionManager.hasPendingQuestion(active.sessionId),
-      hasPendingPlanApproval: sessionManager.hasPendingPlanApproval(active.sessionId),
+      hasPendingQuestion: sessionManager.hasPending(active.sessionId, 'question'),
+      hasPendingPlanApproval: sessionManager.hasPending(active.sessionId, 'plan'),
       lastActivityAt: active.lastActivityAt,
       lastMessageType: active.lastMessageType,
       lastMessageSubtype: active.lastMessageSubtype,
@@ -122,7 +122,7 @@ export function createSessionsRoute(sessionManager: SessionManager) {
     const body = await c.req.json<AnswerQuestionRequest>();
     info(`POST /sessions/${sessionId}/answer - ${Object.keys(body.answers).length} answers`);
 
-    const resolved = sessionManager.resolvePendingQuestion(sessionId, body.answers);
+    const resolved = sessionManager.resolvePending(sessionId, 'question', { answers: body.answers });
     if (!resolved) {
       return c.json({ ok: false, error: 'No pending question' }, 400);
     }
@@ -137,8 +137,11 @@ export function createSessionsRoute(sessionManager: SessionManager) {
     const body = await c.req.json<ApprovePlanRequest>();
     info(`POST /sessions/${sessionId}/approve-plan - approved=${body.approved}, keepContext=${body.keepContext}`);
 
-    const resolved = sessionManager.resolvePendingPlanApproval(
-      sessionId, body.approved, body.keepContext, body.feedback);
+    const resolved = sessionManager.resolvePending(sessionId, 'plan', {
+      approved: body.approved,
+      keepContext: body.keepContext,
+      feedback: body.feedback,
+    });
     if (!resolved) {
       return c.json({ ok: false, error: 'No pending plan approval' }, 400);
     }
@@ -264,38 +267,6 @@ export function createSessionsRoute(sessionManager: SessionManager) {
           isRecoverable: false,
         }));
       }
-    });
-  });
-
-  // GET /sessions/:id/messages - Get message history for catch-up replay
-  // Query params:
-  //   since: ISO timestamp to get messages after (optional)
-  sessions.get('/:id/messages', (c) => {
-    const sessionId = c.req.param('id');
-    const sinceParam = c.req.query('since');
-
-    const ws = sessionManager.get(sessionId);
-    if (!ws) {
-      return c.json({ message: `Session ${sessionId} not found` }, 404);
-    }
-
-    let since: Date | undefined;
-    if (sinceParam) {
-      const parsed = new Date(sinceParam);
-      if (!isNaN(parsed.getTime())) {
-        since = parsed;
-      }
-    }
-
-    const history = sessionManager.getMessageHistory(sessionId, since);
-    info(`GET /sessions/${sessionId}/messages - since=${sinceParam || 'all'}, count=${history.length}`);
-
-    return c.json({
-      sessionId,
-      messages: history.map(entry => ({
-        timestamp: entry.timestamp.toISOString(),
-        event: entry.event,
-      })),
     });
   });
 

--- a/src/Homespun.Worker/src/services/session-manager.ts
+++ b/src/Homespun.Worker/src/services/session-manager.ts
@@ -9,7 +9,6 @@ import type {
   AskUserQuestionInput,
   ExitPlanModeInput,
   UserQuestion,
-  ApprovePlanRequest,
   LastMessageType,
   WorkflowSessionContext,
 } from "../types/index.js";
@@ -32,7 +31,6 @@ import {
 import {
   captureDebugInfo,
   FileMonitor,
-  type DebugInfo,
 } from "../utils/diagnostics.js";
 import { watch, existsSync } from "node:fs";
 
@@ -75,7 +73,12 @@ export interface WorkflowSignalEventData {
 }
 
 export interface ControlEvent {
-  type: "question_pending" | "plan_pending" | "status_resumed" | "workflow_complete" | "workflow_signal";
+  type:
+    | "question_pending"
+    | "plan_pending"
+    | "status_resumed"
+    | "workflow_complete"
+    | "workflow_signal";
   data:
     | { questions: UserQuestion[] }
     | { plan: string }
@@ -99,34 +102,17 @@ export function isControlEvent(event: OutputEvent): event is ControlEvent {
 }
 
 /**
- * Message history entry with timestamp for catch-up replay.
- */
-export interface MessageHistoryEntry {
-  timestamp: Date;
-  event: OutputEvent;
-}
-
-/**
  * Single-consumer async queue that merges pushes from multiple producers
  * (the SDK query background task and the canUseTool callback).
- * Also maintains a history of messages for catch-up replay after server restart.
  */
 export class OutputChannel {
   private queue: OutputEvent[] = [];
   private resolver: ((result: IteratorResult<OutputEvent>) => void) | null =
     null;
   private done = false;
-  private history: MessageHistoryEntry[] = [];
-  private readonly maxHistorySize = 1000; // Limit history to prevent memory issues
 
   push(event: OutputEvent): void {
     if (this.done) return;
-
-    // Add to history with timestamp
-    this.history.push({ timestamp: new Date(), event });
-    if (this.history.length > this.maxHistorySize) {
-      this.history.shift();
-    }
 
     if (this.resolver) {
       const resolve = this.resolver;
@@ -142,22 +128,8 @@ export class OutputChannel {
     if (this.resolver) {
       const resolve = this.resolver;
       this.resolver = null;
-      resolve({ value: undefined as any, done: true });
+      resolve({ value: undefined as unknown as OutputEvent, done: true });
     }
-  }
-
-  /**
-   * Gets messages since a given timestamp for catch-up replay.
-   */
-  getMessagesSince(since: Date): MessageHistoryEntry[] {
-    return this.history.filter((entry) => entry.timestamp > since);
-  }
-
-  /**
-   * Gets all messages in history.
-   */
-  getAllMessages(): MessageHistoryEntry[] {
-    return [...this.history];
   }
 
   async *[Symbol.asyncIterator](): AsyncGenerator<OutputEvent> {
@@ -179,24 +151,40 @@ export class OutputChannel {
   }
 }
 
-// --- Session types ---
+// --- Pending-interaction types ---
 
-interface PendingQuestionState {
-  questions: AskUserQuestionInput["questions"];
-  resolve: (answers: Record<string, string>) => void;
-  reject: (error: Error) => void;
-}
+export type PendingKind = "question" | "plan";
 
-interface PendingPlanApprovalState {
-  plan: string;
+/**
+ * Payload used by `resolvePending` for each kind.
+ * - `question`: the record of answers keyed by question text.
+ * - `plan`: the approval decision with optional context control.
+ */
+export type PendingPayload =
+  | { kind: "question"; answers: Record<string, string> }
+  | {
+      kind: "plan";
+      approved: boolean;
+      keepContext?: boolean;
+      feedback?: string;
+    };
+
+/**
+ * Per-session, per-kind state tracked while the SDK awaits a user decision.
+ * `data` is the interaction-specific captured data (e.g. the questions to
+ * answer, or the plan to approve).
+ */
+interface PendingInteraction<T> {
+  data: T;
   resolve: (result: PermissionResult) => void;
-  reject: (error: Error) => void;
+  reject: (err: Error) => void;
 }
+
+// --- Session types ---
 
 interface WorkerSession {
   id: string;
   query: Query;
-  inputController: InputController;
   outputChannel: OutputChannel;
   conversationId?: string;
   mode: string;
@@ -207,7 +195,6 @@ interface WorkerSession {
   lastActivityAt: Date;
   lastMessageType?: LastMessageType;
   lastMessageSubtype?: string;
-  resultReceived: boolean;
   systemPrompt?: string;
   workingDirectory?: string;
   /** Workflow context when running as part of a workflow execution */
@@ -223,61 +210,11 @@ interface WorkerSession {
    * current session lifecycle phase. Guard against the SDK replaying init.
    */
   inventoryEmitted?: boolean;
-}
-
-/**
- * Controller for managing streaming input to the V1 query() API.
- * Allows sending messages to an active query session.
- */
-class InputController {
-  private messageQueue: SDKUserMessage[] = [];
-  private resolver: ((value: IteratorResult<SDKUserMessage>) => void) | null =
-    null;
-  private done = false;
-
-  async *[Symbol.asyncIterator](): AsyncGenerator<SDKUserMessage> {
-    while (!this.done) {
-      if (this.messageQueue.length > 0) {
-        yield this.messageQueue.shift()!;
-      } else {
-        // Wait for next message
-        const result = await new Promise<IteratorResult<SDKUserMessage>>(
-          (resolve) => {
-            this.resolver = resolve;
-          },
-        );
-        if (result.done) break;
-        yield result.value;
-      }
-    }
-  }
-
-  send(message: string): void {
-    const userMessage: SDKUserMessage = {
-      type: "user",
-      session_id: "",
-      message: {
-        role: "user",
-        content: [{ type: "text", text: message }],
-      },
-      parent_tool_use_id: null,
-    };
-
-    if (this.resolver) {
-      this.resolver({ value: userMessage, done: false });
-      this.resolver = null;
-    } else {
-      this.messageQueue.push(userMessage);
-    }
-  }
-
-  close(): void {
-    this.done = true;
-    if (this.resolver) {
-      this.resolver({ value: undefined as any, done: true });
-      this.resolver = null;
-    }
-  }
+  /**
+   * Cleanup handle for the debug-log file watcher attached in create().
+   * Invoked from runQueryForwarder's finally block.
+   */
+  debugLogCleanup?: () => void;
 }
 
 interface SDKUserMessage {
@@ -299,6 +236,12 @@ const PLAN_MODE_TOOLS = [
   "Task",
   "AskUserQuestion",
   "ExitPlanMode",
+  // Required to let the agent invoke discovered Agent Skills. Skills are
+  // loaded from `.claude/skills/` under the session cwd and `~/.claude/skills/`
+  // via `settingSources: ["user", "project"]`. Without "Skill" in the allowed
+  // list, the Skill tool is not exposed to the model — see
+  // https://code.claude.com/docs/en/agent-sdk/skills.
+  "Skill",
 ];
 
 function buildCommonOptions(
@@ -357,14 +300,257 @@ function buildCommonOptions(
   };
 }
 
+/**
+ * Yields a single SDK user message then returns. Used to push a follow-up
+ * message into the live query via `q.streamInput(...)`.
+ */
+async function* onceIterator(
+  msg: SDKUserMessage,
+): AsyncGenerator<SDKUserMessage> {
+  yield msg;
+}
+
+/**
+ * Attaches a filesystem watcher on the Claude SDK debug log and streams new
+ * lines to the worker's info log. Safe to call once per session; the returned
+ * cleanup fn is invoked when the session ends.
+ */
+function attachDebugLogStreaming(sessionId: string): { cleanup: () => void } {
+  const debugLogPath = "/home/homespun/.claude/debug/claude_sdk_debug.log";
+  const monitor = new FileMonitor(debugLogPath);
+  let watcher: ReturnType<typeof watch> | undefined;
+
+  if (existsSync(debugLogPath)) {
+    watcher = watch(
+      debugLogPath,
+      { persistent: false },
+      async (eventType) => {
+        if (eventType === "change") {
+          const newLines = await monitor.readNewLines();
+          newLines.forEach((line) => {
+            info(`[SDK Debug] ${line} (sessionId: ${sessionId})`);
+          });
+        }
+      },
+    );
+  }
+
+  return {
+    cleanup: () => {
+      watcher?.close();
+    },
+  };
+}
+
+// --- Tool handler registry ---
+
+/**
+ * Shared context passed to every tool handler. Exposes the manager's
+ * internal pending-state primitives without leaking them on the public API.
+ */
+interface HandlerContext {
+  sessionId: string;
+  registerPending: <T>(
+    kind: PendingKind,
+    data: T,
+    resolve: (result: PermissionResult) => void,
+    reject: (err: Error) => void,
+  ) => void;
+  logStatusChange: (session: WorkerSession, next: WorkerSession["status"], reason: string) => void;
+}
+
+type ToolHandler = (
+  input: Record<string, unknown>,
+  session: WorkerSession,
+  ctx: HandlerContext,
+) => Promise<PermissionResult>;
+
+const askUserQuestionHandler: ToolHandler = async (input, session, ctx) => {
+  const questionInput = input as unknown as AskUserQuestionInput;
+
+  const answersPromise = new Promise<Record<string, string>>(
+    (resolve, reject) => {
+      info(
+        `Session entering pending question state (sessionId: ${ctx.sessionId}, questionCount: ${questionInput.questions.length})`,
+      );
+      ctx.registerPending(
+        "question",
+        { questions: questionInput.questions },
+        (result) => {
+          // The unified resolver builds a PermissionResult for us, but the
+          // question handler needs just the answers object to complete.
+          // We unwrap updatedInput.answers back into a plain record.
+          const answers =
+            (result as { behavior: "allow"; updatedInput: { answers: Record<string, string> } })
+              .updatedInput.answers;
+          resolve(answers);
+        },
+        reject,
+      );
+    },
+  );
+
+  session.outputChannel.push({
+    type: "question_pending",
+    data: { questions: questionInput.questions },
+  });
+
+  info(
+    `emitted question_pending, waiting for answers on session '${ctx.sessionId}'`,
+  );
+
+  const answers = await answersPromise;
+
+  info(`received answers for session '${ctx.sessionId}'`);
+
+  ctx.logStatusChange(session, "streaming", "resuming_after_question");
+
+  return {
+    behavior: "allow",
+    updatedInput: {
+      questions: questionInput.questions,
+      answers,
+    },
+  };
+};
+
+const exitPlanModeHandler: ToolHandler = async (input, session, ctx) => {
+  const planInput = input as unknown as ExitPlanModeInput;
+  const planContent = planInput.plan || "";
+
+  const approvalPromise = new Promise<PermissionResult>((resolve, reject) => {
+    info(
+      `Session entering pending plan approval state (sessionId: ${ctx.sessionId})`,
+    );
+    ctx.registerPending("plan", { plan: planContent }, resolve, reject);
+  });
+
+  session.outputChannel.push({
+    type: "plan_pending",
+    data: { plan: planContent },
+  });
+
+  info(
+    `emitted plan_pending, waiting for approval on session '${ctx.sessionId}'`,
+  );
+
+  const result = await approvalPromise;
+
+  info(
+    `received plan approval decision for session '${ctx.sessionId}': behavior='${result.behavior}'`,
+  );
+
+  if (result.behavior === "allow") {
+    ctx.logStatusChange(session, "streaming", "resuming_after_plan_approval");
+  }
+
+  return result;
+};
+
+const workflowCompleteHandler: ToolHandler = async (input, session, ctx) => {
+  if (!session.workflowContext) {
+    info(
+      `WorkflowComplete denied - no workflow context (sessionId: ${ctx.sessionId})`,
+    );
+    return {
+      behavior: "deny",
+      message: "WorkflowComplete tool can only be used in workflow sessions",
+    };
+  }
+
+  if (!isValidWorkflowCompleteInput(input)) {
+    info(
+      `WorkflowComplete denied - invalid input (sessionId: ${ctx.sessionId})`,
+    );
+    return {
+      behavior: "deny",
+      message:
+        "Invalid WorkflowComplete input: requires status, outputs, and summary",
+    };
+  }
+
+  const completionInput = input as WorkflowCompleteInput;
+
+  session.outputChannel.push({
+    type: "workflow_complete",
+    data: {
+      workflowContext: session.workflowContext,
+      completion: completionInput,
+    },
+  });
+
+  info(
+    `emitted workflow_complete for session '${ctx.sessionId}' - status='${completionInput.status}', stepId='${session.workflowContext.stepId}'`,
+  );
+
+  return {
+    behavior: "allow",
+    updatedInput: input,
+  };
+};
+
+const workflowSignalHandler: ToolHandler = async (input, session, ctx) => {
+  if (!session.workflowContext) {
+    info(
+      `workflow_signal denied - no workflow context (sessionId: ${ctx.sessionId})`,
+    );
+    return {
+      behavior: "deny",
+      message: "workflow_signal tool can only be used in workflow sessions",
+    };
+  }
+
+  if (!isValidWorkflowSignalInput(input)) {
+    info(
+      `workflow_signal denied - invalid input (sessionId: ${ctx.sessionId})`,
+    );
+    return {
+      behavior: "deny",
+      message:
+        "Invalid workflow_signal input: requires status (success or fail)",
+    };
+  }
+
+  const signalInput = input as WorkflowSignalInput;
+
+  session.outputChannel.push({
+    type: "workflow_signal",
+    data: {
+      workflowContext: session.workflowContext,
+      signal: signalInput,
+    },
+  });
+
+  info(
+    `emitted workflow_signal for session '${ctx.sessionId}' - status='${signalInput.status}', stepId='${session.workflowContext.stepId}'`,
+  );
+
+  return {
+    behavior: "allow",
+    updatedInput: input,
+  };
+};
+
+const TOOL_HANDLERS: Record<string, ToolHandler> = {
+  AskUserQuestion: askUserQuestionHandler,
+  ExitPlanMode: exitPlanModeHandler,
+  [WORKFLOW_COMPLETE_TOOL]: workflowCompleteHandler,
+  [WORKFLOW_SIGNAL_TOOL]: workflowSignalHandler,
+};
+
 export class SessionManager {
   private sessions = new Map<string, WorkerSession>();
-  private pendingQuestions = new Map<string, PendingQuestionState>();
-  private pendingPlanApprovals = new Map<string, PendingPlanApprovalState>();
+  /**
+   * Unified pending-interaction map: sessionId → (kind → interaction).
+   * One-to-one between session+kind and outstanding promise.
+   */
+  private pending = new Map<
+    string,
+    Map<PendingKind, PendingInteraction<unknown>>
+  >();
 
   /**
    * Helper method to log status changes with consistent format.
-   * Updates the session status and logs the transition.
    */
   private logStatusChange(
     session: WorkerSession,
@@ -376,6 +562,38 @@ export class SessionManager {
     info(
       `Session status changed: ${previousStatus} → ${newStatus} (sessionId: ${session.id}, reason: ${reason})`,
     );
+  }
+
+  private registerPending<T>(
+    sessionId: string,
+    kind: PendingKind,
+    data: T,
+    resolve: (result: PermissionResult) => void,
+    reject: (err: Error) => void,
+  ): void {
+    let bySession = this.pending.get(sessionId);
+    if (!bySession) {
+      bySession = new Map();
+      this.pending.set(sessionId, bySession);
+    }
+    bySession.set(kind, {
+      data,
+      resolve,
+      reject,
+    } as PendingInteraction<unknown>);
+  }
+
+  private popPending(
+    sessionId: string,
+    kind: PendingKind,
+  ): PendingInteraction<unknown> | undefined {
+    const bySession = this.pending.get(sessionId);
+    if (!bySession) return undefined;
+    const entry = bySession.get(kind);
+    if (!entry) return undefined;
+    bySession.delete(kind);
+    if (bySession.size === 0) this.pending.delete(sessionId);
+    return entry;
   }
 
   async create(opts: {
@@ -391,7 +609,6 @@ export class SessionManager {
     const isPlan = opts.mode.toLowerCase() === "plan";
     const startTime = Date.now();
 
-    // Log comprehensive session creation details
     info(
       `Creating session ${id} - mode='${opts.mode}', isPlan=${isPlan}, model='${opts.model}', workingDirectory='${opts.workingDirectory || process.env.WORKING_DIRECTORY || "/workdir"}', systemPromptLength=${opts.systemPrompt?.length || 0}, resumeSessionId='${opts.resumeSessionId}', hasWorkflowContext=${!!opts.workflowContext}`,
     );
@@ -402,12 +619,8 @@ export class SessionManager {
       opts.workingDirectory,
     );
 
-    const inputController = new InputController();
-
-    // Create canUseTool callback that handles AskUserQuestion and ExitPlanMode
     const canUseTool = this.createCanUseToolCallback(id);
 
-    // Build session options
     const sessionOptions: Record<string, unknown> = {
       ...common,
       canUseTool,
@@ -419,6 +632,12 @@ export class SessionManager {
     } else {
       sessionOptions.permissionMode = "bypassPermissions";
       sessionOptions.allowDangerouslySkipPermissions = true;
+      // Build mode bypasses permissions so allowedTools is not used as a
+      // deny-list. Reuse PLAN_MODE_TOOLS so Build has at least the same
+      // exposure as Plan (notably "Skill" — which must be listed explicitly
+      // to be exposed to the model at all). The canUseTool callback handles
+      // everything else. See https://code.claude.com/docs/en/agent-sdk/skills.
+      sessionOptions.allowedTools = PLAN_MODE_TOOLS;
     }
 
     if (opts.resumeSessionId) {
@@ -426,33 +645,24 @@ export class SessionManager {
     }
 
     info(
-      `Session configuration: permissionMode='${sessionOptions.permissionMode}', allowDangerouslySkipPermissions=${sessionOptions.allowDangerouslySkipPermissions}, sessionId='${id}', allowedTools=${isPlan ? "PLAN_MODE_TOOLS" : "all"}, hasCanUseTool=true, hasResume=${!!opts.resumeSessionId}`,
+      `Session configuration: permissionMode='${sessionOptions.permissionMode}', allowDangerouslySkipPermissions=${sessionOptions.allowDangerouslySkipPermissions}, sessionId='${id}', allowedTools=${JSON.stringify(sessionOptions.allowedTools)}, hasCanUseTool=true, hasResume=${!!opts.resumeSessionId}`,
     );
 
-    // Create async generator that yields the initial message and subsequent messages
-    async function* createInputStream(
-      initialPrompt: string,
-      controller: InputController,
-    ): AsyncGenerator<SDKUserMessage> {
-      // Yield initial prompt
-      yield {
-        type: "user",
-        session_id: "",
-        message: {
-          role: "user",
-          content: [{ type: "text", text: initialPrompt }],
-        },
-        parent_tool_use_id: null,
-      };
-
-      // Yield subsequent messages from the controller
-      for await (const msg of controller) {
-        yield msg;
-      }
-    }
+    // Build the initial prompt as a single-message async iterable. The SDK
+    // accepts this as streaming-input mode; follow-up messages are pushed via
+    // q.streamInput() later.
+    const initialPrompt: SDKUserMessage = {
+      type: "user",
+      session_id: "",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: opts.prompt }],
+      },
+      parent_tool_use_id: null,
+    };
 
     const q = query({
-      prompt: createInputStream(opts.prompt, inputController),
+      prompt: onceIterator(initialPrompt),
       options: sessionOptions as Parameters<typeof query>[0]["options"],
     });
 
@@ -461,16 +671,14 @@ export class SessionManager {
     const workerSession: WorkerSession = {
       id,
       query: q,
-      inputController,
       outputChannel,
       conversationId: opts.resumeSessionId,
       mode: opts.mode,
       model: opts.model,
       permissionMode: isPlan ? "plan" : "bypassPermissions",
-      status: "idle", // Initialize as idle, will change to streaming below
+      status: "idle",
       createdAt: new Date(),
       lastActivityAt: new Date(),
-      resultReceived: false,
       systemPrompt: opts.systemPrompt,
       workingDirectory: opts.workingDirectory,
       workflowContext: opts.workflowContext,
@@ -479,30 +687,11 @@ export class SessionManager {
     this.sessions.set(id, workerSession);
     info(`session created, workerSessionId='${id}'`);
 
-    // Log initial status transition
     this.logStatusChange(workerSession, "streaming", "session_created");
 
-    // Setup debug log monitoring
-    let debugLogWatcher: any;
-    const debugLogPath = "/home/homespun/.claude/debug/claude_sdk_debug.log";
-    const debugMonitor = new FileMonitor(debugLogPath);
+    const debugHandle = attachDebugLogStreaming(id);
+    workerSession.debugLogCleanup = debugHandle.cleanup;
 
-    if (existsSync(debugLogPath)) {
-      debugLogWatcher = watch(
-        debugLogPath,
-        { persistent: false },
-        async (eventType) => {
-          if (eventType === "change") {
-            const newLines = await debugMonitor.readNewLines();
-            newLines.forEach((line) => {
-              info(`[SDK Debug] ${line} (sessionId: ${id})`);
-            });
-          }
-        },
-      );
-    }
-
-    // Background task: forward SDK query messages to the output channel
     this.runQueryForwarder(
       workerSession,
       q,
@@ -510,236 +699,37 @@ export class SessionManager {
       startTime,
       opts,
       sessionOptions,
-      debugMonitor,
-      debugLogPath,
-      debugLogWatcher,
     );
 
     return workerSession;
   }
 
   /**
-   * Creates the canUseTool callback for a session.
-   * Intercepts AskUserQuestion to emit a control event before pausing.
-   * Allows ExitPlanMode immediately (server handles plan display/approval).
+   * Creates the canUseTool callback for a session. Delegates to the tool
+   * handler registry; unknown tools are allowed with their input unchanged.
    */
   private createCanUseToolCallback(sessionId: string) {
     return async (
       toolName: string,
       input: Record<string, unknown>,
     ): Promise<PermissionResult> => {
-      const origin = resolveToolOrigin(
-        toolName,
-        this.sessions.get(sessionId)?.init,
-      );
+      const session = this.sessions.get(sessionId);
+      const origin = resolveToolOrigin(toolName, session?.init);
       info(
         `canUseTool - tool='${toolName}', sessionId='${sessionId}' origin=${origin}`,
       );
 
-      if (toolName === "AskUserQuestion") {
-        const questionInput = input as unknown as AskUserQuestionInput;
-
-        // Create promise that will be resolved when /answer endpoint is called
-        const answersPromise = new Promise<Record<string, string>>(
-          (resolve, reject) => {
-            info(
-              `Session entering pending question state (sessionId: ${sessionId}, questionCount: ${questionInput.questions.length})`,
-            );
-            this.pendingQuestions.set(sessionId, {
-              questions: questionInput.questions,
-              resolve,
-              reject,
-            });
-          },
-        );
-
-        // Emit control event BEFORE pausing — this flows to the SSE stream
-        // so the server can detect the pending question and show it to the user
-        const ws = this.sessions.get(sessionId);
-        ws?.outputChannel.push({
-          type: "question_pending",
-          data: { questions: questionInput.questions },
-        });
-
-        info(
-          `emitted question_pending, waiting for answers on session '${sessionId}'`,
-        );
-
-        // Wait for answers (this pauses SDK execution)
-        const answers = await answersPromise;
-
-        info(`received answers for session '${sessionId}'`);
-
-        // Log resuming status
-        const session = this.sessions.get(sessionId);
-        if (session) {
-          this.logStatusChange(session, "streaming", "resuming_after_question");
-        }
-
-        // Return allow with populated answers
-        return {
-          behavior: "allow",
-          updatedInput: {
-            questions: questionInput.questions,
-            answers,
-          },
+      const handler = TOOL_HANDLERS[toolName];
+      if (handler && session) {
+        const ctx: HandlerContext = {
+          sessionId,
+          registerPending: (kind, data, resolve, reject) =>
+            this.registerPending(sessionId, kind, data, resolve, reject),
+          logStatusChange: (s, next, reason) => this.logStatusChange(s, next, reason),
         };
+        return handler(input, session, ctx);
       }
 
-      if (toolName === "ExitPlanMode") {
-        const planInput = input as unknown as ExitPlanModeInput;
-        const planContent = planInput.plan || "";
-
-        // Create promise that will be resolved when /approve-plan endpoint is called
-        const approvalPromise = new Promise<PermissionResult>(
-          (resolve, reject) => {
-            info(
-              `Session entering pending plan approval state (sessionId: ${sessionId})`,
-            );
-            this.pendingPlanApprovals.set(sessionId, {
-              plan: planContent,
-              resolve,
-              reject,
-            });
-          },
-        );
-
-        // Emit control event BEFORE pausing — this flows to the SSE stream
-        // so the server can detect the pending plan and show it to the user
-        const ws = this.sessions.get(sessionId);
-        ws?.outputChannel.push({
-          type: "plan_pending",
-          data: { plan: planContent },
-        });
-
-        info(
-          `emitted plan_pending, waiting for approval on session '${sessionId}'`,
-        );
-
-        // Wait for approval decision (this pauses SDK execution)
-        const result = await approvalPromise;
-
-        info(
-          `received plan approval decision for session '${sessionId}': behavior='${result.behavior}'`,
-        );
-
-        // Log resuming status if approved
-        if (result.behavior === "allow") {
-          const session = this.sessions.get(sessionId);
-          if (session) {
-            this.logStatusChange(
-              session,
-              "streaming",
-              "resuming_after_plan_approval",
-            );
-          }
-        }
-
-        return result;
-      }
-
-      // Handle WorkflowComplete tool - only enabled when session has workflowContext
-      if (toolName === WORKFLOW_COMPLETE_TOOL) {
-        const ws = this.sessions.get(sessionId);
-
-        // Only allow WorkflowComplete when session has workflow context
-        if (!ws?.workflowContext) {
-          info(
-            `WorkflowComplete denied - no workflow context (sessionId: ${sessionId})`,
-          );
-          return {
-            behavior: "deny",
-            message:
-              "WorkflowComplete tool can only be used in workflow sessions",
-          };
-        }
-
-        // Validate the input
-        if (!isValidWorkflowCompleteInput(input)) {
-          info(
-            `WorkflowComplete denied - invalid input (sessionId: ${sessionId})`,
-          );
-          return {
-            behavior: "deny",
-            message:
-              "Invalid WorkflowComplete input: requires status, outputs, and summary",
-          };
-        }
-
-        const completionInput = input as WorkflowCompleteInput;
-
-        // Emit workflow_complete control event to SSE stream
-        // This notifies the server that the workflow node has completed
-        ws.outputChannel.push({
-          type: "workflow_complete",
-          data: {
-            workflowContext: ws.workflowContext,
-            completion: completionInput,
-          },
-        });
-
-        info(
-          `emitted workflow_complete for session '${sessionId}' - status='${completionInput.status}', stepId='${ws.workflowContext.stepId}'`,
-        );
-
-        // Allow the tool to execute - this signals session completion
-        return {
-          behavior: "allow",
-          updatedInput: input,
-        };
-      }
-
-      // Handle workflow_signal tool - only enabled when session has workflowContext
-      if (toolName === WORKFLOW_SIGNAL_TOOL) {
-        const ws = this.sessions.get(sessionId);
-
-        // Only allow workflow_signal when session has workflow context
-        if (!ws?.workflowContext) {
-          info(
-            `workflow_signal denied - no workflow context (sessionId: ${sessionId})`,
-          );
-          return {
-            behavior: "deny",
-            message:
-              "workflow_signal tool can only be used in workflow sessions",
-          };
-        }
-
-        // Validate the input
-        if (!isValidWorkflowSignalInput(input)) {
-          info(
-            `workflow_signal denied - invalid input (sessionId: ${sessionId})`,
-          );
-          return {
-            behavior: "deny",
-            message:
-              "Invalid workflow_signal input: requires status (success or fail)",
-          };
-        }
-
-        const signalInput = input as WorkflowSignalInput;
-
-        // Emit workflow_signal control event to SSE stream
-        ws.outputChannel.push({
-          type: "workflow_signal",
-          data: {
-            workflowContext: ws.workflowContext,
-            signal: signalInput,
-          },
-        });
-
-        info(
-          `emitted workflow_signal for session '${sessionId}' - status='${signalInput.status}', stepId='${ws.workflowContext.stepId}'`,
-        );
-
-        // Allow the tool to execute
-        return {
-          behavior: "allow",
-          updatedInput: input,
-        };
-      }
-
-      // Allow other tools
       return {
         behavior: "allow",
         updatedInput: input,
@@ -748,31 +738,30 @@ export class SessionManager {
   }
 
   /**
-   * Runs the background query forwarder that reads SDK messages and pushes them
-   * to the output channel. Handles result detection and clean shutdown.
+   * Runs the background query forwarder that reads SDK messages and pushes
+   * them to the output channel. There is now a single forwarder per session
+   * lifetime — follow-up messages are delivered via q.streamInput() directly
+   * into the same query without restarting it.
    */
   private runQueryForwarder(
     session: WorkerSession,
     q: Query,
     outputChannel: OutputChannel,
     startTime: number,
-    opts: { mode: string; model: string; systemPrompt?: string; workingDirectory?: string },
+    opts: {
+      mode: string;
+      model: string;
+      systemPrompt?: string;
+      workingDirectory?: string;
+    },
     sessionOptions: Record<string, unknown>,
-    debugMonitor: FileMonitor,
-    debugLogPath: string,
-    debugLogWatcher: any,
-    inventoryEvent: "create" | "resume" = "create",
   ): void {
     (async () => {
       try {
         info(`Query processing started (sessionId: ${session.id})`);
         let messageCount = 0;
-        // Reset inventory-emitted guard for this lifecycle phase.
         session.inventoryEmitted = false;
         for await (const msg of q) {
-          // Sniff the first system/init message for inventory logging (FR-001,
-          // FR-005) and for per-tool origin attribution (US2). Never disrupts
-          // the event stream — the message is still pushed to OutputChannel.
           if (
             !session.inventoryEmitted &&
             msg.type === "system" &&
@@ -785,12 +774,11 @@ export class SessionManager {
               const record = await buildInventoryFromInit(
                 initLike,
                 sessionOptions,
-                inventoryEvent,
+                "create",
                 session.id,
               );
               emitInventoryLog(record);
             } catch (err) {
-              // FR-006: never fail the session for inventory errors.
               warn(
                 `inventory emission failed for session '${session.id}': ${
                   err instanceof Error ? err.message : String(err)
@@ -801,149 +789,138 @@ export class SessionManager {
 
           outputChannel.push(msg);
           messageCount++;
-
-          // Detect result message — close input so CLI can exit cleanly
-          if (msg.type === 'result') {
-            session.resultReceived = true;
-            session.inputController.close();
-            info(`Result received, input closed for clean CLI exit (sessionId: ${session.id})`);
-          }
         }
         const duration = Date.now() - startTime;
-        info(`Query processing completed (sessionId: ${session.id}, messageCount: ${messageCount}, duration: ${duration}ms)`);
-        this.logStatusChange(session, 'idle', 'query_completed');
+        info(
+          `Query processing completed (sessionId: ${session.id}, messageCount: ${messageCount}, duration: ${duration}ms)`,
+        );
+        this.logStatusChange(session, "idle", "query_completed");
       } catch (err) {
         const duration = Date.now() - startTime;
         const errorMessage = err instanceof Error ? err.message : String(err);
 
-        if (session.resultReceived) {
-          // Error after a successful result — the CLI exited after producing output.
-          // This is expected behavior, not a real error.
-          info(`Post-result CLI exit (sessionId: ${session.id}, duration: ${duration}ms, error: ${errorMessage})`);
-          this.logStatusChange(session, 'idle', 'post_result_exit');
-        } else {
-          // Genuine error before any result was produced
-          const errorDetails = {
-            message: errorMessage,
-            stack: err instanceof Error ? err.stack : undefined,
-            type: err?.constructor?.name || 'Unknown',
-            sessionId: session.id,
-            sessionOptions: {
-              mode: opts.mode,
-              model: opts.model,
-              permissionMode: sessionOptions.permissionMode,
-              workingDirectory: sessionOptions.cwd,
+        const errorDetails = {
+          message: errorMessage,
+          stack: err instanceof Error ? err.stack : undefined,
+          type: err?.constructor?.name || "Unknown",
+          sessionId: session.id,
+          sessionOptions: {
+            mode: opts.mode,
+            model: opts.model,
+            permissionMode: sessionOptions.permissionMode,
+            workingDirectory: sessionOptions.cwd,
+          },
+          timestamp: new Date().toISOString(),
+          duration,
+        };
+
+        error(
+          `query forwarder error for session '${session.id}' - ${JSON.stringify(errorDetails)}`,
+        );
+        this.logStatusChange(session, "error", "query_error");
+
+        const debugInfo = await captureDebugInfo(this.sessions.size);
+
+        outputChannel.push({
+          type: "result",
+          subtype: "error_during_execution",
+          session_id: session.id,
+          is_error: true,
+          duration_ms: duration,
+          duration_api_ms: 0,
+          num_turns: 0,
+          total_cost_usd: 0,
+          usage: {
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
+          result: errorDetails.message,
+          errors: [errorDetails.message],
+          debug: {
+            stack: errorDetails.stack,
+            errorType: errorDetails.type,
+            lastStderr: debugInfo.lastStderr.slice(-10),
+            diagnostics: {
+              memory: debugInfo.diagnostics.memory,
+              uptime: debugInfo.diagnostics.uptime,
+              sessionCount: debugInfo.sessionCount,
             },
-            timestamp: new Date().toISOString(),
-            duration,
-          };
-
-          error(`query forwarder error for session '${session.id}' - ${JSON.stringify(errorDetails)}`);
-          this.logStatusChange(session, 'error', 'query_error');
-
-          // Capture debug information
-          const debugInfo = await captureDebugInfo(this.sessions.size);
-
-          // Push a synthetic error result
-          outputChannel.push({
-            type: 'result',
-            subtype: 'error_during_execution',
-            session_id: session.id,
-            is_error: true,
-            duration_ms: duration,
-            duration_api_ms: 0,
-            num_turns: 0,
-            total_cost_usd: 0,
-            usage: { input_tokens: 0, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-            result: errorDetails.message,
-            errors: [errorDetails.message],
-            debug: {
-              stack: errorDetails.stack,
-              errorType: errorDetails.type,
-              lastStderr: debugInfo.lastStderr.slice(-10),
-              diagnostics: {
-                memory: debugInfo.diagnostics.memory,
-                uptime: debugInfo.diagnostics.uptime,
-                sessionCount: debugInfo.sessionCount,
-              },
-              sessionOptions: errorDetails.sessionOptions,
-            },
-          } as unknown as SDKMessage);
-        }
+            sessionOptions: errorDetails.sessionOptions,
+          },
+        } as unknown as SDKMessage);
       } finally {
         outputChannel.complete();
-        debugLogWatcher?.close();
+        session.debugLogCleanup?.();
+        session.debugLogCleanup = undefined;
       }
     })();
   }
 
   /**
-   * Resolves a pending question for a session.
-   * Called by the /answer endpoint when the user provides answers.
+   * Resolves a pending interaction for a session and kind. The payload
+   * is unpacked per kind:
+   * - `question`: `{ answers }` becomes a PermissionResult with answers bound
+   *   into `updatedInput`.
+   * - `plan`: `{ approved, keepContext?, feedback? }` is mapped to an
+   *   allow/deny PermissionResult matching the legacy ExitPlanMode semantics.
+   *
+   * Returns true if a matching pending interaction was resolved, false if
+   * none was outstanding.
    */
-  resolvePendingQuestion(
+  resolvePending(
     sessionId: string,
-    answers: Record<string, string>,
+    kind: PendingKind,
+    payload: Record<string, unknown>,
   ): boolean {
-    const pending = this.pendingQuestions.get(sessionId);
-    if (!pending) {
+    const entry = this.popPending(sessionId, kind);
+    if (!entry) {
       info(
-        `resolvePendingQuestion - no pending question for session '${sessionId}'`,
+        `resolvePending - no pending ${kind} for session '${sessionId}'`,
       );
       return false;
     }
 
-    // Emit status_resumed BEFORE resolving to ensure correct event ordering in SSE stream
     const ws = this.sessions.get(sessionId);
-    ws?.outputChannel.push({
-      type: "status_resumed",
-      data: {},
-    });
 
-    pending.resolve(answers);
-    this.pendingQuestions.delete(sessionId);
-    info(
-      `Session exiting pending question state (sessionId: ${sessionId}, resolved: true)`,
-    );
-    info(`resolvePendingQuestion - resolved for session '${sessionId}'`);
-    return true;
-  }
-
-  /**
-   * Resolves a pending plan approval for a session.
-   * Called by the /approve-plan endpoint when the user makes a decision.
-   */
-  resolvePendingPlanApproval(
-    sessionId: string,
-    approved: boolean,
-    keepContext?: boolean,
-    feedback?: string,
-  ): boolean {
-    const pending = this.pendingPlanApprovals.get(sessionId);
-    if (!pending) {
+    if (kind === "question") {
+      const answers = (payload.answers ?? {}) as Record<string, string>;
+      ws?.outputChannel.push({ type: "status_resumed", data: {} });
+      const data = entry.data as { questions: UserQuestion[] };
+      const result: PermissionResult = {
+        behavior: "allow",
+        updatedInput: {
+          questions: data.questions,
+          answers,
+        },
+      };
+      entry.resolve(result);
       info(
-        `resolvePendingPlanApproval - no pending approval for session '${sessionId}'`,
+        `Session exiting pending question state (sessionId: ${sessionId}, resolved: true)`,
       );
-      return false;
+      return true;
     }
+
+    // kind === "plan"
+    const approved = Boolean(payload.approved);
+    const keepContext = payload.keepContext as boolean | undefined;
+    const feedback = payload.feedback as string | undefined;
+    const planData = entry.data as { plan: string };
 
     let result: PermissionResult;
-
     if (approved && keepContext) {
-      // Approve and continue in same session context
       result = {
         behavior: "allow",
-        updatedInput: { plan: pending.plan },
+        updatedInput: { plan: planData.plan },
       };
     } else if (approved && !keepContext) {
-      // Approve but signal to interrupt (server will start fresh session with plan)
       result = {
         behavior: "deny",
         message:
           "Plan approved. Interrupting to start fresh implementation session.",
       };
     } else {
-      // Reject — agent should revise the plan
       result = {
         behavior: "deny",
         message: feedback
@@ -952,54 +929,37 @@ export class SessionManager {
       };
     }
 
-    // Emit status_resumed BEFORE resolving to ensure correct event ordering in SSE stream
-    // Skip for approved && !keepContext since session will be interrupted
     if (!(approved && !keepContext)) {
-      const ws = this.sessions.get(sessionId);
-      ws?.outputChannel.push({
-        type: "status_resumed",
-        data: {},
-      });
+      ws?.outputChannel.push({ type: "status_resumed", data: {} });
     }
 
-    pending.resolve(result);
-    this.pendingPlanApprovals.delete(sessionId);
+    entry.resolve(result);
     info(
       `Session exiting pending plan approval state (sessionId: ${sessionId}, approved: ${approved})`,
-    );
-    info(
-      `resolvePendingPlanApproval - resolved for session '${sessionId}', approved=${approved}, keepContext=${keepContext}`,
     );
     return true;
   }
 
   /**
-   * Checks if a session has a pending plan approval.
+   * Returns true when a pending interaction of the given kind is outstanding
+   * for the session.
    */
-  hasPendingPlanApproval(sessionId: string): boolean {
-    return this.pendingPlanApprovals.has(sessionId);
+  hasPending(sessionId: string, kind: PendingKind): boolean {
+    return this.pending.get(sessionId)?.has(kind) ?? false;
   }
 
   /**
-   * Checks if a session has a pending question.
+   * Returns the data captured when the pending interaction was registered
+   * (the questions for `question`, the plan string for `plan`), or undefined
+   * if no interaction of that kind is outstanding.
    */
-  hasPendingQuestion(sessionId: string): boolean {
-    return this.pendingQuestions.has(sessionId);
+  getPendingData<T>(sessionId: string, kind: PendingKind): T | undefined {
+    return this.pending.get(sessionId)?.get(kind)?.data as T | undefined;
   }
 
   /**
-   * Gets the pending questions for a session.
-   */
-  getPendingQuestions(
-    sessionId: string,
-  ): AskUserQuestionInput["questions"] | undefined {
-    return this.pendingQuestions.get(sessionId)?.questions;
-  }
-
-  /**
-   * Sets the mode for a session without sending a message.
-   * Updates the permission mode and stores the mode string.
-   * Returns false if session not found.
+   * Sets the mode for a session without sending a message. Updates the
+   * permission mode and pushes it through to the live SDK query.
    */
   async setMode(sessionId: string, mode: "Plan" | "Build"): Promise<boolean> {
     const ws = this.sessions.get(sessionId);
@@ -1010,7 +970,6 @@ export class SessionManager {
 
     const newPermissionMode = mapMode(mode);
 
-    // Skip if no change
     if (ws.mode === mode && ws.permissionMode === newPermissionMode) {
       info(`setMode - no change (mode='${mode}', sessionId='${sessionId}')`);
       return true;
@@ -1022,10 +981,7 @@ export class SessionManager {
       `setMode - mode updated to '${mode}', permissionMode='${newPermissionMode}' (sessionId='${sessionId}')`,
     );
 
-    // Update permission mode on the SDK query if available.
-    // Skip if the query has already completed (resultReceived) — calling
-    // setPermissionMode on an exited CLI process will hang indefinitely.
-    if (!ws.resultReceived && ws.query.setPermissionMode) {
+    if (ws.query.setPermissionMode) {
       await ws.query.setPermissionMode(newPermissionMode);
       info(
         `setMode - setPermissionMode('${newPermissionMode}') applied (sessionId='${sessionId}')`,
@@ -1037,17 +993,16 @@ export class SessionManager {
   }
 
   /**
-   * Sets the model for a session without sending a message.
-   * Returns false if session not found.
+   * Sets the model for a session without sending a message. Applies to the
+   * live SDK query when available so the next turn uses the new model.
    */
-  setModel(sessionId: string, model: string): boolean {
+  async setModel(sessionId: string, model: string): Promise<boolean> {
     const ws = this.sessions.get(sessionId);
     if (!ws) {
       info(`setModel - session '${sessionId}' not found`);
       return false;
     }
 
-    // Skip if no change
     if (ws.model === model) {
       info(`setModel - no change (model='${model}', sessionId='${sessionId}')`);
       return true;
@@ -1055,6 +1010,12 @@ export class SessionManager {
 
     ws.model = model;
     info(`setModel - model updated to '${model}' (sessionId='${sessionId}')`);
+
+    if (ws.query.setModel) {
+      await ws.query.setModel(model);
+      info(`setModel - setModel('${model}') applied (sessionId='${sessionId}')`);
+    }
+
     ws.lastActivityAt = new Date();
     return true;
   }
@@ -1073,24 +1034,21 @@ export class SessionManager {
       throw new Error(`Session ${sessionId} not found`);
     }
 
-    // Track model changes when a different model is specified
     if (model) {
       ws.model = model;
       info(`model updated to '${model}'`);
+      if (ws.query.setModel) {
+        await ws.query.setModel(model);
+      }
     }
 
     if (mode) {
       ws.permissionMode = mapMode(mode);
-      // Update the mode string to reflect the mode change
       ws.mode = ws.permissionMode === "plan" ? "Plan" : "Build";
       info(
         `mode updated to '${ws.mode}', permissionMode='${ws.permissionMode}'`,
       );
-      // Only update the running query's permission mode if it's still active.
-      // If resultReceived is true, the CLI process has exited and
-      // setPermissionMode will hang. The new query (created below) will
-      // use the updated ws.permissionMode instead.
-      if (!ws.resultReceived && ws.query.setPermissionMode) {
+      if (ws.query.setPermissionMode) {
         await ws.query.setPermissionMode(ws.permissionMode);
         info(`setPermissionMode('${ws.permissionMode}') applied`);
       }
@@ -1098,123 +1056,17 @@ export class SessionManager {
 
     ws.lastActivityAt = new Date();
 
-    if (ws.resultReceived) {
-      // Previous CLI process exited after producing a result.
-      // Start a new query() with resume to continue the conversation.
-      info(
-        `send() - previous query completed, starting new query with resume (sessionId='${sessionId}', conversationId='${ws.conversationId}')`,
-      );
+    const userMessage: SDKUserMessage = {
+      type: "user",
+      session_id: ws.conversationId ?? "",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: message }],
+      },
+      parent_tool_use_id: null,
+    };
 
-      if (!ws.conversationId) {
-        throw new Error(
-          `Cannot resume session ${sessionId}: no conversationId available`,
-        );
-      }
-
-      const isPlan = ws.mode.toLowerCase() === "plan";
-      const common = buildCommonOptions(
-        ws.model,
-        ws.systemPrompt,
-        ws.workingDirectory,
-      );
-      const canUseTool = this.createCanUseToolCallback(sessionId);
-
-      const newSessionOptions: Record<string, unknown> = {
-        ...common,
-        canUseTool,
-        resume: ws.conversationId,
-      };
-
-      if (isPlan) {
-        newSessionOptions.permissionMode = "plan";
-        newSessionOptions.allowedTools = PLAN_MODE_TOOLS;
-      } else {
-        newSessionOptions.permissionMode = "bypassPermissions";
-        newSessionOptions.allowDangerouslySkipPermissions = true;
-      }
-
-      const newInputController = new InputController();
-      const newOutputChannel = new OutputChannel();
-
-      // Create input stream that yields the new message then waits for more
-      async function* createResumeInputStream(
-        initialMessage: string,
-        controller: InputController,
-      ): AsyncGenerator<SDKUserMessage> {
-        yield {
-          type: "user",
-          session_id: "",
-          message: {
-            role: "user",
-            content: [{ type: "text", text: initialMessage }],
-          },
-          parent_tool_use_id: null,
-        };
-        for await (const msg of controller) {
-          yield msg;
-        }
-      }
-
-      const newQuery = query({
-        prompt: createResumeInputStream(message, newInputController),
-        options: newSessionOptions as Parameters<typeof query>[0]["options"],
-      });
-
-      // Update session state
-      ws.query = newQuery;
-      ws.inputController = newInputController;
-      ws.outputChannel = newOutputChannel;
-      ws.resultReceived = false;
-
-      this.logStatusChange(ws, "streaming", "resumed_with_new_query");
-
-      // Emit status_resumed control event
-      ws.outputChannel.push({
-        type: "status_resumed",
-        data: {},
-      });
-
-      // Start new forwarder
-      const startTime = Date.now();
-      const debugLogPath = "/home/homespun/.claude/debug/claude_sdk_debug.log";
-      const debugMonitor = new FileMonitor(debugLogPath);
-      let debugLogWatcher: ReturnType<typeof watch> | undefined;
-      if (existsSync(debugLogPath)) {
-        debugLogWatcher = watch(
-          debugLogPath,
-          { persistent: false },
-          async (eventType) => {
-            if (eventType === "change") {
-              const newLines = await debugMonitor.readNewLines();
-              newLines.forEach((line) => {
-                info(`[SDK Debug] ${line} (sessionId: ${sessionId})`);
-              });
-            }
-          },
-        );
-      }
-
-      this.runQueryForwarder(
-        ws,
-        newQuery,
-        newOutputChannel,
-        startTime,
-        {
-          mode: ws.mode,
-          model: ws.model,
-          systemPrompt: ws.systemPrompt,
-          workingDirectory: ws.workingDirectory,
-        },
-        newSessionOptions,
-        debugMonitor,
-        debugLogPath,
-        debugLogWatcher,
-        "resume",
-      );
-    } else {
-      // CLI process still running — send via input controller
-      ws.inputController.send(message);
-    }
+    await ws.query.streamInput(onceIterator(userMessage));
 
     this.logStatusChange(ws, "streaming", "message_sent");
 
@@ -1231,14 +1083,14 @@ export class SessionManager {
       for await (const event of ws.outputChannel) {
         if (isControlEvent(event)) {
           info(`stream() - control event: type='${event.type}'`);
-          // Log additional detail for control events
           if (event.type === "question_pending") {
-            const questionCount = (event.data as any).questions?.length || 0;
+            const questionCount =
+              (event.data as { questions?: UserQuestion[] }).questions?.length ||
+              0;
             debug(`Control event details: ${questionCount} questions pending`);
           } else if (event.type === "plan_pending") {
             debug(`Control event details: plan approval pending`);
           }
-          // Track control event as last message type
           ws.lastMessageType = event.type;
           ws.lastMessageSubtype = undefined;
           ws.lastActivityAt = new Date();
@@ -1246,30 +1098,37 @@ export class SessionManager {
           continue;
         }
 
-        // SDK message — capture conversation ID and track message type
         const msg = event;
         if (msg.session_id) {
           ws.conversationId = msg.session_id;
         }
 
-        // Track SDK message type
         ws.lastMessageType = msg.type as LastMessageType;
-        ws.lastMessageSubtype = (msg as any).subtype;
+        ws.lastMessageSubtype = (msg as { subtype?: string }).subtype;
         ws.lastActivityAt = new Date();
 
-        if (msg.type === "system" && (msg as any).subtype === "init") {
+        if (
+          msg.type === "system" &&
+          (msg as { subtype?: string }).subtype === "init"
+        ) {
+          const initMsg = msg as {
+            permissionMode?: string;
+            model?: string;
+            tools?: string[];
+          };
+          const hasSkill = Array.isArray(initMsg.tools) && initMsg.tools.includes("Skill");
           info(
-            `SDK init: permissionMode='${(msg as any).permissionMode}', model='${(msg as any).model}'`,
+            `SDK init: permissionMode='${initMsg.permissionMode}', model='${initMsg.model}', toolCount=${initMsg.tools?.length ?? 0}, hasSkillTool=${hasSkill}`,
           );
         }
         if (msg.type === "result") {
-          const r = msg as any;
+          const r = msg as { subtype?: string; is_error?: boolean };
           info(`result: subtype='${r.subtype}', is_error=${r.is_error}`);
         }
         yield event;
       }
     } finally {
-      // Don't overwrite error status — it indicates a genuine failure
+      // Don't overwrite error status — it indicates a genuine failure.
       if (ws.status !== "error") {
         this.logStatusChange(ws, "idle", "stream_complete");
       }
@@ -1280,26 +1139,18 @@ export class SessionManager {
     const ws = this.sessions.get(sessionId);
     if (!ws) return;
 
-    // Reject any pending questions
-    const pendingQuestion = this.pendingQuestions.get(sessionId);
-    if (pendingQuestion) {
-      warn(`Session closed with pending question (sessionId: ${sessionId})`);
-      pendingQuestion.reject(new Error("Session closed"));
-      this.pendingQuestions.delete(sessionId);
-    }
-
-    // Reject any pending plan approvals
-    const pendingPlan = this.pendingPlanApprovals.get(sessionId);
-    if (pendingPlan) {
-      warn(
-        `Session closed with pending plan approval (sessionId: ${sessionId})`,
-      );
-      pendingPlan.reject(new Error("Session closed"));
-      this.pendingPlanApprovals.delete(sessionId);
+    const bySession = this.pending.get(sessionId);
+    if (bySession) {
+      for (const [kind, entry] of bySession) {
+        const label = kind === "question" ? "question" : "plan approval";
+        warn(`Session closed with pending ${label} (sessionId: ${sessionId})`);
+        entry.reject(new Error("Session closed"));
+      }
+      this.pending.delete(sessionId);
     }
 
     ws.outputChannel.complete();
-    ws.inputController.close();
+    ws.query.close?.();
     this.logStatusChange(ws, "closed", "session_closed");
     this.sessions.delete(sessionId);
   }
@@ -1330,25 +1181,9 @@ export class SessionManager {
   }
 
   /**
-   * Gets message history for a session since a given timestamp.
-   * Used for catch-up replay after server restart.
-   */
-  getMessageHistory(sessionId: string, since?: Date): MessageHistoryEntry[] {
-    const ws = this.sessions.get(sessionId);
-    if (!ws) {
-      return [];
-    }
-
-    if (since) {
-      return ws.outputChannel.getMessagesSince(since);
-    }
-    return ws.outputChannel.getAllMessages();
-  }
-
-  /**
    * Clears context by closing an existing session and creating a new one.
-   * Returns the new session. The old session is closed but not deleted
-   * from history (handled by the server's message cache).
+   * Returns the new session. Message replay after the swap comes exclusively
+   * from the server-side cache.
    */
   async clearContextAndCreate(
     currentSessionId: string,
@@ -1364,7 +1199,6 @@ export class SessionManager {
       `clearContextAndCreate - closing session '${currentSessionId}' and creating new session`,
     );
 
-    // Close the existing session if it exists
     const existingSession = this.sessions.get(currentSessionId);
     if (existingSession) {
       await this.close(currentSessionId);
@@ -1374,14 +1208,12 @@ export class SessionManager {
       );
     }
 
-    // Create a new session with fresh context (no resume)
     const newSession = await this.create({
       prompt: opts.prompt,
       model: opts.model,
       mode: opts.mode,
       systemPrompt: opts.systemPrompt,
       workingDirectory: opts.workingDirectory,
-      // No resumeSessionId - this is a fresh context
     });
 
     info(

--- a/tests/Homespun.Worker/helpers/mock-sdk.ts
+++ b/tests/Homespun.Worker/helpers/mock-sdk.ts
@@ -18,6 +18,8 @@ export function createMockQuery(messages: SDKMessage[] = []): MockQuery {
     supportedModels: vi.fn().mockResolvedValue([]),
     mcpServerStatus: vi.fn().mockResolvedValue([]),
     accountInfo: vi.fn().mockResolvedValue({}),
+    streamInput: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn(),
     _messages: messages,
     _iterator: null as any,
   };

--- a/tests/Homespun.Worker/helpers/mock-session-manager.ts
+++ b/tests/Homespun.Worker/helpers/mock-session-manager.ts
@@ -13,10 +13,11 @@ export function createMockSessionManager(): MockSessionManager {
     get: vi.fn(),
     list: vi.fn().mockReturnValue([]),
     closeAll: vi.fn().mockResolvedValue(undefined),
-    resolvePendingQuestion: vi.fn().mockReturnValue(true),
-    resolvePendingPlanApproval: vi.fn().mockReturnValue(true),
-    hasPendingQuestion: vi.fn().mockReturnValue(false),
-    hasPendingPlanApproval: vi.fn().mockReturnValue(false),
-    getPendingQuestions: vi.fn().mockReturnValue(undefined),
+    resolvePending: vi.fn().mockReturnValue(true),
+    hasPending: vi.fn().mockReturnValue(false),
+    getPendingData: vi.fn().mockReturnValue(undefined),
+    setMode: vi.fn().mockResolvedValue(true),
+    setModel: vi.fn().mockResolvedValue(true),
+    clearContextAndCreate: vi.fn(),
   };
 }

--- a/tests/Homespun.Worker/routes/sessions.test.ts
+++ b/tests/Homespun.Worker/routes/sessions.test.ts
@@ -45,8 +45,7 @@ describe('GET /sessions/active', () => {
     sm.list.mockReturnValue([
       { sessionId: 's1', status: 'idle', lastActivityAt: '2025-01-01T00:00:00Z' },
     ]);
-    sm.hasPendingQuestion.mockReturnValue(false);
-    sm.hasPendingPlanApproval.mockReturnValue(false);
+    sm.hasPending.mockImplementation(() => false);
 
     const res = await app.request('/active');
     const body = await res.json();
@@ -67,8 +66,7 @@ describe('GET /sessions/active', () => {
     sm.list.mockReturnValue([
       { sessionId: 's1', status: 'streaming', lastActivityAt: '2025-01-01T00:00:00Z' },
     ]);
-    sm.hasPendingQuestion.mockReturnValue(false);
-    sm.hasPendingPlanApproval.mockReturnValue(false);
+    sm.hasPending.mockImplementation(() => false);
 
     const res = await app.request('/active');
     const body = await res.json();
@@ -83,8 +81,7 @@ describe('GET /sessions/active', () => {
     sm.list.mockReturnValue([
       { sessionId: 's1', status: 'idle', lastActivityAt: '2025-01-01T00:00:00Z' },
     ]);
-    sm.hasPendingQuestion.mockReturnValue(true);
-    sm.hasPendingPlanApproval.mockReturnValue(false);
+    sm.hasPending.mockImplementation((_: string, kind: string) => kind === 'question');
 
     const res = await app.request('/active');
     const body = await res.json();
@@ -99,8 +96,7 @@ describe('GET /sessions/active', () => {
     sm.list.mockReturnValue([
       { sessionId: 's1', status: 'idle', lastActivityAt: '2025-01-01T00:00:00Z' },
     ]);
-    sm.hasPendingQuestion.mockReturnValue(false);
-    sm.hasPendingPlanApproval.mockReturnValue(true);
+    sm.hasPending.mockImplementation((_: string, kind: string) => kind === 'plan');
 
     const res = await app.request('/active');
     const body = await res.json();
@@ -257,7 +253,7 @@ describe('POST /sessions/:id/message', () => {
 describe('POST /sessions/:id/answer', () => {
   it('resolves pending question when one exists', async () => {
     const { sm, app } = createApp();
-    sm.resolvePendingQuestion.mockReturnValue(true);
+    sm.resolvePending.mockReturnValue(true);
     sm.get.mockReturnValue({ id: 'sess-1', conversationId: 'c1' });
     sm.stream.mockReturnValue((async function* () {})());
 
@@ -273,9 +269,11 @@ describe('POST /sessions/:id/answer', () => {
     });
 
     expect(res.status).toBe(200);
-    expect(sm.resolvePendingQuestion).toHaveBeenCalledWith('sess-1', {
-      'Which framework?': 'React',
-      'Include tests?': 'Yes',
+    expect(sm.resolvePending).toHaveBeenCalledWith('sess-1', 'question', {
+      answers: {
+        'Which framework?': 'React',
+        'Include tests?': 'Yes',
+      },
     });
     // Should not send as message when pending question was resolved
     expect(sm.send).not.toHaveBeenCalled();
@@ -283,7 +281,7 @@ describe('POST /sessions/:id/answer', () => {
 
   it('returns 400 when no pending question', async () => {
     const { sm, app } = createApp();
-    sm.resolvePendingQuestion.mockReturnValue(false);
+    sm.resolvePending.mockReturnValue(false);
 
     const res = await app.request('/sess-1/answer', {
       method: 'POST',
@@ -300,7 +298,7 @@ describe('POST /sessions/:id/answer', () => {
 describe('POST /sessions/:id/approve-plan', () => {
   it('resolves pending plan approval when approved', async () => {
     const { sm, app } = createApp();
-    sm.resolvePendingPlanApproval.mockReturnValue(true);
+    sm.resolvePending.mockReturnValue(true);
     sm.get.mockReturnValue({ id: 'sess-1', conversationId: 'c1' });
     sm.stream.mockReturnValue((async function* () {})());
 
@@ -311,12 +309,16 @@ describe('POST /sessions/:id/approve-plan', () => {
     });
 
     expect(res.status).toBe(200);
-    expect(sm.resolvePendingPlanApproval).toHaveBeenCalledWith('sess-1', true, undefined, undefined);
+    expect(sm.resolvePending).toHaveBeenCalledWith('sess-1', 'plan', {
+      approved: true,
+      keepContext: undefined,
+      feedback: undefined,
+    });
   });
 
   it('resolves pending plan approval when rejected', async () => {
     const { sm, app } = createApp();
-    sm.resolvePendingPlanApproval.mockReturnValue(true);
+    sm.resolvePending.mockReturnValue(true);
     sm.get.mockReturnValue({ id: 'sess-1', conversationId: 'c1' });
     sm.stream.mockReturnValue((async function* () {})());
 
@@ -327,12 +329,16 @@ describe('POST /sessions/:id/approve-plan', () => {
     });
 
     expect(res.status).toBe(200);
-    expect(sm.resolvePendingPlanApproval).toHaveBeenCalledWith('sess-1', false, undefined, undefined);
+    expect(sm.resolvePending).toHaveBeenCalledWith('sess-1', 'plan', {
+      approved: false,
+      keepContext: undefined,
+      feedback: undefined,
+    });
   });
 
-  it('passes keepContext and feedback to resolvePendingPlanApproval', async () => {
+  it('passes keepContext and feedback to resolvePending', async () => {
     const { sm, app } = createApp();
-    sm.resolvePendingPlanApproval.mockReturnValue(true);
+    sm.resolvePending.mockReturnValue(true);
     sm.get.mockReturnValue({ id: 'sess-1', conversationId: 'c1' });
     sm.stream.mockReturnValue((async function* () {})());
 
@@ -343,12 +349,16 @@ describe('POST /sessions/:id/approve-plan', () => {
     });
 
     expect(res.status).toBe(200);
-    expect(sm.resolvePendingPlanApproval).toHaveBeenCalledWith('sess-1', true, true, 'looks good');
+    expect(sm.resolvePending).toHaveBeenCalledWith('sess-1', 'plan', {
+      approved: true,
+      keepContext: true,
+      feedback: 'looks good',
+    });
   });
 
   it('returns 400 when no pending plan approval', async () => {
     const { sm, app } = createApp();
-    sm.resolvePendingPlanApproval.mockReturnValue(false);
+    sm.resolvePending.mockReturnValue(false);
 
     const res = await app.request('/sess-1/approve-plan', {
       method: 'POST',

--- a/tests/Homespun.Worker/services/session-manager-logging.test.ts
+++ b/tests/Homespun.Worker/services/session-manager-logging.test.ts
@@ -197,7 +197,7 @@ describe('SessionManager Logging', () => {
       );
 
       // Clean up
-      sessionManager.resolvePendingQuestion('test-session-123', { '0': 'Option A' });
+      sessionManager.resolvePending('test-session-123', 'question', { answers: { '0': 'Option A' } });
       await promise;
     });
 
@@ -223,7 +223,7 @@ describe('SessionManager Logging', () => {
       vi.clearAllMocks();
 
       // Act
-      sessionManager.resolvePendingQuestion('test-session-123', { '0': 'Answer' });
+      sessionManager.resolvePending('test-session-123', 'question', { answers: { '0': 'Answer' } });
       await promise;
 
       // Assert
@@ -265,7 +265,7 @@ describe('SessionManager Logging', () => {
       );
 
       // Clean up
-      sessionManager.resolvePendingPlanApproval('test-session-123', true, true);
+      sessionManager.resolvePending('test-session-123', 'plan', { approved: true, keepContext: true });
       await promise;
     });
 
@@ -291,7 +291,7 @@ describe('SessionManager Logging', () => {
       vi.clearAllMocks();
 
       // Act
-      sessionManager.resolvePendingPlanApproval('test-session-123', true, true);
+      sessionManager.resolvePending('test-session-123', 'plan', { approved: true, keepContext: true });
       await promise;
 
       // Assert
@@ -428,52 +428,9 @@ describe('SessionManager Logging', () => {
       expect(invCalls).toHaveLength(1);
     });
 
-    it('T015: emits `inventory event=resume` on the resume code path', async () => {
-      // Arrange — create a session, then push a result so the forwarder completes.
-      setMockQueryMessages(mockQueryInstance, [
-        createSdkInitMessage({ session_id: 'test-session-123' }),
-        createAssistantMessage('Hi'),
-        createResultMessage(),
-      ]);
-      await sessionManager.create({
-        prompt: 'Test prompt',
-        model: 'opus',
-        mode: 'Build',
-      });
-      // Drain to mark resultReceived=true so the next send() takes the
-      // resume-with-new-query branch.
-      await collectAsyncGenerator(sessionManager.stream('test-session-123'));
-
-      // Set conversationId so resume path has something to resume.
-      const ws = (sessionManager as unknown as { sessions: Map<string, { conversationId?: string }> }).sessions.get(
-        'test-session-123',
-      );
-      if (ws) ws.conversationId = 'conv-abc';
-
-      // New mock query for the resume send.
-      const resumeMock = createMockQuery();
-      setMockQueryMessages(resumeMock, [
-        createSdkInitMessage({ session_id: 'test-session-123' }),
-        createAssistantMessage('resumed'),
-        createResultMessage(),
-      ]);
-      setMockQuery(resumeMock);
-
-      // Clear captured logs so we only count the resume-side emission.
-      vi.clearAllMocks();
-
-      // Act
-      await sessionManager.send('test-session-123', 'follow-up');
-      await collectAsyncGenerator(sessionManager.stream('test-session-123'));
-
-      // Assert
-      const invCalls = (info as unknown as Mock).mock.calls.filter(
-        ([msg]: [unknown]) =>
-          typeof msg === 'string' &&
-          msg.startsWith('inventory event=resume sessionId=test-session-123 payload={'),
-      );
-      expect(invCalls).toHaveLength(1);
-    });
+    // T015 removed: the resume-with-new-query code path was deleted by the
+    // simplify-worker-session-manager change. A session now uses a single
+    // long-lived query(), so inventory only emits `event=create`.
 
     it('T025: canUseTool info log includes origin= field (builtin + mcp)', async () => {
       setMockQueryMessages(mockQueryInstance, [
@@ -562,7 +519,7 @@ describe('SessionManager Logging', () => {
       );
 
       // Clean up
-      sessionManager.resolvePendingQuestion('test-session-123', { '0': 'A1', '1': 'A2' });
+      sessionManager.resolvePending('test-session-123', 'question', { answers: { '0': 'A1', '1': 'A2' } });
       await promise;
     });
 
@@ -607,7 +564,7 @@ describe('SessionManager Logging', () => {
       );
 
       // Clean up
-      sessionManager.resolvePendingPlanApproval('test-session-123', true, true);
+      sessionManager.resolvePending('test-session-123', 'plan', { approved: true, keepContext: true });
       await promise;
     });
   });

--- a/tests/Homespun.Worker/services/session-manager.test.ts
+++ b/tests/Homespun.Worker/services/session-manager.test.ts
@@ -1,10 +1,7 @@
-import { vi, type Mock } from 'vitest';
+import { vi } from 'vitest';
 import { createMockQuery, createBlockingMockQuery, setMockQueryMessages, type MockQuery } from '../helpers/mock-sdk.js';
 import { createAssistantMessage, createResultMessage, createSystemMessage } from '../helpers/test-fixtures.js';
 import { collectAsyncGenerator } from '../helpers/async-helpers.js';
-
-// Track the canUseTool callback that gets passed to query()
-let capturedCanUseTool: ((toolName: string, input: Record<string, unknown>) => Promise<any>) | undefined;
 
 // Use vi.hoisted to ensure variables are available during vi.mock factory execution
 const { mockQuery, mockRandomUUID, getMockQuery, setMockQuery, getCapturedCanUseTool, setCapturedCanUseTool } = vi.hoisted(() => {
@@ -12,7 +9,6 @@ const { mockQuery, mockRandomUUID, getMockQuery, setMockQuery, getCapturedCanUse
   let _capturedCanUseTool: any = undefined;
   return {
     mockQuery: vi.fn((...args: any[]) => {
-      // Capture the canUseTool callback from options
       const options = args[0]?.options;
       if (options?.canUseTool) {
         _capturedCanUseTool = options.canUseTool;
@@ -110,7 +106,7 @@ describe('SessionManager', () => {
       expect(opts.permissionMode).toBe('plan');
       expect(opts.allowedTools).toEqual([
         'Read', 'Glob', 'Grep', 'WebFetch', 'WebSearch',
-        'Task', 'AskUserQuestion', 'ExitPlanMode',
+        'Task', 'AskUserQuestion', 'ExitPlanMode', 'Skill',
       ]);
     });
 
@@ -121,6 +117,41 @@ describe('SessionManager', () => {
       const opts = args.options as Record<string, unknown>;
       expect(opts.permissionMode).toBe('bypassPermissions');
       expect(opts.allowDangerouslySkipPermissions).toBe(true);
+    });
+
+    it('includes "Skill" in allowedTools for build mode so Agent Skills are enabled', async () => {
+      await manager.create({ ...baseOpts, mode: 'Build' });
+
+      const args = mockQuery.mock.calls[0][0] as Record<string, unknown>;
+      const opts = args.options as Record<string, unknown>;
+      expect(opts.allowedTools).toContain('Skill');
+    });
+
+    it('build mode allowedTools is a superset of plan mode allowedTools', async () => {
+      // Build mode bypasses permissions via allowDangerouslySkipPermissions +
+      // canUseTool, but it should still expose at least everything plan mode
+      // exposes so the model has consistent tool visibility across modes.
+      await manager.create(baseOpts);
+      const planOpts = mockQuery.mock.calls[0][0] as Record<string, unknown>;
+      const planAllowed = (planOpts.options as { allowedTools: string[] }).allowedTools;
+
+      mockQuery.mockClear();
+      mockRandomUUID.mockReturnValueOnce('build-session-id');
+      await manager.create({ ...baseOpts, mode: 'Build' });
+      const buildOpts = mockQuery.mock.calls[0][0] as Record<string, unknown>;
+      const buildAllowed = (buildOpts.options as { allowedTools: string[] }).allowedTools;
+
+      for (const tool of planAllowed) {
+        expect(buildAllowed).toContain(tool);
+      }
+    });
+
+    it('includes "Skill" in allowedTools for plan mode so Agent Skills are enabled', async () => {
+      await manager.create(baseOpts);
+
+      const args = mockQuery.mock.calls[0][0] as Record<string, unknown>;
+      const opts = args.options as Record<string, unknown>;
+      expect(opts.allowedTools).toContain('Skill');
     });
 
     it('passes resume option when resumeSessionId is provided', async () => {
@@ -227,9 +258,9 @@ describe('SessionManager', () => {
 
   describe('send()', () => {
     it('updates lastActivityAt', async () => {
+      setMockQuery(createBlockingMockQuery());
       const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Build' });
       const beforeActivity = ws.lastActivityAt;
-      mockQuery.mockClear(); // Clear the create() call
 
       await new Promise((r) => setTimeout(r, 5));
 
@@ -239,6 +270,7 @@ describe('SessionManager', () => {
     });
 
     it('sets status to streaming', async () => {
+      setMockQuery(createBlockingMockQuery());
       const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Build' });
       ws.status = 'idle';
 
@@ -248,6 +280,7 @@ describe('SessionManager', () => {
     });
 
     it('updates permissionMode when provided', async () => {
+      setMockQuery(createBlockingMockQuery());
       const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Plan' });
       expect(ws.permissionMode).toBe('plan');
 
@@ -257,6 +290,7 @@ describe('SessionManager', () => {
     });
 
     it('preserves permissionMode when not provided', async () => {
+      setMockQuery(createBlockingMockQuery());
       const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Build' });
       expect(ws.permissionMode).toBe('bypassPermissions');
 
@@ -271,71 +305,91 @@ describe('SessionManager', () => {
       );
     });
 
-    it('creates new query with resume when resultReceived is true', async () => {
+    // Task 3.2: send() after a `result` message delivers the new user message
+    // via q.streamInput() and does NOT call query() a second time.
+    it('task 3.2: delivers follow-up via streamInput without restarting query', async () => {
+      setMockQueryMessages(mockQueryObj, [createResultMessage()]);
       const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Build' });
+
+      // Drain the first query so a result is observed (forwarder finishes).
+      await collectAsyncGenerator(manager.stream(ws.id));
+
+      const streamInputMock = vi.fn().mockResolvedValue(undefined);
+      (ws.query as any).streamInput = streamInputMock;
       mockQuery.mockClear();
 
-      // Simulate that a result was received and conversationId was captured
-      ws.resultReceived = true;
-      ws.conversationId = 'conv-123';
+      await manager.send(ws.id, 'follow up');
 
-      // Set up a blocking mock query so the forwarder doesn't complete before assertions
-      setMockQuery(createBlockingMockQuery());
-
-      await manager.send(ws.id, 'follow up message');
-
-      // Should have called query() again with resume option
-      expect(mockQuery).toHaveBeenCalledOnce();
-      const args = mockQuery.mock.calls[0][0] as Record<string, unknown>;
-      const opts = args.options as Record<string, unknown>;
-      expect(opts.resume).toBe('conv-123');
-
-      // resultReceived should be reset
-      expect(ws.resultReceived).toBe(false);
-      expect(ws.status).toBe('streaming');
-    });
-
-    it('throws when resultReceived but no conversationId', async () => {
-      const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Build' });
-      ws.resultReceived = true;
-      ws.conversationId = undefined;
-
-      await expect(manager.send(ws.id, 'msg')).rejects.toThrow(
-        'Cannot resume session',
-      );
-    });
-
-    it('uses inputController when resultReceived is false', async () => {
-      const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Build' });
-      mockQuery.mockClear();
-
-      // resultReceived defaults to false
-      expect(ws.resultReceived).toBe(false);
-
-      await manager.send(ws.id, 'msg');
-
-      // Should NOT create a new query
       expect(mockQuery).not.toHaveBeenCalled();
+      expect(streamInputMock).toHaveBeenCalledOnce();
+      const [streamArg] = streamInputMock.mock.calls[0];
+      expect(typeof streamArg[Symbol.asyncIterator]).toBe('function');
+
+      const collected: any[] = [];
+      for await (const msg of streamArg) collected.push(msg);
+      expect(collected).toHaveLength(1);
+      expect(collected[0]).toMatchObject({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'follow up' }],
+        },
+      });
+    });
+  });
+
+  // Task 3.3: setMode() calls q.setPermissionMode() after a prior `result`.
+  describe('setMode() after result', () => {
+    it('task 3.3: setMode applies setPermissionMode to the live query', async () => {
+      setMockQueryMessages(mockQueryObj, [createResultMessage()]);
+      const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Plan' });
+
+      // Drain so that from a client's perspective a result has been received.
+      await collectAsyncGenerator(manager.stream(ws.id));
+
+      const setPermissionModeMock = vi.fn().mockResolvedValue(undefined);
+      (ws.query as any).setPermissionMode = setPermissionModeMock;
+
+      const ok = await manager.setMode(ws.id, 'Build');
+      expect(ok).toBe(true);
+      expect(setPermissionModeMock).toHaveBeenCalledWith('bypassPermissions');
+      expect(ws.permissionMode).toBe('bypassPermissions');
+      expect(ws.mode).toBe('Build');
+    });
+  });
+
+  // Task 3.4: setModel() updates the session model and is callable after a prior result.
+  describe('setModel() after result', () => {
+    it('task 3.4: setModel updates model and calls q.setModel', async () => {
+      setMockQueryMessages(mockQueryObj, [createResultMessage()]);
+      const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Build' });
+
+      await collectAsyncGenerator(manager.stream(ws.id));
+
+      const setModelMock = vi.fn().mockResolvedValue(undefined);
+      (ws.query as any).setModel = setModelMock;
+
+      const ok = await manager.setModel(ws.id, 'opus');
+      expect(ok).toBe(true);
+      expect(setModelMock).toHaveBeenCalledWith('opus');
+      expect(ws.model).toBe('opus');
     });
   });
 
   describe('runQueryForwarder()', () => {
-    it('sets resultReceived and transitions to idle on result message', async () => {
+    it('transitions to idle on query completion', async () => {
       setMockQueryMessages(mockQueryObj, [
         createAssistantMessage(),
         createResultMessage(),
       ]);
       const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Build' });
 
-      // Drain the output channel via stream()
       await collectAsyncGenerator(manager.stream(ws.id));
 
-      expect(ws.resultReceived).toBe(true);
       expect(ws.status).toBe('idle');
     });
 
     it('sets status to error on genuine error before result', async () => {
-      // Create a mock query that throws an error
       const errorQuery = createMockQuery();
       (errorQuery as any)[Symbol.asyncIterator] = async function* () {
         throw new Error('SDK crashed');
@@ -344,32 +398,11 @@ describe('SessionManager', () => {
 
       const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Build' });
 
-      // Drain the output channel via stream()
       const messages = await collectAsyncGenerator(manager.stream(ws.id));
 
       expect(ws.status).toBe('error');
-      // Should push a synthetic error result
       const errorResult = messages.find((m: any) => m.type === 'result' && m.is_error);
       expect(errorResult).toBeDefined();
-    });
-
-    it('sets status to idle on error after result (post-result exit)', async () => {
-      // Create a mock query that yields a result then throws
-      const postResultQuery = createMockQuery();
-      (postResultQuery as any)[Symbol.asyncIterator] = async function* () {
-        yield createResultMessage();
-        throw new Error('Claude Code process exited with code 1');
-      };
-      setMockQuery(postResultQuery);
-
-      const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Build' });
-
-      // Drain the output channel via stream()
-      await collectAsyncGenerator(manager.stream(ws.id));
-
-      // Should be idle, not error — the result was already received
-      expect(ws.status).toBe('idle');
-      expect(ws.resultReceived).toBe(true);
     });
   });
 
@@ -409,8 +442,9 @@ describe('SessionManager', () => {
     });
   });
 
-  describe('canUseTool callback', () => {
-    it('allows non-AskUserQuestion tools immediately', async () => {
+  describe('canUseTool callback dispatch', () => {
+    it('allows non-special tools immediately', async () => {
+      setMockQuery(createBlockingMockQuery());
       await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Build' });
 
       const canUseTool = getCapturedCanUseTool();
@@ -424,13 +458,14 @@ describe('SessionManager', () => {
       });
     });
 
-    it('pauses on AskUserQuestion and resumes when resolved', async () => {
+    // Task 3.5: canUseTool("AskUserQuestion", ...) emits question_pending
+    // and awaits resolvePending(id, "question", { answers }).
+    it('task 3.5: AskUserQuestion emits question_pending and awaits resolvePending', async () => {
+      setMockQuery(createBlockingMockQuery());
       const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Plan' });
 
       const canUseTool = getCapturedCanUseTool();
-      expect(canUseTool).toBeDefined();
 
-      // Start the canUseTool call (it will wait)
       const questionInput = {
         questions: [
           {
@@ -447,14 +482,22 @@ describe('SessionManager', () => {
 
       const resultPromise = canUseTool('AskUserQuestion', questionInput);
 
-      // Verify there's a pending question
-      expect(manager.hasPendingQuestion(ws.id)).toBe(true);
+      expect(manager.hasPending(ws.id, 'question')).toBe(true);
 
-      // Resolve the question
-      const resolved = manager.resolvePendingQuestion(ws.id, { 'Which framework?': 'React' });
+      // Verify the question_pending control event was pushed to the channel.
+      let sawQuestionPending = false;
+      const streamGen = manager.stream(ws.id);
+      const firstEvent = await streamGen.next();
+      if (!firstEvent.done && (firstEvent.value as any).type === 'question_pending') {
+        sawQuestionPending = true;
+      }
+      expect(sawQuestionPending).toBe(true);
+
+      const resolved = manager.resolvePending(ws.id, 'question', {
+        answers: { 'Which framework?': 'React' },
+      });
       expect(resolved).toBe(true);
 
-      // Check the result
       const result = await resultPromise;
       expect(result).toEqual({
         behavior: 'allow',
@@ -464,11 +507,15 @@ describe('SessionManager', () => {
         },
       });
 
-      // Pending question should be cleared
-      expect(manager.hasPendingQuestion(ws.id)).toBe(false);
+      expect(manager.hasPending(ws.id, 'question')).toBe(false);
+      // Silence the still-open async iterator.
+      await streamGen.return(undefined);
     });
 
-    it('pauses on ExitPlanMode and resumes when approved with keepContext', async () => {
+    // Task 3.6: canUseTool("ExitPlanMode", ...) emits plan_pending and resolves
+    // via resolvePending(id, "plan", { approved, keepContext, feedback }).
+    it('task 3.6: ExitPlanMode emits plan_pending and resolves via resolvePending', async () => {
+      setMockQuery(createBlockingMockQuery());
       const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Plan' });
 
       const canUseTool = getCapturedCanUseTool();
@@ -476,33 +523,30 @@ describe('SessionManager', () => {
 
       const resultPromise = canUseTool('ExitPlanMode', planInput);
 
-      // Verify there's a pending approval
-      expect(manager.hasPendingPlanApproval(ws.id)).toBe(true);
+      expect(manager.hasPending(ws.id, 'plan')).toBe(true);
 
-      // Approve the plan with keepContext=true
-      const resolved = manager.resolvePendingPlanApproval(ws.id, true, true);
+      const resolved = manager.resolvePending(ws.id, 'plan', {
+        approved: true,
+        keepContext: true,
+      });
       expect(resolved).toBe(true);
 
-      // Check the result
       const result = await resultPromise;
       expect(result).toEqual({
         behavior: 'allow',
         updatedInput: { plan: planInput.plan },
       });
 
-      expect(manager.hasPendingPlanApproval(ws.id)).toBe(false);
+      expect(manager.hasPending(ws.id, 'plan')).toBe(false);
     });
 
-    it('denies ExitPlanMode when approved without keepContext', async () => {
+    it('resolvePending(plan, approved without keepContext) denies with interrupt message', async () => {
+      setMockQuery(createBlockingMockQuery());
       const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Plan' });
-
       const canUseTool = getCapturedCanUseTool();
-      const planInput = { plan: 'The plan content' };
 
-      const resultPromise = canUseTool('ExitPlanMode', planInput);
-
-      // Approve the plan without keepContext (interrupts to start fresh session)
-      manager.resolvePendingPlanApproval(ws.id, true);
+      const resultPromise = canUseTool('ExitPlanMode', { plan: 'x' });
+      manager.resolvePending(ws.id, 'plan', { approved: true });
 
       const result = await resultPromise;
       expect(result).toEqual({
@@ -511,42 +555,137 @@ describe('SessionManager', () => {
       });
     });
 
-    it('denies ExitPlanMode when rejected', async () => {
+    it('resolvePending(plan, rejected) denies with rejection message', async () => {
+      setMockQuery(createBlockingMockQuery());
       const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Plan' });
-
       const canUseTool = getCapturedCanUseTool();
-      const planInput = { plan: 'The plan content' };
 
-      const resultPromise = canUseTool('ExitPlanMode', planInput);
+      const resultPromise = canUseTool('ExitPlanMode', { plan: 'x' });
+      manager.resolvePending(ws.id, 'plan', { approved: false });
 
-      // Reject the plan
-      manager.resolvePendingPlanApproval(ws.id, false);
-
-      // Check the result
       const result = await resultPromise;
       expect(result).toEqual({
         behavior: 'deny',
         message: 'User rejected the plan. Please revise.',
       });
     });
+
+    // Task 3.7: canUseTool("WorkflowComplete", ...) with workflow context
+    // emits workflow_complete and returns allow; without returns deny.
+    it('task 3.7: WorkflowComplete with context emits and allows; without denies', async () => {
+      setMockQuery(createBlockingMockQuery());
+      const ws = await manager.create({
+        prompt: 'init',
+        model: 'sonnet',
+        mode: 'Build',
+        workflowContext: { stepId: 'step-1', executionId: 'exec-1', nodeType: 'agent' } as any,
+      });
+      const canUseTool = getCapturedCanUseTool();
+
+      const completionInput = {
+        status: 'success',
+        outputs: { result: 'ok' },
+        summary: 'Done',
+      };
+
+      const allowedResult = await canUseTool('WorkflowComplete', completionInput);
+      expect(allowedResult).toEqual({
+        behavior: 'allow',
+        updatedInput: completionInput,
+      });
+
+      await manager.close(ws.id);
+
+      // Fresh session without workflow context
+      setMockQuery(createBlockingMockQuery());
+      mockRandomUUID.mockReturnValue('session-no-wc');
+      await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Build' });
+      const canUseTool2 = getCapturedCanUseTool();
+
+      const deniedResult = await canUseTool2('WorkflowComplete', completionInput);
+      expect(deniedResult).toMatchObject({
+        behavior: 'deny',
+      });
+    });
+
+    // Task 3.8: canUseTool("workflow_signal", ...) with workflow context emits
+    // and allows; without returns deny.
+    it('task 3.8: workflow_signal with context emits and allows; without denies', async () => {
+      setMockQuery(createBlockingMockQuery());
+      const ws = await manager.create({
+        prompt: 'init',
+        model: 'sonnet',
+        mode: 'Build',
+        workflowContext: { stepId: 'step-1', executionId: 'exec-1', nodeType: 'agent' } as any,
+      });
+      const canUseTool = getCapturedCanUseTool();
+
+      const signalInput = { status: 'success' };
+
+      const allowedResult = await canUseTool('workflow_signal', signalInput);
+      expect(allowedResult).toEqual({
+        behavior: 'allow',
+        updatedInput: signalInput,
+      });
+
+      await manager.close(ws.id);
+
+      setMockQuery(createBlockingMockQuery());
+      mockRandomUUID.mockReturnValue('session-no-wc-2');
+      await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Build' });
+      const canUseTool2 = getCapturedCanUseTool();
+
+      const deniedResult = await canUseTool2('workflow_signal', signalInput);
+      expect(deniedResult).toMatchObject({
+        behavior: 'deny',
+      });
+    });
   });
 
-  describe('resolvePendingQuestion()', () => {
-    it('returns false when no pending question exists', () => {
-      const result = manager.resolvePendingQuestion('non-existent', { Q: 'A' });
+  describe('resolvePending()', () => {
+    it('returns false when no pending interaction exists (question)', () => {
+      const result = manager.resolvePending('non-existent', 'question', { answers: {} });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when no pending interaction exists (plan)', () => {
+      const result = manager.resolvePending('non-existent', 'plan', { approved: true });
       expect(result).toBe(false);
     });
   });
 
-  describe('resolvePendingPlanApproval()', () => {
-    it('returns false when no pending approval exists', () => {
-      const result = manager.resolvePendingPlanApproval('non-existent', true);
-      expect(result).toBe(false);
+  describe('hasPending() / getPendingData()', () => {
+    it('returns false / undefined before registration', async () => {
+      setMockQuery(createBlockingMockQuery());
+      const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Plan' });
+
+      expect(manager.hasPending(ws.id, 'question')).toBe(false);
+      expect(manager.hasPending(ws.id, 'plan')).toBe(false);
+      expect(manager.getPendingData(ws.id, 'question')).toBeUndefined();
+      expect(manager.getPendingData(ws.id, 'plan')).toBeUndefined();
+    });
+
+    it('exposes captured data while a pending interaction is outstanding', async () => {
+      setMockQuery(createBlockingMockQuery());
+      const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Plan' });
+      const canUseTool = getCapturedCanUseTool();
+
+      const questionInput = {
+        questions: [{ question: 'Q?', header: 'Q', options: [], multiSelect: false }],
+      };
+      const promise = canUseTool('AskUserQuestion', questionInput);
+
+      const data = manager.getPendingData<{ questions: unknown[] }>(ws.id, 'question');
+      expect(data?.questions).toEqual(questionInput.questions);
+
+      manager.resolvePending(ws.id, 'question', { answers: {} });
+      await promise;
     });
   });
 
   describe('close()', () => {
     it('removes session from map and sets status to closed', async () => {
+      setMockQuery(createBlockingMockQuery());
       const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Build' });
 
       await manager.close(ws.id);
@@ -555,21 +694,24 @@ describe('SessionManager', () => {
       expect(manager.get(ws.id)).toBeUndefined();
     });
 
-    it('rejects pending questions when session is closed', async () => {
+    // Task 3.9: close() rejects any outstanding pending interactions for the session.
+    it('task 3.9: rejects outstanding pending interactions on close', async () => {
+      setMockQuery(createBlockingMockQuery());
       const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Plan' });
-
       const canUseTool = getCapturedCanUseTool();
-      const questionInput = {
+
+      const questionPromise = canUseTool('AskUserQuestion', {
         questions: [{ question: 'Test?', header: 'Test', options: [], multiSelect: false }],
-      };
+      });
+      const planPromise = canUseTool('ExitPlanMode', { plan: 'x' });
 
-      const resultPromise = canUseTool('AskUserQuestion', questionInput);
+      expect(manager.hasPending(ws.id, 'question')).toBe(true);
+      expect(manager.hasPending(ws.id, 'plan')).toBe(true);
 
-      // Close the session while question is pending
       await manager.close(ws.id);
 
-      // The promise should be rejected
-      await expect(resultPromise).rejects.toThrow('Session closed');
+      await expect(questionPromise).rejects.toThrow('Session closed');
+      await expect(planPromise).rejects.toThrow('Session closed');
     });
 
     it('does not throw for non-existent session', async () => {


### PR DESCRIPTION
## Summary

- **Single long-lived `query()` per session**: replaces the per-turn close-and-resume workaround; follow-up messages now flow through `q.streamInput()`. Removes `InputController`, `resultReceived`, the 1000-entry `OutputChannel` history ring buffer, and the worker's `GET /sessions/:id/messages` endpoint (server-side `MessageCacheStore` remains the authoritative replay source).
- **Handler-registry `canUseTool`**: the 220-line if-ladder becomes a small `Record<string, ToolHandler>` with one self-contained function per special-cased tool (`AskUserQuestion`, `ExitPlanMode`, `WorkflowComplete`, `workflow_signal`). The two pending-state maps collapse into a single `PendingKind`-keyed map with a unified `resolvePending(sessionId, kind, payload)` API.
- **Enables Agent Skills**: adds `"Skill"` to `allowedTools` in both Plan and Build modes — the SDK requires this entry for the `Skill` tool to be exposed to the model, independent of permission mode. Reuses `PLAN_MODE_TOOLS` in Build mode so Build has at least the same tool exposure as Plan. Live worker confirms `toolCount=45, hasSkillTool=true` in the SDK init message.
- **Extracts `attachDebugLogStreaming`**: the debug-log file-watcher setup runs once per session lifetime rather than per turn.

Full artifacts live under `openspec/changes/simplify-worker-session-manager/` (proposal, design, delta spec, tasks).

## Validation

- ✅ `npx tsc --noEmit` clean in the worker.
- ✅ 176/176 worker Vitest tests pass, including 10 new TDD tests for `send`-via-`streamInput`, `setMode`/`setModel` on a live query, the four `canUseTool` handlers, `close` rejecting outstanding pending interactions, and `Skill` in `allowedTools` for both modes.
- ✅ 2302/2302 non-Live `dotnet test` tests pass.
- ✅ Direct `curl POST /api/sessions` to a rebuilt worker container shows the SSE contract is preserved (`"final":false` on `working` status-update, `"final":true` on the terminal status-update).
- ✅ Live Docker integration run against the rebuilt image logs `SDK init: ... toolCount=45, hasSkillTool=true`.
- ⚠️  One `[Category(\"Live\")]` test (`DockerAgentExecutionServiceLiveTests.FollowUpPrompts_SameSession_BothComplete`) has a pre-existing assertion flake against `final:true` that reproduces on unchanged `main`; not caused by this change.

## BREAKING

Removes the worker's `GET /sessions/:id/messages` endpoint. No C# server-side or web-client callers existed (verified via grep + API-client inspection) so no downstream migration is needed.

## Test plan

- [ ] Review `openspec/changes/simplify-worker-session-manager/design.md` for the refactor rationale and decisions.
- [ ] Run `cd src/Homespun.Worker && npx vitest run` — 176/176 should pass (1 unrelated pre-existing `ajv` env failure in `session-inventory.test.ts`).
- [ ] Run `dotnet test --filter \"TestCategory!=Live\"` — 2302/2302 should pass.
- [ ] Run the idle-tolerance spike before merging: `cd src/Homespun.Worker && ANTHROPIC_API_KEY=... IDLE_SECONDS=600 npx tsx scripts/spike-idle-tolerance.ts`. Expected output: `FOLLOW-UP SUCCESS`. If it fails, see `design.md` for the keep-alive mitigation to add before merging.
- [ ] Manual smoke via a real session in the Homespun UI: new session → send → plan mode → approve plan → ask question → answer → switch model → switch mode → close. Confirm no regressions and that Skills are invocable (ask the agent to list or use an installed skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)