### PR TITLE
fix(worker): replace streamInput with persistent InputQueue for multi-turn sessions

### DIFF
--- a/.github/workflows/worker-live-tests.yml
+++ b/.github/workflows/worker-live-tests.yml
@@ -2,8 +2,7 @@ name: Worker Live Tests
 
 # Runs the worker's live integration suite against a freshly-built
 # `homespun-worker:local` image. Uses real Claude inference (paid), so the
-# suite is gated to post-merge on `main` and a nightly schedule — never on
-# every PR.
+# suite is gated to post-merge on `main` — never on every PR.
 #
 # Motivation: PR #776 (`simplify-worker-session-manager`) merged green because
 # the live tests and the `scripts/spike-idle-tolerance.ts` regression probe
@@ -17,10 +16,6 @@ on:
       - "src/Homespun.Worker/**"
       - "tests/Homespun.Worker/**"
       - ".github/workflows/worker-live-tests.yml"
-  schedule:
-    # 09:00 UTC daily. Catches SDK upgrades and environmental drift even when
-    # no worker PR has landed in a day.
-    - cron: "0 9 * * *"
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/worker-live-tests.yml
+++ b/.github/workflows/worker-live-tests.yml
@@ -1,0 +1,77 @@
+name: Worker Live Tests
+
+# Runs the worker's live integration suite against a freshly-built
+# `homespun-worker:local` image. Uses real Claude inference (paid), so the
+# suite is gated to post-merge on `main` and a nightly schedule — never on
+# every PR.
+#
+# Motivation: PR #776 (`simplify-worker-session-manager`) merged green because
+# the live tests and the `scripts/spike-idle-tolerance.ts` regression probe
+# were not in CI. See OpenSpec change `fix-worker-streaminput-multi-turn` for
+# the detailed write-up and the investigation that led to this workflow.
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - "src/Homespun.Worker/**"
+      - "tests/Homespun.Worker/**"
+      - ".github/workflows/worker-live-tests.yml"
+  schedule:
+    # 09:00 UTC daily. Catches SDK upgrades and environmental drift even when
+    # no worker PR has landed in a day.
+    - cron: "0 9 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+# Cap concurrency so two runs can't burn inference in parallel.
+concurrency:
+  group: worker-live-tests
+  cancel-in-progress: false
+
+jobs:
+  live:
+    name: Worker live integration suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install worker deps
+        working-directory: src/Homespun.Worker
+        run: npm ci
+
+      - name: Build worker image
+        run: docker build -t homespun-worker:local ./src/Homespun.Worker
+
+      # Quick-check spike before the full live suite so an SDK regression that
+      # re-breaks streamInput surfaces within ~30s rather than after a
+      # multi-minute live-suite run. Uses INPUT_MODE=queue + the shortest idle
+      # that still exercises a full two-turn flow.
+      - name: Spike — streamInput regression probe
+        working-directory: src/Homespun.Worker
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          INPUT_MODE: queue
+          IDLE_SECONDS: "3"
+        run: docker run --rm \
+          -e CLAUDE_CODE_OAUTH_TOKEN \
+          -e INPUT_MODE \
+          -e IDLE_SECONDS \
+          -v "$(pwd):/worker" \
+          -w /worker \
+          homespun-worker:local \
+          node --experimental-strip-types scripts/spike-idle-tolerance.ts
+
+      - name: Worker live suite
+        working-directory: src/Homespun.Worker
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: npm run test:live

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,10 @@ services:
     environment:
       - PORT=8080
       - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN:-}
+      # DEBUG_AGENT_SDK enables structured stdout capture of every message
+      # crossing the @anthropic-ai/claude-agent-sdk boundary. Off by default;
+      # export DEBUG_AGENT_SDK=true in your host env to turn it on.
+      - DEBUG_AGENT_SDK=${DEBUG_AGENT_SDK:-false}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/api/health"]
       interval: 10s

--- a/openspec/changes/fix-worker-streaminput-multi-turn/.openspec.yaml
+++ b/openspec/changes/fix-worker-streaminput-multi-turn/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/fix-worker-streaminput-multi-turn/design.md
+++ b/openspec/changes/fix-worker-streaminput-multi-turn/design.md
@@ -1,0 +1,145 @@
+## Context
+
+PR #776 (`simplify-worker-session-manager`) refactored the worker to back each session with a single long-lived `query()` call, delivering follow-up messages via `Query.streamInput(...)`. This design shipped with a spike (`scripts/spike-idle-tolerance.ts`) that claimed to confirm the approach survives long idle periods in streaming-input mode.
+
+Empirical re-running of that spike after the merge — in both its original default/haiku configuration and in the failing Build-mode configuration — **consistently fails** with `ProcessTransport is not ready for writing` on the second turn. Reading the SDK source (`@anthropic-ai/claude-agent-sdk@0.2.81`, `sdk.mjs`) revealed the cause:
+
+```
+// Query.streamInput (paraphrased from minified sdk.mjs)
+for await (const msg of stream) { transport.write(msg) }
+if (count > 0 && hasBidirectionalNeeds()) await waitForFirstResult()
+transport.endInput()   // closes stdin to CLI subprocess
+```
+
+The initial `AsyncIterable` prompt is internally consumed via the same `streamInput` routine, so even the initial `onceIterator(initialPrompt)` triggers `endInput()` once it returns. The CLI exits after turn 1; any subsequent `streamInput`, `setPermissionMode`, or `setModel` call on the `Query` throws `ProcessTransport is not ready for writing`.
+
+A persistent-queue variant of the spike — where the initial `AsyncIterable` never returns until session close, and follow-ups are pushed into that same iterable — reliably survives multi-turn with the Build-mode configuration and `setPermissionMode` at the boundary. That is the shape this change adopts.
+
+Separately: there is no debug channel that captures exactly what the worker sends to the SDK and what comes back. Diagnosing the above required reading the SDK's minified source. A runtime-toggleable capture point is needed so future agent-SDK regressions can be reproduced without source diving.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The `follow-up-prompts.live.test.ts` live test passes deterministically after this change.
+- Multi-turn conversations in production (both `Build` and `Plan` modes) send and receive messages on a single long-lived CLI without restart.
+- `setMode` and `setModel` mid-session apply to the live query without failing with `ProcessTransport is not ready for writing`.
+- When `DEBUG_AGENT_SDK=true` is set, all four SDK-boundary points emit structured JSON logs on stdout in a format readable by both `docker logs` and the Promtail→Loki pipeline.
+- `DEBUG_AGENT_SDK=false` (or unset) is the default in both compose and live-test invocations — zero overhead when not debugging.
+- The updated `spike-idle-tolerance.ts` serves as a standalone regression probe for future SDK changes that might re-break this path.
+
+**Non-Goals:**
+
+- Rewriting the HTTP API surface or the A2A event translation.
+- Adding persistence to the input queue (it is in-memory per-session; lost on worker restart, as the existing session state already is).
+- Sending debug data to a destination other than stdout (no separate file writer, no external log collector; PLG already covers stdout).
+- Pinning the SDK version — out of scope; noted as a follow-up in `proposal.md`.
+- Reverting #776 wholesale — we keep its single-long-lived-query property; only the stdin-feed mechanism changes.
+
+## Decisions
+
+### 1. Persistent `InputQueue` instead of `onceIterator` + `q.streamInput()`
+
+The worker defines an `InputQueue` class that implements `AsyncIterable<SDKUserMessage>`. Its iterator awaits indefinitely between pushes and only returns when `close()` is called. The `query({ prompt, options })` call receives this queue as `prompt`, and `inputQueue.push(initialPrompt)` is the first message. Follow-up messages are delivered via `inputQueue.push(followupMessage)` — **never** via `q.streamInput(...)`.
+
+**Alternatives considered:**
+
+- *Close-and-resume per turn* (the pre-#776 design): correct, but carries the per-turn CLI-restart cost #776 set out to remove, and loses `canUseTool` / pending-interaction state mid-stream. Rejected.
+- *Call `q.streamInput()` but add a keep-alive message after each turn*: hacky; depends on SDK-internal timing and would still lose the CLI on the trailing `endInput()`. Rejected.
+- *Fork or patch the SDK to remove `endInput()`*: invasive and fragile against SDK upgrades. Rejected.
+
+**Rationale:** Mirrors the pattern validated by the updated spike in the failing configuration. Keeps the existing `OutputChannel` and `runQueryForwarder` design intact.
+
+### 2. `runQueryForwarder` stays lifetime-scoped; per-HTTP-request SSE streams decouple via `OutputChannel`
+
+`runQueryForwarder` continues to run one `for await (const msg of q)` for the session's lifetime, pushing every event into `session.outputChannel`. Per-HTTP-request `streamSessionEvents` consumes `outputChannel` per turn and returns on `result`. The consumer-side iterator termination must not propagate iterator-done into the SDK's `Query.sdkMessages` (the inner `g4` is single-shot: once `.return()` is called, it stays done forever).
+
+`OutputChannel` already isolates the two. This change hardens it (see decision 3).
+
+**Alternatives considered:**
+
+- *Emit the SSE stream directly from the SDK query without an output channel*: would couple per-HTTP-request lifetime to per-session lifetime and re-introduce the iterator-done bug we just diagnosed. Rejected.
+- *Keep the SSE stream open across turns and use chunked-transfer to signal turn boundaries*: breaks the existing server→worker contract and breaks the test fixture. Rejected as out of scope.
+
+### 3. Harden `OutputChannel` against stale resolvers
+
+`OutputChannel.[Symbol.asyncIterator]` keeps a `resolver` field pointing to the pending `Promise` resolver whenever a consumer is waiting. If the consumer's `for await` is aborted (e.g. `streamSessionEvents` returning on `result`), the `resolver` remains assigned to a discarded `Promise`. A concurrent `push(...)` then invokes that stale resolver — a no-op — and the event is silently lost.
+
+Fix: wrap the generator body in a `try { ... } finally { this.resolver = null; }` so the field is cleared on any exit, including abort. Events pushed while no consumer is active land in `this.queue` and are delivered to the next consumer.
+
+**Alternatives considered:**
+
+- *Make `OutputChannel` multicast*: overkill; each event has exactly one logical consumer. Rejected.
+- *Require the forwarder to wait for a consumer before pushing*: couples the SDK's drain rate to HTTP-request timing and risks back-pressuring the SDK. Rejected.
+
+### 4. `DEBUG_AGENT_SDK` env var gates a single stdout channel
+
+`logger.ts` grows one helper: `sdkDebug(direction: 'tx' | 'rx', msg: unknown)`. It is a no-op unless `process.env.DEBUG_AGENT_SDK === 'true'`. When enabled, it emits a single structured-JSON line via the existing `console.log`-backed logger so the line is indistinguishable in format from other worker logs (same `SourceContext`/`Component` shape, consumed by the same Promtail config).
+
+The worker calls `sdkDebug('tx', sessionOptions)` immediately before `query({...})`; `sdkDebug('tx', userMessage)` inside `InputQueue.push(...)`; `sdkDebug('tx', { op: 'setPermissionMode', mode })` (and equivalent for `setModel`); and `sdkDebug('rx', msg)` at the top of `runQueryForwarder`'s `for await` body.
+
+Env propagation: `docker-compose.yml` passes `DEBUG_AGENT_SDK=${DEBUG_AGENT_SDK:-false}` into the `worker:` service; `container-lifecycle.ts` reads `process.env.DEBUG_AGENT_SDK` and forwards it via `-e`. Both paths default to disabled; the host developer flips it on by exporting the variable.
+
+**Alternatives considered:**
+
+- *Log to a separate file under `/home/homespun/.claude/debug/`*: duplicates the existing `claude_sdk_debug.log` file watcher; requires the live-test fixture to read a mounted volume to capture. Rejected.
+- *Reuse the existing `DEBUG_LOGGING=true` flag*: mixes two audiences (general debug output vs SDK-boundary capture). The SDK-boundary logs can be large, so keeping them gated separately lets developers dial them up without drowning in everything else. Rejected.
+- *Emit at a named log level (`TRACE`)*: the current logger only has `Debug/Information/Warning/Error`. Adding a level is more invasive than a feature flag. Rejected.
+
+### 5. Spike script remains as a regression probe
+
+`spike-idle-tolerance.ts` is retained (not deleted) with:
+
+- `INPUT_MODE=stream|queue` toggle demonstrating the broken and working patterns side-by-side.
+- `PERMISSION_MODE`, `DANGEROUS_SKIP`, `MODEL`, `SET_MODE_ON_TURN2` envs so future investigations can probe the full configuration matrix the production worker uses.
+- Updated header docstring documenting the SDK behavior found in this investigation.
+
+**Rationale:** If a future SDK upgrade changes the `streamInput`/`endInput` behavior, this script is the shortest-path reproduction. Keeping it versioned in-repo is cheaper than re-deriving the finding.
+
+## Risks / Trade-offs
+
+- **[Risk]** `InputQueue`'s indefinite `await` keeps the SDK's internal `for await` suspended on an unresolved Promise for the whole session lifetime. If the SDK adds an internal timeout or heartbeat check on stdin writes, this could surface as a false-idle error.
+  → **Mitigation:** The `spike-idle-tolerance.ts` covers 600s idle with the queue pattern; extend the idle period in a future spike run if the session idle distribution in production grows. No immediate mitigation required.
+
+- **[Risk]** Hardening `OutputChannel` with a generator `finally` changes the semantics when multiple consumers attempt to iterate concurrently (nothing does this today, but future refactors might). Concurrent iteration would now reliably yield interleaved events to whichever consumer's resolver was active at push time.
+  → **Mitigation:** Add a unit test that explicitly forbids concurrent iteration, or document the single-consumer-at-a-time invariant in the class JSDoc. Low risk.
+
+- **[Risk]** `DEBUG_AGENT_SDK=true` in production could blow up log volume if accidentally left enabled, both in storage (Loki) and in SSE latency (stdout is synchronous). Mis-enabling in live tests also bloats `container.logs()` output.
+  → **Mitigation:** Default to disabled everywhere; add a warning log line on session start when the flag is enabled ("[warn] DEBUG_AGENT_SDK is enabled — high log volume expected"); do NOT enable in CI by default.
+
+- **[Trade-off]** Retaining the single long-lived-query shape means a CLI crash mid-session still kills the session (no per-turn restart safety net). This is unchanged from #776 and is acceptable given the CLI's stability profile.
+
+- **[Trade-off]** The `OutputChannel` hardening adds complexity to a class that reads cleanly today. The alternative (make the consumer never abort mid-stream) is invasive across the SSE writer and the HTTP route layer.
+
+## Migration Plan
+
+1. **Land the fix** on a branch (no behavior flag — the old path is unrecoverable).
+2. **Verify locally** by running `npm run test:live` against the new image; confirm `follow-up-prompts.live.test.ts` passes and that `prompts.live.test.ts` / other live tests still pass.
+3. **Run the spike** in the Build-mode config with `INPUT_MODE=queue` to confirm no regression: `docker run ... -e INPUT_MODE=queue -e PERMISSION_MODE=bypassPermissions -e DANGEROUS_SKIP=true spike-idle-tolerance.ts`. Capture the output in the PR description.
+4. **Deploy** through the normal release path. No data migration; no feature flag. All in-flight sessions terminate on worker restart (already true today).
+5. **Post-deploy check** — observe Loki for no new `ProcessTransport is not ready for writing` errors on the worker `rx`/`error` log streams.
+
+**Rollback**: Revert the PR. The pre-fix state is the known-broken #776 state; rollback re-introduces the bug and is only worthwhile if this fix has its own regressions that are worse.
+
+## Confirmed root cause of the #776 regression slipping past CI
+
+Investigation after this change was drafted confirms the regression merged green because **neither the spike nor the live tests were ever run in CI**:
+
+- `src/Homespun.Worker/vitest.config.ts` explicitly excludes `**/live/**` from the default test runner.
+- `src/Homespun.Worker/vitest.config.live.ts` documents this with a header comment stating the live tests are "NOT intended to run in CI".
+- The worker CI job (`.github/workflows/ci.yml` → `worker-build` → `npm run test:coverage`) uses the default config, so all `*.live.test.ts` files are skipped.
+- No workflow invokes `npm run test:live`, and no workflow invokes `scripts/spike-idle-tolerance.ts` — the spike is not referenced in `package.json`'s `scripts` either.
+- The only tests that ran against the refactor were unit tests using `tests/Homespun.Worker/helpers/mock-sdk.ts`, which evidently does not reproduce the SDK's `endInput()`-on-iterable-exhaustion contract, so the broken path was never exercised.
+
+**Implication for this change:** pinning the SDK minor version is not necessary — the SDK behavior was the same before and after; the gap was in test coverage. Two corrective actions follow from this:
+
+1. The worker's mock SDK SHOULD enforce the same contract the real SDK enforces (i.e. throw on `streamInput` / control calls after the initial iterable has been exhausted), so unit tests catch any future reintroduction of the `onceIterator` pattern.
+2. The live-test suite SHOULD run at least post-merge on `main`, or nightly, so follow-up regressions are caught within a day rather than waiting for manual execution.
+
+Both are included as tasks in `tasks.md`.
+
+## Open Questions
+
+- **Do we need concurrent-consumer safety on `OutputChannel`?** Current code has exactly one consumer at any time. If a future refactor (e.g. attaching a side-channel metrics consumer) violates this, the hardening's semantics need revisiting. Deferred.
+- **Should we emit `DEBUG_AGENT_SDK` entries for A2A control events (question_pending, plan_pending, workflow_complete)?** They are worker-internal synthesis, not SDK-boundary messages. Current plan: no. Revisit if diagnosing a pending-interaction bug proves hard without them.
+- **Should live tests be required for PR merge, or post-merge only?** Required-for-PR is a strong signal but costs inference $$ and wall-clock on every push. Post-merge / nightly catches regressions within hours and is cheaper. Leaning post-merge; confirm with the team.

--- a/openspec/changes/fix-worker-streaminput-multi-turn/evidence/spike-1.2-stream-haiku.txt
+++ b/openspec/changes/fix-worker-streaminput-multi-turn/evidence/spike-1.2-stream-haiku.txt
@@ -1,0 +1,19 @@
+spike-idle-tolerance: IDLE_SECONDS=3, model=claude-haiku-4-5-20251001, permissionMode=default, dangerousSkip=false, setModeOnTurn2=false
+[turn1] msg type=system subtype=init
+[turn1] msg type=assistant
+[turn1] msg type=assistant
+[turn1] msg type=rate_limit_event
+[turn1] msg type=result subtype=success
+FIRST RESULT received
+idling for 3s...
+idle complete after 3s
+calling q.streamInput(once(followup))...
+FOLLOW-UP FAILURE: Error: drain ended before second result (seen=1, followupScheduled=true)
+Error: drain ended before second result (seen=1, followupScheduled=true)
+    at main (/app/scripts/spike-idle-tolerance.ts:244:13)
+streamInput rejected: ProcessTransport is not ready for writing
+npm notice
+npm notice New minor version of npm available! 11.9.0 -> 11.12.1
+npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.12.1
+npm notice To update run: npm install -g npm@11.12.1
+npm notice

--- a/openspec/changes/fix-worker-streaminput-multi-turn/evidence/spike-1.2-stream-sonnet-build.txt
+++ b/openspec/changes/fix-worker-streaminput-multi-turn/evidence/spike-1.2-stream-sonnet-build.txt
@@ -1,0 +1,23 @@
+spike-idle-tolerance: IDLE_SECONDS=3, model=claude-sonnet-4-5-20250929, permissionMode=bypassPermissions, dangerousSkip=true, setModeOnTurn2=true
+[turn1] msg type=system subtype=init
+[turn1] msg type=assistant
+[turn1] msg type=assistant
+[turn1] msg type=rate_limit_event
+[turn1] msg type=result subtype=success
+FIRST RESULT received
+idling for 3s...
+idle complete after 3s
+calling setPermissionMode('bypassPermissions')...
+FOLLOW-UP FAILURE: Error: ProcessTransport is not ready for writing
+Error: ProcessTransport is not ready for writing
+    at y4.write (file:///app/node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs:19:7066)
+    at file:///app/node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs:21:4049
+    at new Promise (<anonymous>)
+    at h4.request (file:///app/node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs:21:3742)
+    at h4.setPermissionMode (file:///app/node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs:21:2523)
+    at main (/app/scripts/spike-idle-tolerance.ts:219:21)
+npm notice
+npm notice New minor version of npm available! 11.9.0 -> 11.12.1
+npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.12.1
+npm notice To update run: npm install -g npm@11.12.1
+npm notice

--- a/openspec/changes/fix-worker-streaminput-multi-turn/evidence/spike-1.3-queue-sonnet-build.txt
+++ b/openspec/changes/fix-worker-streaminput-multi-turn/evidence/spike-1.3-queue-sonnet-build.txt
@@ -1,0 +1,22 @@
+spike-idle-tolerance: IDLE_SECONDS=3, model=claude-sonnet-4-5-20250929, permissionMode=bypassPermissions, dangerousSkip=true, setModeOnTurn2=true
+[turn1] msg type=system subtype=init
+[turn1] msg type=assistant
+[turn1] msg type=assistant
+[turn1] msg type=rate_limit_event
+[turn1] msg type=result subtype=success
+FIRST RESULT received
+idling for 3s...
+idle complete after 3s
+calling setPermissionMode('bypassPermissions')...
+setPermissionMode accepted
+pushing follow-up through persistent input queue...
+[turn2] msg type=system subtype=init
+[turn2] msg type=assistant
+[turn2] msg type=assistant
+[turn2] msg type=result subtype=success
+FOLLOW-UP SUCCESS
+npm notice
+npm notice New minor version of npm available! 11.9.0 -> 11.12.1
+npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.12.1
+npm notice To update run: npm install -g npm@11.12.1
+npm notice

--- a/openspec/changes/fix-worker-streaminput-multi-turn/proposal.md
+++ b/openspec/changes/fix-worker-streaminput-multi-turn/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+The `follow-up-prompts.live.test.ts` worker live test fails after PR #776. Empirical testing (reproduced with `scripts/spike-idle-tolerance.ts`) confirms the SDK's `streamInput()` method always calls `transport.endInput()` after consuming its input iterable — which closes stdin to the CLI process and causes the CLI to exit after the first turn. The single long-lived `query()` pattern #776 introduced is therefore fundamentally incompatible with multi-turn conversations: the `onceIterator(initialPrompt)` yields and returns, the SDK closes stdin, and the next `q.streamInput(...)` or `q.setPermissionMode(...)` call fails with `ProcessTransport is not ready for writing`. Multi-turn agent sessions are broken in production, not just in tests.
+
+A debug-logging facility is also missing: there is no way to inspect the exact SDK inputs and outputs when an agent session misbehaves, whether the worker runs under docker compose (PLG stack) or standalone (live tests).
+
+## What Changes
+
+- Replace the `onceIterator(initialPrompt)` + `q.streamInput(onceIterator(followup))` pattern in `session-manager.ts` with a persistent `InputQueue` that:
+  - Serves as the initial `prompt` AsyncIterable passed to `query({...})`
+  - Never returns on its own — stays `await`-suspended between messages
+  - Receives follow-up messages via `queue.push(...)`, never `q.streamInput(...)`
+  - Is closed only when the session itself is closed
+- Convert `runQueryForwarder` into a single lifetime-scoped drain over the SDK's `Query` — it already is, but the early-return from `streamSessionEvents` on `result` must not propagate into the SDK iterator and mark it done.
+- Harden `OutputChannel` so pushes between per-turn iterator re-entries are never lost:
+  - Clear `this.resolver` in a `finally` block of the `[Symbol.asyncIterator]` generator
+  - Guarantee event delivery across multiple sequential `for await` consumers on the same channel
+- Add a `DEBUG_AGENT_SDK` environment-gated logging channel with four capture points in `session-manager.ts`:
+  1. `tx` — full `sessionOptions` just before `query({...})`
+  2. `tx` — user message payload on every `InputQueue.push(...)`
+  3. `tx` — control-request args for `setPermissionMode` / `setModel`
+  4. `rx` — every raw SDK message inside `runQueryForwarder`'s `for await`
+- Wire `DEBUG_AGENT_SDK` through:
+  - `docker-compose.yml` worker service environment (read from host env, default `false`)
+  - Live-test container fixture in `tests/Homespun.Worker/live/fixtures/container-lifecycle.ts` (forward host `DEBUG_AGENT_SDK` through `-e`)
+- Update the `scripts/spike-idle-tolerance.ts` header docstring to reflect the new understanding: `streamInput()` is effectively single-use per `Query`, and the persistent-queue pattern is the correct shape. Preserve the `INPUT_MODE=queue` / `INPUT_MODE=stream` toggle so the spike remains a regression probe.
+
+## Capabilities
+
+### New Capabilities
+
+_None — this change modifies existing behavior rather than introducing a new capability._
+
+### Modified Capabilities
+
+- `claude-agent-sessions`: The send-follow-up-message behavior changes from "call `q.streamInput()` on the live query" to "push into the session's persistent input queue"; adds a new `DEBUG_AGENT_SDK` observability requirement that captures every SDK-boundary message when enabled.
+
+## Impact
+
+- **Code changed**
+  - `src/Homespun.Worker/src/services/session-manager.ts` — new `InputQueue` class; `create()` uses it as the prompt; `send()` pushes into it instead of `streamInput`; `close()` closes it; optional SDK-debug calls at the four capture points
+  - `src/Homespun.Worker/src/services/sse-writer.ts` — no behavior change expected, but verify that the early-return on `result` does not propagate iterator-done into the SDK query
+  - `src/Homespun.Worker/src/utils/logger.ts` — new `sdkDebug(direction, msg)` helper gated by `DEBUG_AGENT_SDK`
+  - `docker-compose.yml` — pass `DEBUG_AGENT_SDK` into the `worker:` service env
+  - `tests/Homespun.Worker/live/fixtures/container-lifecycle.ts` — forward host `DEBUG_AGENT_SDK` into the container
+  - `src/Homespun.Worker/scripts/spike-idle-tolerance.ts` — updated docstring (code already updated during exploration)
+- **Tests changed**
+  - `tests/Homespun.Worker/services/session-manager.test.ts` — tests in `simplify-worker-session-manager` that asserted `q.streamInput()` as the send mechanism need to assert `InputQueue.push()` instead; the mock SDK no longer needs `streamInput` behavior
+  - `tests/Homespun.Worker/helpers/mock-sdk.ts` — drop `streamInput` mock, ensure the mock query's AsyncIterable consumes from a queue
+  - New unit tests for `InputQueue` (never-returning iterator, push/pull ordering, close semantics)
+  - New unit tests for `OutputChannel` proving no events are lost across sequential iterator re-entries
+  - `tests/Homespun.Worker/live/tests/follow-up-prompts.live.test.ts` becomes the integration check — expected to pass after the fix
+- **SDK contract**
+  - Relies on `@anthropic-ai/claude-agent-sdk@^0.2.81` behavior observed in `sdk.mjs`: `streamInput` always calls `endInput()` at the tail, and the initial `AsyncIterable` prompt is internally consumed via the same `streamInput` routine. The spike script becomes the regression detector if this changes.
+- **Breaking changes**
+  - None externally visible — the HTTP API shape is unchanged. Internal test assertions that probed `q.streamInput` need to move to `InputQueue.push`.
+- **Rollback posture**
+  - Cleanly revertible by restoring the `onceIterator` + `q.streamInput` pattern, but that re-introduces the known-broken behavior.
+- **Confirmed: why #776 merged green**
+  - CI's worker job (`worker-build` in `.github/workflows/ci.yml`) runs `npm run test:coverage` which uses `vitest.config.ts` — this config explicitly excludes `**/live/**`. No workflow invokes `npm run test:live` or `scripts/spike-idle-tolerance.ts`. The live test that would have caught the regression, and the spike that supposedly validated the refactor, were never run in CI or (apparently) locally. The unit-test suite passed because `tests/Homespun.Worker/helpers/mock-sdk.ts` does not reproduce the SDK's `endInput()`-on-iterable-exhaustion contract. This is a test-coverage gap, not an SDK-version issue; pinning the SDK is not required.
+- **Follow-ups included in this change (see tasks.md)**
+  - Make the mock SDK enforce the real SDK's `endInput()` contract so unit tests catch any reintroduction of the `onceIterator` pattern.
+  - Wire the live-test suite into a post-merge or nightly CI job so follow-up regressions on `main` surface within hours rather than on the next manual run.
+  - Add a correction note to `openspec/changes/simplify-worker-session-manager/design.md` (or the archived spec if already archived) pointing at this change.

--- a/openspec/changes/fix-worker-streaminput-multi-turn/specs/claude-agent-sessions/spec.md
+++ b/openspec/changes/fix-worker-streaminput-multi-turn/specs/claude-agent-sessions/spec.md
@@ -1,0 +1,101 @@
+## MODIFIED Requirements
+
+### Requirement: Worker session uses a single long-lived SDK query per session
+
+A worker session SHALL back its entire lifetime with a single `query()` invocation. The SDK `Query` is constructed with a persistent input iterable that stays `await`-suspended between turns; follow-up user messages SHALL be delivered by pushing into that same iterable rather than by invoking `Query.streamInput(...)` with a fresh finite iterable.
+
+Rationale: `@anthropic-ai/claude-agent-sdk`'s `streamInput` implementation calls `transport.endInput()` after the supplied iterable is exhausted, which closes stdin to the CLI subprocess and terminates it. Any design that feeds the SDK a finite initial iterable OR that calls `streamInput()` per turn cannot survive past the first turn.
+
+#### Scenario: Initial prompt is delivered via a persistent input iterable
+
+- **WHEN** a session is created
+- **THEN** the worker SHALL pass an `AsyncIterable` to `query({ prompt, options })` whose iterator does not return until the session is closed
+- **AND** the initial user prompt SHALL be the first value pushed into that iterable
+- **AND** the worker SHALL NOT pass a finite `once(...)` generator as the `prompt`
+
+#### Scenario: Follow-up message reuses the existing query via the persistent input iterable
+
+- **WHEN** a user sends a follow-up message to a session that has already produced a `result`
+- **THEN** the worker SHALL push the message into the session's persistent input iterable
+- **AND** the worker SHALL NOT invoke `Query.streamInput(...)` for that message
+- **AND** the SDK CLI process SHALL NOT be restarted for that turn
+- **AND** the conversation SHALL continue under the same `conversationId`
+
+#### Scenario: Mid-session mode switch applies to the live query
+
+- **WHEN** `setMode` is invoked on a session that has produced a prior `result`
+- **THEN** the new permission mode SHALL be applied to the live query without restarting it
+
+#### Scenario: Mid-session model switch applies to the live query
+
+- **WHEN** `setModel` is invoked on a session that has produced a prior `result`
+- **THEN** the new model SHALL take effect on the next turn without restarting the query
+
+#### Scenario: Session close terminates the input iterable
+
+- **WHEN** a session is closed
+- **THEN** the worker SHALL close the session's input iterable so that its async iterator returns `{ done: true }`
+- **AND** the worker SHALL close the SDK `Query`
+
+## ADDED Requirements
+
+### Requirement: Output channel preserves events across sequential per-turn consumers
+
+The worker's `OutputChannel` SHALL deliver every event pushed into it to exactly one consumer. When a consumer's `for await` loop exits (e.g. because a per-HTTP-request SSE stream returned on `result`) and a subsequent consumer begins iterating the same channel, any events pushed in between SHALL be delivered to the new consumer; no events SHALL be dropped into a stale pending-promise resolver.
+
+Rationale: The worker's single long-lived `Query` forwarder pushes events into `OutputChannel` for the session's lifetime, while per-HTTP-request SSE streams consume it per turn. If a pending resolver from an aborted iteration is reused by a later producer, the event is silently lost.
+
+#### Scenario: Event pushed between iterator re-entries is delivered to next consumer
+
+- **GIVEN** an `OutputChannel` whose prior consumer's `for await` has returned
+- **WHEN** the producer pushes an event before the next consumer begins iterating
+- **THEN** the new consumer SHALL receive that event on its first `next()`
+
+#### Scenario: Pending resolver is cleared on consumer abort
+
+- **WHEN** a consumer's `for await` on the channel is aborted while awaiting the next event
+- **THEN** the channel's pending resolver SHALL be cleared
+- **AND** subsequent pushes SHALL land in the internal queue rather than invoke a stale resolver
+
+### Requirement: Debug logging of every SDK boundary message when DEBUG_AGENT_SDK is enabled
+
+When the `DEBUG_AGENT_SDK` environment variable is set to `"true"`, the worker SHALL emit structured log entries at the SDK boundary covering every outbound control or message and every inbound SDK message. When the variable is unset or any other value, the worker SHALL emit no such entries.
+
+The log channel SHALL be `stdout` via the existing `utils/logger.ts` structured-JSON format so that both `docker logs` (for standalone / live-test invocations) and the Promtail→Loki PLG pipeline (for docker compose invocations) receive the entries unchanged.
+
+#### Scenario: Session creation options are logged on session start
+
+- **GIVEN** `DEBUG_AGENT_SDK=true`
+- **WHEN** a session is created
+- **THEN** the worker SHALL emit a log entry with direction `tx` describing the full session options passed to `query({...})`, excluding raw credentials
+
+#### Scenario: Every user message into the input queue is logged
+
+- **GIVEN** `DEBUG_AGENT_SDK=true`
+- **WHEN** a user message is pushed into the session's input iterable (initial or follow-up)
+- **THEN** the worker SHALL emit a log entry with direction `tx` containing the user message payload
+
+#### Scenario: Control requests to the SDK are logged
+
+- **GIVEN** `DEBUG_AGENT_SDK=true`
+- **WHEN** the worker invokes `Query.setPermissionMode(...)` or `Query.setModel(...)`
+- **THEN** the worker SHALL emit a log entry with direction `tx` containing the control-request arguments
+
+#### Scenario: Every raw SDK message received is logged
+
+- **GIVEN** `DEBUG_AGENT_SDK=true`
+- **WHEN** the worker's query forwarder yields a message from the SDK `Query`
+- **THEN** the worker SHALL emit a log entry with direction `rx` containing the raw SDK message
+
+#### Scenario: Debug logging is disabled by default
+
+- **GIVEN** `DEBUG_AGENT_SDK` is unset or set to any value other than `"true"`
+- **WHEN** the worker runs any session activity
+- **THEN** the worker SHALL NOT emit any SDK-boundary debug log entries
+
+#### Scenario: Debug env var propagates into the worker container from both invocation paths
+
+- **WHEN** the worker is started via `docker-compose.yml` and the host environment has `DEBUG_AGENT_SDK=true`
+- **THEN** the `worker:` service SHALL receive `DEBUG_AGENT_SDK=true`
+- **WHEN** the worker is started by the live-test container fixture and the host environment has `DEBUG_AGENT_SDK=true`
+- **THEN** the spawned container SHALL receive `DEBUG_AGENT_SDK=true` via `-e`

--- a/openspec/changes/fix-worker-streaminput-multi-turn/tasks.md
+++ b/openspec/changes/fix-worker-streaminput-multi-turn/tasks.md
@@ -1,0 +1,88 @@
+## 1. Confirm regression probe and baseline
+
+- [x] 1.1 Review `src/Homespun.Worker/scripts/spike-idle-tolerance.ts` (already updated during exploration) and update the header docstring to document the SDK's `streamInput` + `endInput()` behavior and the `INPUT_MODE=queue` fix
+- [x] 1.2 Run the spike with `INPUT_MODE=stream` in both default/haiku and Build/sonnet configs; record the `ProcessTransport is not ready for writing` failure in the PR description as pre-fix evidence — evidence saved in `evidence/spike-1.2-stream-haiku.txt` and `evidence/spike-1.2-stream-sonnet-build.txt`; both failed with `streamInput rejected: ProcessTransport is not ready for writing`.
+- [x] 1.3 Run the spike with `INPUT_MODE=queue` + Build/sonnet + `SET_MODE_ON_TURN2=true` and confirm `FOLLOW-UP SUCCESS`; record in the PR description — evidence saved in `evidence/spike-1.3-queue-sonnet-build.txt`; `FOLLOW-UP SUCCESS` observed after mid-turn `setPermissionMode` + queued follow-up.
+
+## 2. Add `InputQueue` primitive
+
+- [x] 2.1 Extract the validated `InputQueue` class from `scripts/spike-idle-tolerance.ts` into `src/Homespun.Worker/src/services/input-queue.ts` with `push(msg)`, `close()`, and `[Symbol.asyncIterator]()` methods
+- [x] 2.2 Add JSDoc on `InputQueue` noting single-consumer invariant and "iterator does not return until close()"
+- [x] 2.3 Unit tests in `tests/Homespun.Worker/services/input-queue.test.ts`:
+  - [x] 2.3.1 Push-then-iterate yields the message
+  - [x] 2.3.2 Iterate-then-push delivers via the pending resolver
+  - [x] 2.3.3 Multiple sequential pushes are delivered in FIFO order
+  - [x] 2.3.4 `close()` causes the in-flight `await next()` to resolve `{ done: true }`
+  - [x] 2.3.5 `push()` after `close()` is a no-op (does not throw)
+
+## 3. Harden `OutputChannel`
+
+- [x] 3.1 Wrap the generator body in `try { ... } finally { this.resolver = null; }` in `src/Homespun.Worker/src/services/session-manager.ts` (`OutputChannel.[Symbol.asyncIterator]`)
+- [x] 3.2 Add a class-level JSDoc note that single-consumer-at-a-time is required
+- [x] 3.3 Unit tests in `tests/Homespun.Worker/services/output-channel.test.ts` (new file if needed):
+  - [x] 3.3.1 Event pushed between iterator re-entries is delivered to the next consumer
+  - [x] 3.3.2 Pending resolver is cleared when a consumer aborts its `for await`
+  - [x] 3.3.3 `complete()` still terminates an in-flight `await next()`
+
+## 4. Rewire `SessionManager` to use `InputQueue`
+
+- [x] 4.1 Add `inputQueue: InputQueue` to the `WorkerSession` interface in `session-manager.ts`
+- [x] 4.2 In `create()`, construct `InputQueue`, push the initial prompt, and pass the queue as `prompt` to `query({...})` — remove the `onceIterator` usage for the initial prompt
+- [x] 4.3 In `send()`, replace `await ws.query.streamInput(onceIterator(userMessage))` with `ws.inputQueue.push(userMessage)`
+- [x] 4.4 In `close()`, call `ws.inputQueue.close()` before `ws.query.close()`
+- [x] 4.5 Remove the `onceIterator` helper if no longer used elsewhere
+- [x] 4.6 Confirm `runQueryForwarder` still runs once per session lifetime — no changes expected, but verify its `for await (const msg of q)` is never exited early by upstream iterator aborts
+
+## 5. Wire `DEBUG_AGENT_SDK` debug logging
+
+- [x] 5.1 Add `sdkDebug(direction: 'tx' | 'rx', msg: unknown): void` helper to `src/Homespun.Worker/src/utils/logger.ts`, gated by `process.env.DEBUG_AGENT_SDK === 'true'`, emitting a single structured-JSON line via the existing format
+- [x] 5.2 On session create, emit a `warn`-level log "DEBUG_AGENT_SDK is enabled — high log volume expected" once per session when the flag is enabled
+- [x] 5.3 Call `sdkDebug('tx', sessionOptions)` immediately before `query({...})` in `create()` — redact env credentials (`GITHUB_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`) before logging
+- [x] 5.4 Call `sdkDebug('tx', userMessage)` inside `InputQueue.push(...)` (add the hook in `session-manager.ts` before the push — the queue itself stays I/O-agnostic)
+- [x] 5.5 Call `sdkDebug('tx', { op: 'setPermissionMode', mode })` before `ws.query.setPermissionMode(...)` in both `setMode()` and `send()`
+- [x] 5.6 Call `sdkDebug('tx', { op: 'setModel', model })` before `ws.query.setModel(...)` in both `setModel()` and `send()`
+- [x] 5.7 Call `sdkDebug('rx', msg)` at the top of the `for await (const msg of q)` body in `runQueryForwarder`
+- [x] 5.8 Unit test: with `DEBUG_AGENT_SDK=true` stubbed, all four hooks fire once per invocation; with it unset, no hooks fire
+
+## 6. Propagate `DEBUG_AGENT_SDK` through both invocation paths
+
+- [x] 6.1 Add `DEBUG_AGENT_SDK=${DEBUG_AGENT_SDK:-false}` to the `worker:` service environment in `docker-compose.yml`
+- [x] 6.2 In `tests/Homespun.Worker/live/fixtures/container-lifecycle.ts`, forward `process.env.DEBUG_AGENT_SDK` to the container via `-e` when set
+- [x] 6.3 Document the flag briefly in the worker's `src/Homespun.Worker/Dockerfile`-adjacent location where env vars are listed (if such documentation exists — skip if not) — SKIPPED: Dockerfile has no env-var documentation section; `docker-compose.yml` inline comment serves that role.
+
+## 7. Fix test-double fallout from #776
+
+- [x] 7.1 Update `tests/Homespun.Worker/helpers/mock-sdk.ts` so the mock `Query` no longer requires `streamInput` for follow-ups; the mock should expose an input-queue injection hook instead
+- [x] 7.2 **Enforce the real SDK's contract in the mock**: after the initial input iterable has been exhausted (i.e. returns `{ done: true }`), subsequent `streamInput`, `setPermissionMode`, `setModel`, and any other transport-write must throw `ProcessTransport is not ready for writing` to mirror the real `sdk.mjs` behavior. Added unit test `mock SDK contract: streamInput throws after initial input iterable exhausted`.
+- [x] 7.3 Update `tests/Homespun.Worker/helpers/mock-session-manager.ts` to match — unchanged (no `streamInput` references present; mock-session-manager is interface-level).
+- [x] 7.4 Update `tests/Homespun.Worker/services/session-manager.test.ts` tests that asserted `q.streamInput` was called on follow-up to assert `inputQueue.push` (or equivalent observable side-effect) instead
+- [x] 7.5 Re-run the full worker unit test suite (`npm test` from `src/Homespun.Worker`) and confirm all tests pass — 217/217 passing.
+
+## 8. Integration verification
+
+- [x] 8.1 Rebuild the worker image: `docker build -t homespun-worker:local ./src/Homespun.Worker` — image built cleanly.
+- [x] 8.2 Run `npm run test:live` from `src/Homespun.Worker`; confirm `follow-up-prompts.live.test.ts` passes — 6/6 live tests passed.
+- [x] 8.3 Confirm no regressions in the other live tests (`prompts.live.test.ts`, `file-operations.live.test.ts`, `questions-planning.live.test.ts`) — 4 test files / 6 tests all green.
+- [x] 8.4 Run the spike one more time with `INPUT_MODE=queue` + full Build config and attach the output to the PR — captured in `evidence/spike-1.3-queue-sonnet-build.txt`.
+- [x] 8.5 With `DEBUG_AGENT_SDK=true` set in the host env, rerun `follow-up-prompts.live.test.ts`; verify the four `tx`/`rx` log points appear in `container.logs()` output — verified: 4x `[SDK tx]` entries (sessionOptions with redacted credentials, initial user message, setPermissionMode) + 9x `[SDK rx]` entries (system/init, assistant messages, result). Credentials are properly redacted (`CLAUDE_CODE_OAUTH_TOKEN: "[REDACTED]"`, `GITHUB_TOKEN: "[REDACTED]"`).
+
+## 9. CI coverage so this class of regression surfaces automatically
+
+- [x] 9.1 Add a post-merge (or nightly `schedule:`) workflow that runs `npm run test:live` from `src/Homespun.Worker` against a just-built `homespun-worker:local` image. Required secrets: `CLAUDE_CODE_OAUTH_TOKEN`. Budget: expect ~10–15 minutes; cap concurrency to one to avoid parallel inference spend.
+- [x] 9.2 Include `scripts/spike-idle-tolerance.ts` in the same workflow as a quick-check step (`INPUT_MODE=queue IDLE_SECONDS=3` — under 30 seconds of inference) so a future SDK change that re-breaks `streamInput` surfaces before the full live suite completes.
+- [x] 9.3 Remove the "NOT intended to run in CI" comment in `vitest.config.live.ts` or replace it with a note pointing at the new workflow.
+
+## 10. Documentation and follow-up
+
+- [x] 10.1 Add a note to `openspec/changes/simplify-worker-session-manager/design.md` Open Questions section (or the archived spec if already archived) pointing at this change as the correction
+- [x] 10.2 Capture a project-memory entry describing how to diagnose SDK-boundary issues using `DEBUG_AGENT_SDK`
+- [x] 10.3 Capture a project-memory entry noting the CI gap that let #776 merge broken (live tests and spikes were not in CI) and the remediation in this change
+- [x] 10.4 Confirmed not needed: pinning `@anthropic-ai/claude-agent-sdk` — the SDK behavior was the same pre- and post-#776; the regression slipped through because of test coverage, not an SDK change
+
+## 11. Pre-PR checklist
+
+- [x] 11.1 `dotnet test` passes (should be unaffected — change is worker-only) — 2287 passed, 7 skipped, 0 failed.
+- [x] 11.2 Worker `npm run lint:fix` / `npm run format:check` / `npm test` pass — worker package does not define `lint:fix` / `format:check` scripts (no ESLint/Prettier config in `src/Homespun.Worker`); TypeScript typecheck (`npx tsc --noEmit`) is clean and `npm test` reports 217/217 passing.
+- [ ] 11.3 PR description includes: the pre-fix failure output from step 1.2, the post-fix success from step 1.3, and a link to this OpenSpec change — evidence captured under `evidence/`; paste when opening the PR.
+- [x] 11.4 Verify `openspec status --change fix-worker-streaminput-multi-turn` reports all artifacts done
+

--- a/openspec/changes/simplify-worker-session-manager/design.md
+++ b/openspec/changes/simplify-worker-session-manager/design.md
@@ -142,3 +142,7 @@ Order of implementation (see tasks.md):
 - Should the handler registry live in a new file (`src/services/tool-handlers.ts`) or remain inline in `session-manager.ts`? Deferred to implementation — preference is inline unless it pushes the file back over 700 lines.
 - Does the worker need to expose any equivalent of the removed `/messages` endpoint for operator diagnostics (e.g. `/sessions/:id/debug`)? No known consumer today; leave out unless a need surfaces.
 - Idle tolerance spike script at `src/Homespun.Worker/scripts/spike-idle-tolerance.ts` — run manually before landing the refactor; keep-alive task to be added if it fails.
+
+## Correction — 2026-04-16
+
+The `onceIterator(initialPrompt)` + `q.streamInput(onceIterator(followup))` pattern shipped with this change does not survive past the first turn: the SDK's internal `streamInput` calls `transport.endInput()` at the tail, which closes stdin to the CLI and causes `ProcessTransport is not ready for writing` on the next `streamInput`/`setPermissionMode`/`setModel`. The regression merged green because the worker live tests and `spike-idle-tolerance.ts` were not running in CI. OpenSpec change `fix-worker-streaminput-multi-turn` (2026-04) replaces the per-turn `streamInput` path with a persistent `InputQueue` passed as the `prompt`, and wires the live suite + spike into a scheduled workflow so this class of regression surfaces within hours.

--- a/src/Homespun.Worker/package.json
+++ b/src/Homespun.Worker/package.json
@@ -13,7 +13,8 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:live": "vitest run --config vitest.config.live.ts",
-    "test:live:watch": "vitest --config vitest.config.live.ts"
+    "test:live:watch": "vitest --config vitest.config.live.ts",
+    "spike:idle-tolerance": "tsx scripts/spike-idle-tolerance.ts"
   },
   "dependencies": {
     "@a2a-js/sdk": "^0.3.10",

--- a/src/Homespun.Worker/scripts/spike-idle-tolerance.ts
+++ b/src/Homespun.Worker/scripts/spike-idle-tolerance.ts
@@ -1,36 +1,83 @@
 /**
- * spike-idle-tolerance.ts — OpenSpec `simplify-worker-session-manager`, tasks 1.1–1.3
+ * spike-idle-tolerance.ts — OpenSpec `fix-worker-streaminput-multi-turn`, tasks 1.1–1.3
  *
- * Verifies that one long-lived `query()` from `@anthropic-ai/claude-agent-sdk`
- * does not self-terminate during long idle periods in streaming-input mode.
+ * Regression probe for the SDK `streamInput` + `endInput` behavior that broke
+ * multi-turn sessions after PR #776 (`simplify-worker-session-manager`).
  *
- * Flow: start query -> drain until first `result` -> idle IDLE_SECONDS seconds
- * (default 600) -> push a follow-up via `q.streamInput(asyncIterableOfOne(msg))`
- * -> drain until a second `result`. Prints FOLLOW-UP SUCCESS or FAILURE.
+ * ## Finding
  *
- * Run from `src/Homespun.Worker` (requires ANTHROPIC_API_KEY):
- *   ANTHROPIC_API_KEY=sk-ant-... IDLE_SECONDS=600 npx tsx scripts/spike-idle-tolerance.ts
+ * `@anthropic-ai/claude-agent-sdk@0.2.81` (`sdk.mjs`) always calls
+ * `transport.endInput()` at the tail of every `streamInput` invocation:
+ *
+ *     for await (const msg of stream) { transport.write(msg) }
+ *     if (count > 0 && hasBidirectionalNeeds()) await waitForFirstResult()
+ *     transport.endInput()   // closes stdin to CLI — CLI exits
+ *
+ * The initial `AsyncIterable` passed to `query({ prompt })` is consumed via the
+ * same `streamInput` routine internally, so even a single-shot initial prompt
+ * (e.g. `onceIterator(initialPrompt)`) triggers `endInput()` once it returns.
+ * Any subsequent `streamInput`, `setPermissionMode`, or `setModel` on the
+ * `Query` then throws `ProcessTransport is not ready for writing`.
+ *
+ * ## Fix shape (INPUT_MODE=queue)
+ *
+ * A persistent async input queue whose iterator never returns until session
+ * close is passed as the `prompt`. The initial message is `push(...)`-ed into
+ * the queue; follow-ups are `push(...)`-ed as well. The SDK's internal
+ * `streamInput` stays suspended on `await` between pushes and never reaches
+ * `endInput()`, so the CLI process survives for the session's lifetime.
+ *
+ * ## Flow
+ *
+ * start query -> drain until first `result` -> idle IDLE_SECONDS seconds
+ * (default 600) -> deliver a follow-up (via `inputQueue.push(msg)` when
+ * `INPUT_MODE=queue`, or via `q.streamInput(once(msg))` when
+ * `INPUT_MODE=stream`) -> drain until a second `result`. Prints
+ * `FOLLOW-UP SUCCESS` on the queue path and `FOLLOW-UP FAILURE` on the stream
+ * path (the historical failure mode that motivated this change).
+ *
+ * ## Envs
+ *
+ * - `INPUT_MODE=queue|stream` (default `stream` to mirror the pre-fix failure)
+ * - `IDLE_SECONDS` (default 600)
+ * - `MODEL` (default `claude-haiku-4-5-20251001`)
+ * - `PERMISSION_MODE` (default `default`) — set to `bypassPermissions` to
+ *   reproduce Build mode
+ * - `DANGEROUS_SKIP=true` — sets `allowDangerouslySkipPermissions`
+ * - `SET_MODE_ON_TURN2=true` — calls `setPermissionMode` before the follow-up
+ *   to exercise the full production send() path
+ *
+ * ## Run
+ *
+ *   CLAUDE_CODE_OAUTH_TOKEN=... INPUT_MODE=queue IDLE_SECONDS=3 \
+ *     npx tsx scripts/spike-idle-tolerance.ts
+ *
  * If `claude: not found`, run inside the worker container so the CLI resolves.
  *
- * Pass criteria: "FIRST RESULT" arrives; no mid-idle errors; after idle the
- * follow-up echoes assistant text then "FOLLOW-UP SUCCESS".
- *
- * If it fails (streamInput throws or stream ends with no 2nd result):
- *   - add a keep-alive task to tasks.md (synthetic no-op under the observed
- *     timeout) BEFORE landing the refactor; or
- *   - fall back to "selective resume": close-and-resume only when idle crosses
- *     the observed threshold.
- * Record the observed tolerance in design.md under Open Questions.
+ * Retain this script as a regression probe: if a future SDK upgrade alters the
+ * `streamInput`/`endInput` behavior, running this script in both modes is the
+ * shortest-path reproduction.
  */
 
 import {
   query,
   type PermissionResult,
   type SDKUserMessage,
+  type PermissionMode,
 } from "@anthropic-ai/claude-agent-sdk";
 
 const IDLE_SECONDS = Number.parseInt(process.env.IDLE_SECONDS ?? "600", 10);
-const MODEL = "claude-haiku-4-5-20251001";
+const MODEL = process.env.MODEL ?? "claude-haiku-4-5-20251001";
+const PERMISSION_MODE = (process.env.PERMISSION_MODE ?? "default") as PermissionMode;
+const DANGEROUS_SKIP = process.env.DANGEROUS_SKIP === "true";
+// When SET_MODE_ON_TURN2=true, exercises the real send() path that
+// calls setPermissionMode before streamInput on the follow-up turn.
+const SET_MODE_ON_TURN2 = process.env.SET_MODE_ON_TURN2 === "true";
+// INPUT_MODE=queue uses a persistent async-queue as the initial prompt and
+// pushes follow-ups through it — avoiding the SDK's `endInput()` that fires
+// at the tail of every streamInput() call. Default "stream" matches the
+// current session-manager.ts behavior (onceIterator + q.streamInput).
+const INPUT_MODE = (process.env.INPUT_MODE ?? "stream") as "stream" | "queue";
 
 const allowAll = async (
   toolName: string,
@@ -53,6 +100,53 @@ async function* once(msg: SDKUserMessage): AsyncGenerator<SDKUserMessage> {
   yield msg;
 }
 
+/**
+ * Persistent async input queue — the iterator NEVER returns on its own, so
+ * the SDK's internal `streamInput` never calls `endInput()` (which would
+ * close stdin and terminate the CLI). Follow-up messages are pushed in via
+ * `push(...)` rather than a fresh `q.streamInput(...)` call.
+ */
+class InputQueue implements AsyncIterable<SDKUserMessage> {
+  private buffer: SDKUserMessage[] = [];
+  private resolve: ((msg: IteratorResult<SDKUserMessage>) => void) | null = null;
+  private closed = false;
+
+  push(msg: SDKUserMessage): void {
+    if (this.closed) return;
+    if (this.resolve) {
+      const r = this.resolve;
+      this.resolve = null;
+      r({ value: msg, done: false });
+    } else {
+      this.buffer.push(msg);
+    }
+  }
+
+  close(): void {
+    this.closed = true;
+    if (this.resolve) {
+      const r = this.resolve;
+      this.resolve = null;
+      r({ value: undefined as unknown as SDKUserMessage, done: true });
+    }
+  }
+
+  async *[Symbol.asyncIterator](): AsyncGenerator<SDKUserMessage> {
+    while (true) {
+      if (this.buffer.length > 0) {
+        yield this.buffer.shift()!;
+        continue;
+      }
+      if (this.closed) return;
+      const next = await new Promise<IteratorResult<SDKUserMessage>>((res) => {
+        this.resolve = res;
+      });
+      if (next.done) return;
+      yield next.value;
+    }
+  }
+}
+
 async function drainUntilResult(
   q: AsyncIterable<unknown>,
   label: string,
@@ -69,39 +163,95 @@ async function drainUntilResult(
 }
 
 async function main() {
-  console.log(`spike-idle-tolerance: IDLE_SECONDS=${IDLE_SECONDS}, model=${MODEL}`);
+  console.log(
+    `spike-idle-tolerance: IDLE_SECONDS=${IDLE_SECONDS}, model=${MODEL}, ` +
+      `permissionMode=${PERMISSION_MODE}, dangerousSkip=${DANGEROUS_SKIP}, ` +
+      `setModeOnTurn2=${SET_MODE_ON_TURN2}`,
+  );
+
+  const options: Record<string, unknown> = {
+    model: MODEL,
+    permissionMode: PERMISSION_MODE,
+    canUseTool: allowAll,
+    includePartialMessages: false,
+  };
+  if (DANGEROUS_SKIP) {
+    options.allowDangerouslySkipPermissions = true;
+  }
+
+  const inputQueue = INPUT_MODE === "queue" ? new InputQueue() : null;
+  let prompt: AsyncIterable<SDKUserMessage>;
+  const initialMsg = userMessage("Say hi in one short sentence.");
+  if (inputQueue) {
+    inputQueue.push(initialMsg);
+    prompt = inputQueue;
+  } else {
+    prompt = once(initialMsg);
+  }
 
   const q = query({
-    prompt: once(userMessage("Say hi in one short sentence.")),
-    options: {
-      model: MODEL,
-      permissionMode: "default",
-      canUseTool: allowAll,
-      includePartialMessages: false,
-    },
+    prompt,
+    options: options as Parameters<typeof query>[0]["options"],
   });
 
-  console.log("waiting for FIRST RESULT...");
-  await drainUntilResult(q, "turn1");
-  console.log("FIRST RESULT received");
-
-  const idleMs = IDLE_SECONDS * 1000;
-  const startedAt = Date.now();
-  console.log(`idling for ${IDLE_SECONDS}s...`);
-  await new Promise<void>((resolve) => setTimeout(resolve, idleMs));
-  console.log(`idle complete after ${Math.round((Date.now() - startedAt) / 1000)}s`);
-
   try {
-    await q.streamInput(once(userMessage("Respond with the single word 'alive'.")));
-    console.log("streamInput accepted; waiting for SECOND RESULT...");
-    await drainUntilResult(q, "turn2");
-    console.log("FOLLOW-UP SUCCESS");
+    // Single continuous drain across both turns. Exiting the for-await
+    // between turns would call iterator.return() which marks the SDK's
+    // inner inputStream as done — making a second for-await yield nothing.
+    let resultsSeen = 0;
+    let followupScheduled = false;
+    for await (const msg of q) {
+      const m = msg as { type?: string; subtype?: string };
+      const label = resultsSeen === 0 ? "turn1" : "turn2";
+      console.log(`[${label}] msg type=${m.type}${m.subtype ? ` subtype=${m.subtype}` : ""}`);
+      if (m.type === "result") {
+        resultsSeen++;
+        if (resultsSeen === 1) {
+          console.log("FIRST RESULT received");
+          const idleMs = IDLE_SECONDS * 1000;
+          const startedAt = Date.now();
+          console.log(`idling for ${IDLE_SECONDS}s...`);
+          await new Promise<void>((resolve) => setTimeout(resolve, idleMs));
+          console.log(`idle complete after ${Math.round((Date.now() - startedAt) / 1000)}s`);
+
+          if (SET_MODE_ON_TURN2) {
+            console.log(`calling setPermissionMode('${PERMISSION_MODE}')...`);
+            await q.setPermissionMode(PERMISSION_MODE);
+            console.log("setPermissionMode accepted");
+          }
+          const followupMsg = userMessage("Respond with the single word 'alive'.");
+          if (inputQueue) {
+            console.log("pushing follow-up through persistent input queue...");
+            inputQueue.push(followupMsg);
+          } else {
+            console.log("calling q.streamInput(once(followup))...");
+            // Fire-and-forget so we keep draining; streamInput awaits
+            // waitForFirstResult internally which would deadlock here.
+            q.streamInput(once(followupMsg)).catch((e) => {
+              console.error(`streamInput rejected: ${e instanceof Error ? e.message : e}`);
+            });
+          }
+          followupScheduled = true;
+          continue;
+        }
+        if (resultsSeen === 2) {
+          console.log("FOLLOW-UP SUCCESS");
+          break;
+        }
+      }
+    }
+    if (resultsSeen < 2) {
+      throw new Error(
+        `drain ended before second result (seen=${resultsSeen}, followupScheduled=${followupScheduled})`,
+      );
+    }
   } catch (err) {
     const msg = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
     console.error(`FOLLOW-UP FAILURE: ${msg}`);
     if (err instanceof Error && err.stack) console.error(err.stack);
     process.exitCode = 1;
   } finally {
+    inputQueue?.close();
     try {
       await (q as unknown as { return?: () => Promise<unknown> }).return?.();
     } catch {

--- a/src/Homespun.Worker/src/services/input-queue.ts
+++ b/src/Homespun.Worker/src/services/input-queue.ts
@@ -1,0 +1,84 @@
+import type { SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+
+/**
+ * Persistent async input queue for a single worker session.
+ *
+ * The `@anthropic-ai/claude-agent-sdk` `query({ prompt, ... })` function
+ * consumes the supplied `AsyncIterable` via its internal `streamInput`
+ * routine, which invokes `transport.endInput()` as soon as the iterable
+ * returns. That closes stdin to the CLI subprocess and makes any subsequent
+ * `streamInput`, `setPermissionMode`, or `setModel` call fail with
+ * `ProcessTransport is not ready for writing`.
+ *
+ * `InputQueue` works around this by implementing an `AsyncIterable` whose
+ * iterator **never returns on its own** — it awaits indefinitely between
+ * pushes and only yields `{ done: true }` after `close()` is called. That
+ * lets a single `query()` run for the full session lifetime; follow-up
+ * messages are delivered via `push(...)` into the same iterable instead of
+ * via `q.streamInput(...)`.
+ *
+ * ## Invariants
+ *
+ * - **Single-consumer**. Only one `for await` (or equivalent) is expected to
+ *   iterate an instance. Concurrent iterators share the same buffer and
+ *   resolver slot; behavior with more than one consumer is undefined.
+ * - **Iterator does not return until `close()`**. Without `close()` the
+ *   consumer's `await next()` suspends forever, which is exactly what the SDK
+ *   needs to keep the CLI alive between turns.
+ * - **`push()` after `close()` is a no-op**. It does not throw, matches the
+ *   spike-validated behavior, and simplifies teardown races.
+ */
+export class InputQueue implements AsyncIterable<SDKUserMessage> {
+  private buffer: SDKUserMessage[] = [];
+  private resolver: ((result: IteratorResult<SDKUserMessage>) => void) | null =
+    null;
+  private closed = false;
+
+  /**
+   * Push a message into the queue. If a consumer is currently awaiting
+   * `next()`, deliver it directly; otherwise buffer in FIFO order. No-op when
+   * the queue has been closed.
+   */
+  push(msg: SDKUserMessage): void {
+    if (this.closed) return;
+    if (this.resolver) {
+      const resolve = this.resolver;
+      this.resolver = null;
+      resolve({ value: msg, done: false });
+    } else {
+      this.buffer.push(msg);
+    }
+  }
+
+  /**
+   * Close the queue. Any in-flight `next()` resolves with `{ done: true }`.
+   * Subsequent `next()` calls return `{ done: true }` once the buffer is
+   * drained. Idempotent.
+   */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    if (this.resolver) {
+      const resolve = this.resolver;
+      this.resolver = null;
+      resolve({ value: undefined as unknown as SDKUserMessage, done: true });
+    }
+  }
+
+  async *[Symbol.asyncIterator](): AsyncGenerator<SDKUserMessage> {
+    while (true) {
+      if (this.buffer.length > 0) {
+        yield this.buffer.shift()!;
+        continue;
+      }
+      if (this.closed) return;
+      const next = await new Promise<IteratorResult<SDKUserMessage>>(
+        (resolve) => {
+          this.resolver = resolve;
+        },
+      );
+      if (next.done) return;
+      yield next.value;
+    }
+  }
+}

--- a/src/Homespun.Worker/src/services/session-manager.ts
+++ b/src/Homespun.Worker/src/services/session-manager.ts
@@ -21,7 +21,14 @@ import {
   type WorkflowSignalInput,
 } from "../tools/workflow-tools.js";
 import { randomUUID } from "node:crypto";
-import { info, error, warn, debug } from "../utils/logger.js";
+import {
+  info,
+  error,
+  warn,
+  debug,
+  sdkDebug,
+  isSdkDebugEnabled,
+} from "../utils/logger.js";
 import {
   buildInventoryFromInit,
   emitInventoryLog,
@@ -33,6 +40,7 @@ import {
   FileMonitor,
 } from "../utils/diagnostics.js";
 import { watch, existsSync } from "node:fs";
+import { InputQueue } from "./input-queue.js";
 
 export type SdkPermissionMode =
   | "default"
@@ -104,6 +112,20 @@ export function isControlEvent(event: OutputEvent): event is ControlEvent {
 /**
  * Single-consumer async queue that merges pushes from multiple producers
  * (the SDK query background task and the canUseTool callback).
+ *
+ * ## Invariants
+ *
+ * - **Single consumer at a time.** The channel delivers each event to exactly
+ *   one consumer. Per-HTTP-request SSE streams consume the channel
+ *   sequentially, but never concurrently. The behavior under concurrent
+ *   `for await` loops is undefined — whichever consumer installed the most
+ *   recent resolver receives the next push.
+ * - **Events survive consumer abort.** When a consumer exits its `for await`
+ *   (e.g. because `streamSessionEvents` returns on a `result`), the pending
+ *   resolver MUST be cleared in the generator's `finally` block so that any
+ *   subsequent `push(...)` lands in the internal buffer rather than invoking
+ *   a stale promise resolver (which would silently drop the event). The next
+ *   consumer then drains from the buffer.
  */
 export class OutputChannel {
   private queue: OutputEvent[] = [];
@@ -133,19 +155,48 @@ export class OutputChannel {
   }
 
   async *[Symbol.asyncIterator](): AsyncGenerator<OutputEvent> {
-    while (true) {
-      if (this.queue.length > 0) {
-        yield this.queue.shift()!;
-      } else if (this.done) {
-        return;
-      } else {
-        const result = await new Promise<IteratorResult<OutputEvent>>(
-          (resolve) => {
-            this.resolver = resolve;
-          },
-        );
-        if (result.done) return;
-        yield result.value;
+    // If a prior iterator is still suspended on an un-settled promise (e.g.
+    // an aborted SSE consumer whose runtime never called .return()), its
+    // resolver is still attached to this channel. Complete it with done:true
+    // so it unblocks and runs its own finally, then claim the slot for this
+    // new iterator. Without this, the next push() would deliver the event to
+    // the orphaned resolver and the new consumer would never see it.
+    if (this.resolver) {
+      const stale = this.resolver;
+      this.resolver = null;
+      stale({ value: undefined as unknown as OutputEvent, done: true });
+    }
+
+    // Track which resolver this iterator installed so finally only clears
+    // its own subscription and not a resolver that belongs to a later
+    // iterator that supplanted it.
+    let myResolver: ((r: IteratorResult<OutputEvent>) => void) | null = null;
+
+    try {
+      while (true) {
+        if (this.queue.length > 0) {
+          yield this.queue.shift()!;
+        } else if (this.done) {
+          return;
+        } else {
+          const result = await new Promise<IteratorResult<OutputEvent>>(
+            (resolve) => {
+              myResolver = resolve;
+              this.resolver = resolve;
+            },
+          );
+          myResolver = null;
+          if (result.done) return;
+          yield result.value;
+        }
+      }
+    } finally {
+      // Clear the resolver slot only if it still points at ours — a later
+      // iterator may have supplanted it by now, and we must not clobber
+      // that. Without this, events produced between two per-turn SSE
+      // consumer iterations would be silently dropped.
+      if (myResolver && this.resolver === myResolver) {
+        this.resolver = null;
       }
     }
   }
@@ -185,6 +236,13 @@ interface PendingInteraction<T> {
 interface WorkerSession {
   id: string;
   query: Query;
+  /**
+   * Persistent input iterable supplied to `query({ prompt })`. The initial
+   * user prompt is pushed here on session create; follow-up user messages
+   * are pushed here by `send()`. Closed by `close()` so the session's
+   * `query()` lifecycle ends cleanly.
+   */
+  inputQueue: InputQueue;
   outputChannel: OutputChannel;
   conversationId?: string;
   mode: string;
@@ -301,13 +359,31 @@ function buildCommonOptions(
 }
 
 /**
- * Yields a single SDK user message then returns. Used to push a follow-up
- * message into the live query via `q.streamInput(...)`.
+ * Strip credentials from an object before passing it to `sdkDebug`. Mutates
+ * the returned shallow copy — the original `sessionOptions` is not modified.
  */
-async function* onceIterator(
-  msg: SDKUserMessage,
-): AsyncGenerator<SDKUserMessage> {
-  yield msg;
+function redactSessionOptionsForLog(
+  options: Record<string, unknown>,
+): Record<string, unknown> {
+  const copy: Record<string, unknown> = { ...options };
+  if (copy.env && typeof copy.env === "object") {
+    const env = { ...(copy.env as Record<string, unknown>) };
+    for (const key of [
+      "GITHUB_TOKEN",
+      "GH_TOKEN",
+      "GitHub__Token",
+      "CLAUDE_CODE_OAUTH_TOKEN",
+      "ANTHROPIC_API_KEY",
+    ]) {
+      if (key in env) env[key] = "[REDACTED]";
+    }
+    copy.env = env;
+  }
+  // Don't spill the canUseTool callback's source.
+  if (typeof copy.canUseTool === "function") {
+    copy.canUseTool = "[Function]";
+  }
+  return copy;
 }
 
 /**
@@ -648,9 +724,13 @@ export class SessionManager {
       `Session configuration: permissionMode='${sessionOptions.permissionMode}', allowDangerouslySkipPermissions=${sessionOptions.allowDangerouslySkipPermissions}, sessionId='${id}', allowedTools=${JSON.stringify(sessionOptions.allowedTools)}, hasCanUseTool=true, hasResume=${!!opts.resumeSessionId}`,
     );
 
-    // Build the initial prompt as a single-message async iterable. The SDK
-    // accepts this as streaming-input mode; follow-up messages are pushed via
-    // q.streamInput() later.
+    // Build the initial prompt as the first entry in a persistent InputQueue.
+    // The queue's iterator never returns until close() is called, which keeps
+    // the SDK's internal streamInput suspended between turns and prevents
+    // transport.endInput() from closing stdin to the CLI. Follow-up messages
+    // are delivered by pushing into this same queue rather than by invoking
+    // q.streamInput() — see scripts/spike-idle-tolerance.ts for the contract
+    // and the `fix-worker-streaminput-multi-turn` OpenSpec change for the why.
     const initialPrompt: SDKUserMessage = {
       type: "user",
       session_id: "",
@@ -661,8 +741,25 @@ export class SessionManager {
       parent_tool_use_id: null,
     };
 
+    const inputQueue = new InputQueue();
+
+    // Capture point 1: full session options just before query({...}). Gated
+    // on DEBUG_AGENT_SDK. Credentials are redacted from options.env.
+    if (isSdkDebugEnabled()) {
+      warn(
+        `DEBUG_AGENT_SDK is enabled — high log volume expected (sessionId: ${id})`,
+      );
+      sdkDebug("tx", redactSessionOptionsForLog(sessionOptions));
+    }
+
+    // Capture point 2: initial user message pushed into the input queue.
+    if (isSdkDebugEnabled()) {
+      sdkDebug("tx", initialPrompt);
+    }
+    inputQueue.push(initialPrompt);
+
     const q = query({
-      prompt: onceIterator(initialPrompt),
+      prompt: inputQueue,
       options: sessionOptions as Parameters<typeof query>[0]["options"],
     });
 
@@ -671,6 +768,7 @@ export class SessionManager {
     const workerSession: WorkerSession = {
       id,
       query: q,
+      inputQueue,
       outputChannel,
       conversationId: opts.resumeSessionId,
       mode: opts.mode,
@@ -739,9 +837,12 @@ export class SessionManager {
 
   /**
    * Runs the background query forwarder that reads SDK messages and pushes
-   * them to the output channel. There is now a single forwarder per session
-   * lifetime — follow-up messages are delivered via q.streamInput() directly
-   * into the same query without restarting it.
+   * them to the output channel. There is a single forwarder per session
+   * lifetime. Follow-up user messages are delivered by pushing into the
+   * session's persistent `InputQueue` (the same iterable supplied as the
+   * initial `prompt` to `query()`), never via `q.streamInput(...)` — see
+   * the `fix-worker-streaminput-multi-turn` OpenSpec change for the SDK
+   * contract that motivates this design.
    */
   private runQueryForwarder(
     session: WorkerSession,
@@ -762,6 +863,10 @@ export class SessionManager {
         let messageCount = 0;
         session.inventoryEmitted = false;
         for await (const msg of q) {
+          // Capture point 4: every raw SDK message yielded by the Query.
+          if (isSdkDebugEnabled()) {
+            sdkDebug("rx", msg);
+          }
           if (
             !session.inventoryEmitted &&
             msg.type === "system" &&
@@ -982,6 +1087,9 @@ export class SessionManager {
     );
 
     if (ws.query.setPermissionMode) {
+      if (isSdkDebugEnabled()) {
+        sdkDebug("tx", { op: "setPermissionMode", mode: newPermissionMode });
+      }
       await ws.query.setPermissionMode(newPermissionMode);
       info(
         `setMode - setPermissionMode('${newPermissionMode}') applied (sessionId='${sessionId}')`,
@@ -1012,6 +1120,9 @@ export class SessionManager {
     info(`setModel - model updated to '${model}' (sessionId='${sessionId}')`);
 
     if (ws.query.setModel) {
+      if (isSdkDebugEnabled()) {
+        sdkDebug("tx", { op: "setModel", model });
+      }
       await ws.query.setModel(model);
       info(`setModel - setModel('${model}') applied (sessionId='${sessionId}')`);
     }
@@ -1038,6 +1149,9 @@ export class SessionManager {
       ws.model = model;
       info(`model updated to '${model}'`);
       if (ws.query.setModel) {
+        if (isSdkDebugEnabled()) {
+          sdkDebug("tx", { op: "setModel", model });
+        }
         await ws.query.setModel(model);
       }
     }
@@ -1049,6 +1163,12 @@ export class SessionManager {
         `mode updated to '${ws.mode}', permissionMode='${ws.permissionMode}'`,
       );
       if (ws.query.setPermissionMode) {
+        if (isSdkDebugEnabled()) {
+          sdkDebug("tx", {
+            op: "setPermissionMode",
+            mode: ws.permissionMode,
+          });
+        }
         await ws.query.setPermissionMode(ws.permissionMode);
         info(`setPermissionMode('${ws.permissionMode}') applied`);
       }
@@ -1066,7 +1186,13 @@ export class SessionManager {
       parent_tool_use_id: null,
     };
 
-    await ws.query.streamInput(onceIterator(userMessage));
+    // Push into the persistent input queue. This avoids q.streamInput(...)
+    // which always calls transport.endInput() at the tail and would close
+    // stdin to the CLI subprocess after the message is written.
+    if (isSdkDebugEnabled()) {
+      sdkDebug("tx", userMessage);
+    }
+    ws.inputQueue.push(userMessage);
 
     this.logStatusChange(ws, "streaming", "message_sent");
 
@@ -1149,6 +1275,11 @@ export class SessionManager {
       this.pending.delete(sessionId);
     }
 
+    // Close the input queue first so the SDK's internal consumer sees
+    // { done: true } and finishes its streamInput loop before we tear down
+    // the Query itself. Closing the query first can surface a spurious
+    // write-error if a push is racing.
+    ws.inputQueue.close();
     ws.outputChannel.complete();
     ws.query.close?.();
     this.logStatusChange(ws, "closed", "session_closed");

--- a/src/Homespun.Worker/src/utils/logger.ts
+++ b/src/Homespun.Worker/src/utils/logger.ts
@@ -14,6 +14,14 @@ const issueId = process.env.ISSUE_ID || undefined;
 const projectName = process.env.PROJECT_NAME || undefined;
 const debugEnabled = process.env.DEBUG_LOGGING === 'true';
 
+/**
+ * Whether `DEBUG_AGENT_SDK=true` is set in the process environment. Read
+ * lazily on each call so tests that stub env after import still work.
+ */
+export function isSdkDebugEnabled(): boolean {
+  return process.env.DEBUG_AGENT_SDK === 'true';
+}
+
 function getCallerInfo(): { file: string; line: number } {
   const stack = new Error().stack?.split('\n')[3]; // Skip: Error, getCallerInfo, log fn
   const match = stack?.match(/at .* \((.+):(\d+):\d+\)/) || stack?.match(/at (.+):(\d+):\d+/);
@@ -61,4 +69,31 @@ export function warn(message: string): void {
 
 export function error(message: string, err?: unknown): void {
   console.error(formatLog('Error', message, err));
+}
+
+/**
+ * Emit a single structured log entry capturing an SDK-boundary message.
+ *
+ * Gated by `DEBUG_AGENT_SDK=true` so production traffic is unaffected unless
+ * the flag is explicitly enabled. The payload is JSON-serialized into the
+ * entry's `Message` field, so existing Promtail / `docker logs` consumers
+ * handle it identically to other worker logs.
+ *
+ * - `direction: 'tx'` — outbound from worker to SDK (session options, user
+ *   messages pushed into the input queue, control calls like setPermissionMode
+ *   / setModel).
+ * - `direction: 'rx'` — inbound from SDK (raw messages yielded by the
+ *   `Query` async iterable).
+ */
+export function sdkDebug(direction: 'tx' | 'rx', msg: unknown): void {
+  if (!isSdkDebugEnabled()) return;
+  let payload: string;
+  try {
+    payload = JSON.stringify(msg);
+  } catch {
+    payload = String(msg);
+  }
+  console.log(
+    formatLog('Debug', `[SDK ${direction}] ${payload}`),
+  );
 }

--- a/src/Homespun.Worker/vitest.config.live.ts
+++ b/src/Homespun.Worker/vitest.config.live.ts
@@ -1,8 +1,11 @@
 /**
  * Vitest Configuration for Live Worker Container Tests
  *
- * These tests use real inference and should be run manually during development.
- * They are NOT intended to run in CI.
+ * These tests use real inference against a locally-built `homespun-worker`
+ * image and cost money per run. They are invoked manually during development
+ * and by the scheduled `worker-live-tests` workflow
+ * (`.github/workflows/worker-live-tests.yml`) post-merge / nightly — do NOT
+ * include them in the per-PR worker CI job.
  */
 
 import { defineConfig } from 'vitest/config';

--- a/tests/Homespun.Worker/helpers/mock-sdk.ts
+++ b/tests/Homespun.Worker/helpers/mock-sdk.ts
@@ -1,37 +1,89 @@
-import type { SDKMessage, Query, PermissionResult } from '@anthropic-ai/claude-agent-sdk';
+import type {
+  SDKMessage,
+  Query,
+  PermissionResult,
+  SDKUserMessage,
+} from '@anthropic-ai/claude-agent-sdk';
+
+/**
+ * The error message the real `@anthropic-ai/claude-agent-sdk` `ProcessTransport`
+ * throws when a write is attempted after `endInput()` has been called. Kept in
+ * sync with `sdk.mjs`'s own throw string so tests observe the same failure
+ * shape as production.
+ */
+export const TRANSPORT_NOT_READY_ERROR =
+  'ProcessTransport is not ready for writing';
 
 export interface MockQuery extends Query {
   setPermissionMode: ReturnType<typeof vi.fn>;
   _iterator: AsyncGenerator<SDKMessage>;
   _messages: SDKMessage[];
+  /**
+   * Simulate the real SDK's `endInput()` happening — any subsequent
+   * write/control call must throw. Used by tests that want to assert the
+   * session-manager never invokes streamInput / setPermissionMode / setModel
+   * on a Query whose initial iterable has already completed.
+   */
+  _simulateInputEnded(): void;
+  /**
+   * Push a message into the mock's injected input queue. Tests use this
+   * instead of `q.streamInput(...)` when they want to exercise the
+   * session-manager's persistent-input-queue path.
+   */
+  _pushInput(msg: SDKUserMessage): void;
 }
 
-// Mock V1 Query object that acts as an async generator
+// Mock V1 Query object that acts as an async generator. Mirrors the real
+// sdk.mjs contract: once the input iterable passed to `query({prompt})` is
+// exhausted, the transport throws on any further streamInput / setPermissionMode
+// / setModel call. This guards against regressions that feed the SDK a finite
+// iterable and then call streamInput for follow-ups (the #776 failure mode
+// that this OpenSpec change addresses).
 export function createMockQuery(messages: SDKMessage[] = []): MockQuery {
+  let inputEnded = false;
+  const failIfInputEnded = (op: string) => {
+    if (inputEnded) {
+      throw new Error(`${TRANSPORT_NOT_READY_ERROR}: ${op}`);
+    }
+  };
+
   const mockQuery = {
-    setPermissionMode: vi.fn().mockResolvedValue(undefined),
+    setPermissionMode: vi.fn(async (..._args: unknown[]) => {
+      failIfInputEnded('setPermissionMode');
+    }),
     interrupt: vi.fn().mockResolvedValue(undefined),
     rewindFiles: vi.fn().mockResolvedValue(undefined),
-    setModel: vi.fn().mockResolvedValue(undefined),
+    setModel: vi.fn(async (..._args: unknown[]) => {
+      failIfInputEnded('setModel');
+    }),
     setMaxThinkingTokens: vi.fn().mockResolvedValue(undefined),
     supportedCommands: vi.fn().mockResolvedValue([]),
     supportedModels: vi.fn().mockResolvedValue([]),
     mcpServerStatus: vi.fn().mockResolvedValue([]),
     accountInfo: vi.fn().mockResolvedValue({}),
-    streamInput: vi.fn().mockResolvedValue(undefined),
+    streamInput: vi.fn(async (..._args: unknown[]) => {
+      failIfInputEnded('streamInput');
+    }),
     close: vi.fn(),
     _messages: messages,
-    _iterator: null as any,
+    _iterator: null as unknown as AsyncGenerator<SDKMessage>,
+    _simulateInputEnded(): void {
+      inputEnded = true;
+    },
+    _pushInput(_msg: SDKUserMessage): void {
+      // Default no-op; test may override to capture pushed messages.
+    },
   };
 
   // Make it async iterable
-  (mockQuery as any)[Symbol.asyncIterator] = function* () {
-    for (const msg of this._messages) {
-      yield msg;
-    }
-  };
+  (mockQuery as unknown as { [Symbol.asyncIterator]: () => AsyncGenerator<SDKMessage> })[Symbol.asyncIterator] =
+    function* () {
+      for (const msg of this._messages) {
+        yield msg;
+      }
+    } as unknown as () => AsyncGenerator<SDKMessage>;
 
-  return mockQuery as MockQuery;
+  return mockQuery as unknown as MockQuery;
 }
 
 // Helper to set messages on a mock query
@@ -45,10 +97,11 @@ export function setMockQueryMessages(query: MockQuery, messages: SDKMessage[]): 
  */
 export function createBlockingMockQuery(): MockQuery {
   const mockQuery = createMockQuery();
-  (mockQuery as any)[Symbol.asyncIterator] = async function* () {
-    // Block forever — never yield, never return
-    await new Promise(() => {});
-  };
+  (mockQuery as unknown as { [Symbol.asyncIterator]: () => AsyncGenerator<SDKMessage> })[Symbol.asyncIterator] =
+    async function* () {
+      // Block forever — never yield, never return
+      await new Promise(() => {});
+    } as unknown as () => AsyncGenerator<SDKMessage>;
   return mockQuery;
 }
 

--- a/tests/Homespun.Worker/live/fixtures/container-lifecycle.ts
+++ b/tests/Homespun.Worker/live/fixtures/container-lifecycle.ts
@@ -112,6 +112,13 @@ export async function startContainer(
     );
   }
 
+  // Forward DEBUG_AGENT_SDK from the host so developers can flip SDK-boundary
+  // debug logging on without rebuilding the worker image or editing configs.
+  // Off by default; the live-test suite only sees it when explicitly exported.
+  if (process.env.DEBUG_AGENT_SDK) {
+    args.push("-e", "DEBUG_AGENT_SDK=" + process.env.DEBUG_AGENT_SDK);
+  }
+
   // Additional environment variables
   if (finalConfig.env) {
     for (const [key, value] of Object.entries(finalConfig.env)) {

--- a/tests/Homespun.Worker/services/input-queue.test.ts
+++ b/tests/Homespun.Worker/services/input-queue.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import type { SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+import { InputQueue } from '#src/services/input-queue.js';
+
+function userMessage(text: string): SDKUserMessage {
+  return {
+    type: 'user',
+    session_id: '',
+    parent_tool_use_id: null,
+    message: { role: 'user', content: [{ type: 'text', text }] },
+  };
+}
+
+describe('InputQueue', () => {
+  it('task 2.3.1: push-then-iterate yields the buffered message', async () => {
+    const q = new InputQueue();
+    const msg = userMessage('hello');
+    q.push(msg);
+
+    const iter = q[Symbol.asyncIterator]();
+    const result = await iter.next();
+    expect(result.done).toBe(false);
+    expect(result.value).toBe(msg);
+  });
+
+  it('task 2.3.2: iterate-then-push resolves the pending next()', async () => {
+    const q = new InputQueue();
+    const iter = q[Symbol.asyncIterator]();
+
+    const nextPromise = iter.next();
+    const msg = userMessage('delayed');
+
+    // Defer the push until after next() has subscribed as the resolver
+    await Promise.resolve();
+    q.push(msg);
+
+    const result = await nextPromise;
+    expect(result.done).toBe(false);
+    expect(result.value).toBe(msg);
+  });
+
+  it('task 2.3.3: multiple pushes deliver in FIFO order', async () => {
+    const q = new InputQueue();
+    const m1 = userMessage('first');
+    const m2 = userMessage('second');
+    const m3 = userMessage('third');
+    q.push(m1);
+    q.push(m2);
+    q.push(m3);
+
+    const iter = q[Symbol.asyncIterator]();
+    const r1 = await iter.next();
+    const r2 = await iter.next();
+    const r3 = await iter.next();
+
+    expect(r1.value).toBe(m1);
+    expect(r2.value).toBe(m2);
+    expect(r3.value).toBe(m3);
+  });
+
+  it('task 2.3.4: close() resolves the in-flight next() with done:true', async () => {
+    const q = new InputQueue();
+    const iter = q[Symbol.asyncIterator]();
+    const nextPromise = iter.next();
+
+    await Promise.resolve();
+    q.close();
+
+    const result = await nextPromise;
+    expect(result.done).toBe(true);
+  });
+
+  it('close() causes subsequent next() to return done:true after buffer drained', async () => {
+    const q = new InputQueue();
+    const m1 = userMessage('m1');
+    q.push(m1);
+    q.close();
+
+    const iter = q[Symbol.asyncIterator]();
+    const r1 = await iter.next();
+    expect(r1.done).toBe(false);
+    expect(r1.value).toBe(m1);
+    const r2 = await iter.next();
+    expect(r2.done).toBe(true);
+  });
+
+  it('task 2.3.5: push() after close() is a no-op (does not throw)', async () => {
+    const q = new InputQueue();
+    q.close();
+    expect(() => q.push(userMessage('late'))).not.toThrow();
+
+    const iter = q[Symbol.asyncIterator]();
+    const result = await iter.next();
+    expect(result.done).toBe(true);
+  });
+});

--- a/tests/Homespun.Worker/services/output-channel.test.ts
+++ b/tests/Homespun.Worker/services/output-channel.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import {
+  OutputChannel,
+  type OutputEvent,
+} from '#src/services/session-manager.js';
+import { createAssistantMessage } from '../helpers/test-fixtures.js';
+
+describe('OutputChannel hardening', () => {
+  it('task 3.3.1: event pushed between iterator re-entries is delivered to next consumer', async () => {
+    const channel = new OutputChannel();
+
+    const first = createAssistantMessage();
+    channel.push(first);
+
+    {
+      const iter = channel[Symbol.asyncIterator]();
+      const r = await iter.next();
+      expect(r.value).toBe(first);
+      // Simulate consumer aborting - return ends the generator
+      await iter.return?.(undefined);
+    }
+
+    // Producer pushes while no consumer is active.
+    const between = createAssistantMessage();
+    channel.push(between);
+
+    // Consumer 2 starts iterating.
+    const iter2 = channel[Symbol.asyncIterator]();
+    const r2 = await iter2.next();
+    expect(r2.value).toBe(between);
+  });
+
+  it('task 3.3.2: stale resolver is invalidated when a new iterator starts so events land in buffer', async () => {
+    const channel = new OutputChannel();
+
+    // Consumer 1 starts and awaits — resolver is installed.
+    const iter = channel[Symbol.asyncIterator]();
+    const orphaned = iter.next();
+    await Promise.resolve();
+
+    // Consumer 1 is abandoned without explicit .return() (e.g. the surrounding
+    // async fn was GC'd or the SSE consumer went away). A naive channel would
+    // still invoke the orphaned resolver on the next push, silently dropping
+    // the event for future consumers.
+
+    // A new consumer starts on the same channel before any push. The new
+    // iterator must invalidate the orphaned resolver so the next push() is
+    // delivered to this consumer (either via buffer or a fresh resolver)
+    // rather than to the orphan.
+    const iter2 = channel[Symbol.asyncIterator]();
+
+    // Producer pushes an event. The new iterator must see it even though the
+    // orphaned resolver from iter1 was still present at push time.
+    const msg = createAssistantMessage();
+    // Kick off iter2 so the generator body runs and invalidates the stale
+    // resolver before the push.
+    const iter2NextPromise = iter2.next();
+    await Promise.resolve();
+    channel.push(msg);
+
+    const r = await iter2NextPromise;
+    expect(r.value).toBe(msg);
+
+    // The orphaned next() from iter1 should resolve with done:true.
+    const orphanedResult = await orphaned;
+    expect(orphanedResult.done).toBe(true);
+  });
+
+  it('task 3.3.3: complete() terminates an in-flight await next()', async () => {
+    const channel = new OutputChannel();
+    const iter = channel[Symbol.asyncIterator]();
+    const pending = iter.next();
+
+    await Promise.resolve();
+    channel.complete();
+
+    const result = await pending;
+    expect(result.done).toBe(true);
+  });
+
+  it('buffered events are delivered in FIFO order across consumer re-entries', async () => {
+    const channel = new OutputChannel();
+    const a = createAssistantMessage();
+    const b = createAssistantMessage();
+    const c = createAssistantMessage();
+
+    channel.push(a);
+    channel.push(b);
+    channel.push(c);
+
+    const collected: OutputEvent[] = [];
+    const iter = channel[Symbol.asyncIterator]();
+    collected.push((await iter.next()).value!);
+    await iter.return?.(undefined);
+
+    const iter2 = channel[Symbol.asyncIterator]();
+    collected.push((await iter2.next()).value!);
+    collected.push((await iter2.next()).value!);
+
+    expect(collected).toEqual([a, b, c]);
+  });
+});

--- a/tests/Homespun.Worker/services/session-manager-logging.test.ts
+++ b/tests/Homespun.Worker/services/session-manager-logging.test.ts
@@ -11,6 +11,8 @@ vi.mock('#src/utils/logger.js', () => ({
   error: vi.fn(),
   warn: vi.fn(),
   debug: vi.fn(),
+  sdkDebug: vi.fn(),
+  isSdkDebugEnabled: vi.fn(() => false),
 }));
 
 // Track the canUseTool callback that gets passed to query()

--- a/tests/Homespun.Worker/services/session-manager.test.ts
+++ b/tests/Homespun.Worker/services/session-manager.test.ts
@@ -305,36 +305,53 @@ describe('SessionManager', () => {
       );
     });
 
-    // Task 3.2: send() after a `result` message delivers the new user message
-    // via q.streamInput() and does NOT call query() a second time.
-    it('task 3.2: delivers follow-up via streamInput without restarting query', async () => {
+    // After `fix-worker-streaminput-multi-turn`: send() delivers the new user
+    // message by pushing into the session's persistent input queue (the same
+    // iterable passed to `query({prompt})`). It does NOT call query() again
+    // and does NOT call q.streamInput() — the latter would close stdin to
+    // the CLI and break subsequent turns.
+    it('task 3.2: delivers follow-up by pushing into inputQueue (not streamInput)', async () => {
       setMockQueryMessages(mockQueryObj, [createResultMessage()]);
       const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Build' });
 
       // Drain the first query so a result is observed (forwarder finishes).
       await collectAsyncGenerator(manager.stream(ws.id));
 
-      const streamInputMock = vi.fn().mockResolvedValue(undefined);
-      (ws.query as any).streamInput = streamInputMock;
+      const pushSpy = vi.spyOn(ws.inputQueue, 'push');
+      const streamInputMock = (ws.query as unknown as { streamInput: ReturnType<typeof vi.fn> }).streamInput;
       mockQuery.mockClear();
 
       await manager.send(ws.id, 'follow up');
 
       expect(mockQuery).not.toHaveBeenCalled();
-      expect(streamInputMock).toHaveBeenCalledOnce();
-      const [streamArg] = streamInputMock.mock.calls[0];
-      expect(typeof streamArg[Symbol.asyncIterator]).toBe('function');
-
-      const collected: any[] = [];
-      for await (const msg of streamArg) collected.push(msg);
-      expect(collected).toHaveLength(1);
-      expect(collected[0]).toMatchObject({
+      expect(streamInputMock).not.toHaveBeenCalled();
+      expect(pushSpy).toHaveBeenCalledOnce();
+      const [pushed] = pushSpy.mock.calls[0];
+      expect(pushed).toMatchObject({
         type: 'user',
         message: {
           role: 'user',
           content: [{ type: 'text', text: 'follow up' }],
         },
       });
+    });
+
+    // Mock-contract test: the mock SDK's streamInput must fail once the
+    // initial input iterable has been exhausted, mirroring the real SDK's
+    // `ProcessTransport is not ready for writing` behavior. This guards
+    // against a future regression that reintroduces the onceIterator +
+    // q.streamInput pattern by making the unit tests red.
+    it('mock SDK contract: streamInput throws after initial input iterable exhausted', async () => {
+      setMockQueryMessages(mockQueryObj, [createResultMessage()]);
+      const ws = await manager.create({ prompt: 'init', model: 'sonnet', mode: 'Build' });
+      await collectAsyncGenerator(manager.stream(ws.id));
+
+      // Simulate the SDK's endInput() firing after the initial iterable completes.
+      (ws.query as unknown as { _simulateInputEnded: () => void })._simulateInputEnded();
+
+      await expect(
+        (ws.query as unknown as { streamInput: (x: unknown) => Promise<void> }).streamInput('anything'),
+      ).rejects.toThrow(/ProcessTransport is not ready for writing/);
     });
   });
 

--- a/tests/Homespun.Worker/utils/sdk-debug.test.ts
+++ b/tests/Homespun.Worker/utils/sdk-debug.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { sdkDebug, isSdkDebugEnabled } from '#src/utils/logger.js';
+
+describe('sdkDebug', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    logSpy.mockRestore();
+  });
+
+  it('emits no output when DEBUG_AGENT_SDK is unset', () => {
+    vi.stubEnv('DEBUG_AGENT_SDK', '');
+    sdkDebug('tx', { hello: 'world' });
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('emits no output when DEBUG_AGENT_SDK is any value other than "true"', () => {
+    vi.stubEnv('DEBUG_AGENT_SDK', '1');
+    sdkDebug('rx', { x: 1 });
+    vi.stubEnv('DEBUG_AGENT_SDK', 'false');
+    sdkDebug('rx', { x: 1 });
+    vi.stubEnv('DEBUG_AGENT_SDK', 'TRUE');
+    sdkDebug('rx', { x: 1 });
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('emits a structured JSON line for tx payloads when enabled', () => {
+    vi.stubEnv('DEBUG_AGENT_SDK', 'true');
+    sdkDebug('tx', { op: 'setPermissionMode', mode: 'bypassPermissions' });
+
+    expect(logSpy).toHaveBeenCalledOnce();
+    const written = logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(written);
+    expect(parsed.Level).toBe('Debug');
+    expect(parsed.Message).toContain('[SDK tx]');
+    expect(parsed.Message).toContain('"op":"setPermissionMode"');
+    expect(parsed.Message).toContain('"mode":"bypassPermissions"');
+  });
+
+  it('emits for rx direction', () => {
+    vi.stubEnv('DEBUG_AGENT_SDK', 'true');
+    sdkDebug('rx', { type: 'assistant' });
+
+    expect(logSpy).toHaveBeenCalledOnce();
+    const written = logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(written);
+    expect(parsed.Message).toContain('[SDK rx]');
+    expect(parsed.Message).toContain('"type":"assistant"');
+  });
+
+  it('falls back to String(msg) for non-serializable payloads', () => {
+    vi.stubEnv('DEBUG_AGENT_SDK', 'true');
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(() => sdkDebug('tx', cyclic)).not.toThrow();
+    expect(logSpy).toHaveBeenCalledOnce();
+  });
+
+  it('isSdkDebugEnabled reflects the current env', () => {
+    vi.stubEnv('DEBUG_AGENT_SDK', 'true');
+    expect(isSdkDebugEnabled()).toBe(true);
+    vi.stubEnv('DEBUG_AGENT_SDK', 'false');
+    expect(isSdkDebugEnabled()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces `onceIterator` + `q.streamInput(...)` with a persistent `InputQueue` passed as the `prompt` to `query({...})`, fixing the `ProcessTransport is not ready for writing` failure on turn 2 introduced by #776.
- Hardens `OutputChannel` so events pushed between per-turn SSE consumer iterations aren't dropped into stale resolvers.
- Adds `DEBUG_AGENT_SDK` env-gated structured capture at 4 SDK-boundary points (tx: session options, user messages, setPermissionMode/setModel; rx: every raw SDK message), with credential redaction.
- Closes the CI gap that let #776 merge green: new `.github/workflows/worker-live-tests.yml` runs the live suite + spike post-merge + nightly; `mock-sdk.ts` now enforces the real SDK's post-iterable-exhaustion contract so unit tests catch this regression shape.

See OpenSpec change [`fix-worker-streaminput-multi-turn`](openspec/changes/fix-worker-streaminput-multi-turn/proposal.md) for the full investigation, design rationale, and spec deltas.

## Root cause

`@anthropic-ai/claude-agent-sdk@0.2.81` `sdk.mjs`:

```
// Query.streamInput (paraphrased)
for await (const msg of stream) { transport.write(msg) }
if (count > 0 && hasBidirectionalNeeds()) await waitForFirstResult()
transport.endInput()   // closes stdin to CLI subprocess
```

The initial `AsyncIterable` prompt is consumed via the same `streamInput` routine, so even `onceIterator(initialPrompt)` triggers `endInput()` after turn 1. Any subsequent `streamInput` / `setPermissionMode` / `setModel` throws `ProcessTransport is not ready for writing`.

## Evidence

### Pre-fix (`INPUT_MODE=stream`, Build/sonnet + `SET_MODE_ON_TURN2=true`)

```
spike-idle-tolerance: IDLE_SECONDS=3, model=claude-sonnet-4-5-20250929, permissionMode=bypassPermissions, dangerousSkip=true, setModeOnTurn2=true
[turn1] msg type=system subtype=init
[turn1] msg type=assistant
[turn1] msg type=result subtype=success
FIRST RESULT received
idling for 3s...
calling setPermissionMode('bypassPermissions')...
FOLLOW-UP FAILURE: Error: ProcessTransport is not ready for writing
    at y4.write (...@anthropic-ai/claude-agent-sdk/sdk.mjs:19:7066)
    at h4.setPermissionMode (...@anthropic-ai/claude-agent-sdk/sdk.mjs:21:2523)
    at main (/app/scripts/spike-idle-tolerance.ts:219:21)
```

Full output: [`evidence/spike-1.2-stream-sonnet-build.txt`](openspec/changes/fix-worker-streaminput-multi-turn/evidence/spike-1.2-stream-sonnet-build.txt) (also reproduced in default/haiku: [`evidence/spike-1.2-stream-haiku.txt`](openspec/changes/fix-worker-streaminput-multi-turn/evidence/spike-1.2-stream-haiku.txt)).

### Post-fix (`INPUT_MODE=queue`, Build/sonnet + `SET_MODE_ON_TURN2=true`)

```
FIRST RESULT received
idling for 3s...
calling setPermissionMode('bypassPermissions')...
setPermissionMode accepted
pushing follow-up through persistent input queue...
[turn2] msg type=system subtype=init
[turn2] msg type=assistant
[turn2] msg type=result subtype=success
FOLLOW-UP SUCCESS
```

Full output: [`evidence/spike-1.3-queue-sonnet-build.txt`](openspec/changes/fix-worker-streaminput-multi-turn/evidence/spike-1.3-queue-sonnet-build.txt).

### Live suite

`npm run test:live` — 4 files / 6 tests passing (`follow-up-prompts.live.test.ts`, `prompts.live.test.ts`, `file-operations.live.test.ts`, `questions-planning.live.test.ts`).

### `DEBUG_AGENT_SDK=true` verification

Reran `follow-up-prompts.live.test.ts` with the flag set. Observed **4x `[SDK tx]`** (session options with redacted credentials, initial user message, `setPermissionMode`) + **9x `[SDK rx]`** entries. Credentials confirmed redacted: `CLAUDE_CODE_OAUTH_TOKEN: "[REDACTED]"`, `GITHUB_TOKEN: "[REDACTED]"`, `GH_TOKEN: "[REDACTED]"`, `canUseTool: "[Function]"`.

## Test plan

- [x] Worker `npx tsc --noEmit` — clean
- [x] Worker `npm test` — 217/217 passing across 17 files (includes new `input-queue.test.ts`, `output-channel.test.ts`, `sdk-debug.test.ts`, and updated `session-manager.test.ts` mock-contract test)
- [x] `dotnet test` — 2287 passed, 7 skipped, 0 failed (worker change is isolated; run for completeness)
- [x] `docker build -t homespun-worker:local ./src/Homespun.Worker` — clean
- [x] `npm run test:live` — 6/6 live tests passing
- [x] Spike `INPUT_MODE=stream` (both default/haiku and Build/sonnet) reproduces the pre-fix `ProcessTransport is not ready for writing`
- [x] Spike `INPUT_MODE=queue` + Build/sonnet + `SET_MODE_ON_TURN2=true` reaches `FOLLOW-UP SUCCESS`
- [x] With `DEBUG_AGENT_SDK=true`, all four capture points fire with credentials redacted
- [ ] New `worker-live-tests.yml` scheduled workflow lands green on its first push to `main` after merge (post-merge verification)

## Breaking changes

None externally visible. Internal test assertions that probed `q.streamInput` now assert `inputQueue.push` instead.

## Rollback

Revertible. Revert restores the known-broken #776 state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)