### PR TITLE
fix: client-telemetry route + SingleContainer Windows paths

### DIFF
--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -1,0 +1,19 @@
+# Windows-only docker-compose overlay used by `scripts/mock.ps1 -WithWorker`.
+# Opt-in: this file is loaded via `docker compose -f docker-compose.yml -f
+# docker-compose.windows.yml up worker`, never by the default compose flow, so
+# Linux/macOS dev and production deployments are unaffected.
+#
+# Why: the worker is a Linux container but the host-side backend emits sessions
+# whose WorkingDirectory is a Windows path (C:\Users\...). The SDK's cwd must
+# resolve inside the container, so we bind-mount the host workspace root at
+# /workdir and the SingleContainer shim rewrites the path prefix before
+# forwarding the session request.
+#
+# HOMESPUN_WORKSPACE is set by scripts/mock.ps1 (defaults to
+# %USERPROFILE%\.homespun\projects). The same value must be passed to the
+# backend as AgentExecution__SingleContainer__HostWorkspaceRoot so the shim
+# knows how to translate it.
+services:
+  worker:
+    volumes:
+      - ${HOMESPUN_WORKSPACE}:/workdir

--- a/scripts/mock.ps1
+++ b/scripts/mock.ps1
@@ -67,7 +67,7 @@ function Stop-ComposeWorker {
     Write-Host "Stopping docker-compose worker..." -ForegroundColor Cyan
     Push-Location $ProjectRoot
     try {
-        & docker compose stop worker | Out-Null
+        & docker compose -f docker-compose.yml -f docker-compose.windows.yml stop worker | Out-Null
     } catch {
         Write-Host "Failed to stop worker: $_" -ForegroundColor Yellow
     } finally {
@@ -82,11 +82,24 @@ if ($WithWorker) {
         exit 1
     }
 
+    # Bind-mount the host workspace root into the worker so the Linux container
+    # can resolve Windows-format WorkingDirectory paths. The SingleContainer shim
+    # rewrites the prefix from $HOMESPUN_WORKSPACE → /workdir before forwarding.
+    # Defaults to the standard Homespun clone root.
+    if (-not $env:HOMESPUN_WORKSPACE) {
+        $env:HOMESPUN_WORKSPACE = Join-Path $env:USERPROFILE ".homespun\projects"
+    }
+    if (-not (Test-Path $env:HOMESPUN_WORKSPACE)) {
+        Write-Host "Creating workspace root at $env:HOMESPUN_WORKSPACE..." -ForegroundColor Cyan
+        New-Item -ItemType Directory -Path $env:HOMESPUN_WORKSPACE -Force | Out-Null
+    }
+    Write-Host "Mounting $env:HOMESPUN_WORKSPACE -> /workdir in worker container." -ForegroundColor Cyan
+
     Write-Host "Starting docker-compose worker on host port $WorkerHostPort..." -ForegroundColor Cyan
     Push-Location $ProjectRoot
     try {
         $env:WORKER_HOST_PORT = $WorkerHostPort
-        & docker compose up -d worker
+        & docker compose -f docker-compose.yml -f docker-compose.windows.yml up -d worker
         if ($LASTEXITCODE -ne 0) {
             throw "docker compose up -d worker failed"
         }
@@ -113,6 +126,7 @@ if ($WithWorker) {
 
     $env:AgentExecution__Mode = "SingleContainer"
     $env:AgentExecution__SingleContainer__WorkerUrl = "http://localhost:$WorkerHostPort"
+    $env:AgentExecution__SingleContainer__HostWorkspaceRoot = $env:HOMESPUN_WORKSPACE
     $env:ASPNETCORE_ENVIRONMENT = "Development"
     # The `mock` launch profile enables HOMESPUN_MOCK_MODE which bypasses the
     # real agent-execution registration entirely. With --WithWorker the point
@@ -121,16 +135,28 @@ if ($WithWorker) {
     $env:MockMode__Enabled = "false"
 }
 
-# Build the dotnet run command args
+# Build the dotnet run command args. With -WithWorker we skip the `mock`
+# launch profile entirely: that profile forces ASPNETCORE_ENVIRONMENT=Mock
+# and HOMESPUN_MOCK_MODE=true, which would override the env vars set above
+# and cause the server to register MockAgentExecutionService instead of the
+# SingleContainer shim we actually want. Without the profile we set the
+# application URL explicitly.
+$BackendPort = if ($Port -ne 0) { $Port } else { 5101 }
 $dotnetArgs = @(
     "run"
     "--project", $ProjectPath
-    "--launch-profile", "mock"
 )
 
-if ($Port -ne 0) {
+if ($WithWorker) {
     $dotnetArgs += "--urls"
-    $dotnetArgs += "http://localhost:$Port"
+    $dotnetArgs += "http://localhost:$BackendPort"
+} else {
+    $dotnetArgs += "--launch-profile"
+    $dotnetArgs += "mock"
+    if ($Port -ne 0) {
+        $dotnetArgs += "--urls"
+        $dotnetArgs += "http://localhost:$Port"
+    }
 }
 
 # Foreground mode: original behavior (backend only, output to terminal)

--- a/src/Homespun.Server/Features/ClaudeCode/Hubs/ClaudeCodeHub.cs
+++ b/src/Homespun.Server/Features/ClaudeCode/Hubs/ClaudeCodeHub.cs
@@ -1,23 +1,61 @@
 using System.Text.Json;
 using Homespun.Features.ClaudeCode.Services;
 using Homespun.Features.ClaudeCode.Settings;
+using Homespun.Features.Observability;
+using Homespun.Shared.Models.Observability;
 using Homespun.Shared.Models.Sessions;
 using Homespun.Shared.Requests;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Options;
 
 namespace Homespun.Features.ClaudeCode.Hubs;
 
 /// <summary>
 /// SignalR hub for Claude Code session real-time communication.
 /// </summary>
-public class ClaudeCodeHub(IClaudeSessionService sessionService) : Hub
+public class ClaudeCodeHub(
+    IClaudeSessionService sessionService,
+    ILogger<ClaudeCodeHub> logger,
+    IOptions<SessionEventLogOptions> sessionEventLogOptions) : Hub
 {
+    private readonly SessionEventLogOptions _sessionEventLogOptions = sessionEventLogOptions.Value;
+
+    public override Task OnConnectedAsync()
+    {
+        SessionEventLog.LogHubHop(
+            logger,
+            _sessionEventLogOptions,
+            SessionEventHops.ServerHubConnected,
+            sessionId: "unknown",
+            connectionId: Context.ConnectionId);
+        return base.OnConnectedAsync();
+    }
+
+    public override Task OnDisconnectedAsync(Exception? exception)
+    {
+        SessionEventLog.LogHubHop(
+            logger,
+            _sessionEventLogOptions,
+            SessionEventHops.ServerHubDisconnected,
+            sessionId: "unknown",
+            connectionId: Context.ConnectionId,
+            detail: exception is null ? null : $"reason={exception.Message}");
+        return base.OnDisconnectedAsync(exception);
+    }
+
     /// <summary>
     /// Join a session group to receive session-specific messages.
     /// </summary>
     public async Task JoinSession(string sessionId)
     {
         await Groups.AddToGroupAsync(Context.ConnectionId, $"session-{sessionId}");
+
+        SessionEventLog.LogHubHop(
+            logger,
+            _sessionEventLogOptions,
+            SessionEventHops.ServerHubJoin,
+            sessionId: sessionId,
+            connectionId: Context.ConnectionId);
 
         // Send current session state to the joining client
         var session = sessionService.GetSession(sessionId);
@@ -33,6 +71,13 @@ public class ClaudeCodeHub(IClaudeSessionService sessionService) : Hub
     public async Task LeaveSession(string sessionId)
     {
         await Groups.RemoveFromGroupAsync(Context.ConnectionId, $"session-{sessionId}");
+
+        SessionEventLog.LogHubHop(
+            logger,
+            _sessionEventLogOptions,
+            SessionEventHops.ServerHubLeave,
+            sessionId: sessionId,
+            connectionId: Context.ConnectionId);
     }
 
     /// <summary>

--- a/src/Homespun.Server/Features/ClaudeCode/Services/SingleContainerAgentExecutionOptions.cs
+++ b/src/Homespun.Server/Features/ClaudeCode/Services/SingleContainerAgentExecutionOptions.cs
@@ -22,4 +22,23 @@ public sealed class SingleContainerAgentExecutionOptions
     /// <c>DockerAgentExecutionOptions.RequestTimeout</c>.
     /// </summary>
     public TimeSpan RequestTimeout { get; set; } = TimeSpan.FromMinutes(30);
+
+    /// <summary>
+    /// Host-filesystem directory bind-mounted into the worker container at
+    /// <see cref="ContainerWorkspaceRoot"/>. Applies on <b>Windows hosts only</b>
+    /// — the Linux worker container can't resolve a Windows <c>C:\...</c> cwd,
+    /// so the shim rewrites that prefix to the container path before forwarding
+    /// the request. On Linux / macOS the host path already resolves inside the
+    /// container (via Docker Desktop's shared filesystem or matching paths) so
+    /// this option is ignored even if set.
+    /// </summary>
+    public string HostWorkspaceRoot { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Container-side mount point that <see cref="HostWorkspaceRoot"/> is
+    /// bind-mounted to. Must match the <c>worker.volumes</c> target in
+    /// <c>docker-compose.override.yml</c>. Default <c>/workdir</c>. Windows-only
+    /// (see <see cref="HostWorkspaceRoot"/>).
+    /// </summary>
+    public string ContainerWorkspaceRoot { get; set; } = "/workdir";
 }

--- a/src/Homespun.Server/Features/ClaudeCode/Services/SingleContainerAgentExecutionService.cs
+++ b/src/Homespun.Server/Features/ClaudeCode/Services/SingleContainerAgentExecutionService.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using Homespun.Features.ClaudeCode.Data;
@@ -115,9 +116,11 @@ public sealed class SingleContainerAgentExecutionService : IAgentExecutionServic
             _slotLock.Release();
         }
 
+        var containerWorkingDirectory = TranslateWorkingDirectoryForContainer(request.WorkingDirectory);
+
         var startBody = new
         {
-            workingDirectory = request.WorkingDirectory,
+            workingDirectory = containerWorkingDirectory,
             mode = request.Mode.ToString(),
             model = request.Model,
             prompt = request.Prompt,
@@ -310,6 +313,57 @@ public sealed class SingleContainerAgentExecutionService : IAgentExecutionServic
             new StringContent(JsonSerializer.Serialize(new { approved, keepContext, feedback }, CamelCaseJsonOptions), Encoding.UTF8, "application/json"),
             cancellationToken);
         return response.IsSuccessStatusCode;
+    }
+
+    /// <summary>
+    /// Rewrites a host working-directory path to the path the worker container
+    /// sees after bind-mounting <see cref="SingleContainerAgentExecutionOptions.HostWorkspaceRoot"/>
+    /// at <see cref="SingleContainerAgentExecutionOptions.ContainerWorkspaceRoot"/>.
+    ///
+    /// <para>
+    /// Windows-only. On Linux/macOS the host path already resolves inside the
+    /// container (Docker Desktop shared filesystem on macOS; matching paths on
+    /// Linux) so the raw value is forwarded unchanged.
+    /// </para>
+    ///
+    /// <para>
+    /// Throws <see cref="InvalidOperationException"/> when the shim is running
+    /// on Windows and the caller's <paramref name="hostWorkingDirectory"/> is
+    /// not under <c>HostWorkspaceRoot</c> — forwarding a raw Windows path to a
+    /// Linux worker breaks the SDK's <c>cwd</c> resolution and produces the
+    /// misleading "Claude Code executable not found" error.
+    /// </para>
+    /// </summary>
+    internal string TranslateWorkingDirectoryForContainer(string hostWorkingDirectory)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return hostWorkingDirectory;
+        }
+
+        if (string.IsNullOrEmpty(_options.HostWorkspaceRoot))
+        {
+            throw new InvalidOperationException(
+                "AgentExecution:SingleContainer:HostWorkspaceRoot must be configured on Windows so the shim can rewrite host paths to the worker container's mount point.");
+        }
+
+        var hostRoot = Path.GetFullPath(_options.HostWorkspaceRoot).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var requested = Path.GetFullPath(hostWorkingDirectory).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        if (!requested.StartsWith(hostRoot, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"WorkingDirectory '{hostWorkingDirectory}' is not under HostWorkspaceRoot '{_options.HostWorkspaceRoot}'. SingleContainer mode can only run sessions whose working directory sits inside the mounted workspace.");
+        }
+
+        var relative = requested.Length == hostRoot.Length
+            ? string.Empty
+            : requested[(hostRoot.Length + 1)..];
+        var containerRoot = _options.ContainerWorkspaceRoot.TrimEnd('/');
+        var containerRelative = relative.Replace('\\', '/');
+        return string.IsNullOrEmpty(containerRelative)
+            ? containerRoot
+            : $"{containerRoot}/{containerRelative}";
     }
 
     public Task<CloneContainerState?> GetCloneContainerStateAsync(string workingDirectory, CancellationToken cancellationToken = default)

--- a/src/Homespun.Server/Features/Observability/SessionEventLog.cs
+++ b/src/Homespun.Server/Features/Observability/SessionEventLog.cs
@@ -155,6 +155,50 @@ public static class SessionEventLog
     }
 
     /// <summary>
+    /// Logs a hub-lifecycle hop (connect / disconnect / join / leave). These are
+    /// diagnostic-only — they do not correspond to an A2A or AG-UI event — but
+    /// they share the log schema so one LogQL query pinned to <c>SessionId</c>
+    /// returns lifecycle + event hops together.
+    /// </summary>
+    public static void LogHubHop(
+        ILogger logger,
+        SessionEventLogOptions options,
+        string hop,
+        string sessionId,
+        string? connectionId = null,
+        string? detail = null)
+    {
+        if (!ShouldLog(logger, options, hop))
+        {
+            return;
+        }
+
+        var parts = new List<string> { hop };
+        if (!string.IsNullOrEmpty(connectionId))
+        {
+            parts.Add($"conn={ShortId(connectionId!)}");
+        }
+        if (!string.IsNullOrEmpty(detail))
+        {
+            parts.Add(detail!);
+        }
+
+        var entry = new SessionEventLogEntry
+        {
+            Timestamp = DateTimeOffset.UtcNow.ToString("O"),
+            Level = "Information",
+            Message = string.Join(' ', parts),
+            SourceContext = SessionEventSourceContexts.Server,
+            Component = SessionEventComponents.Server,
+            Hop = hop,
+            SessionId = sessionId,
+            ContentPreview = connectionId is null ? null : $"connectionId={connectionId}",
+        };
+
+        Emit(entry);
+    }
+
+    /// <summary>
     /// Writes a prebuilt entry to the server-side log stream under
     /// <see cref="SessionEventSourceContexts.Client"/>. Used by
     /// <c>POST /api/log/client</c> to forward browser-originated entries.

--- a/src/Homespun.Shared/Models/Observability/SessionEventLogEntry.cs
+++ b/src/Homespun.Shared/Models/Observability/SessionEventLogEntry.cs
@@ -76,6 +76,20 @@ public static class SessionEventHops
     public const string ClientSignalrRx = "client.signalr.rx";
     public const string ClientReducerApply = "client.reducer.apply";
 
+    // Hub lifecycle diagnostics. Not part of the event fan-out but necessary to
+    // distinguish "client never connected" / "client never joined group" from
+    // "server broadcast never reached client".
+    public const string ServerHubConnected = "server.hub.connected";
+    public const string ServerHubDisconnected = "server.hub.disconnected";
+    public const string ServerHubJoin = "server.hub.join";
+    public const string ServerHubLeave = "server.hub.leave";
+    public const string ClientSignalrConnect = "client.signalr.connect";
+    public const string ClientSignalrDisconnect = "client.signalr.disconnect";
+    public const string ClientSignalrReconnecting = "client.signalr.reconnecting";
+    public const string ClientSignalrReconnected = "client.signalr.reconnected";
+    public const string ClientSignalrJoin = "client.signalr.join";
+    public const string ClientSignalrJoinError = "client.signalr.join.error";
+
     public static readonly IReadOnlyList<string> All =
     [
         WorkerA2AEmit,
@@ -85,6 +99,16 @@ public static class SessionEventHops
         ServerSignalrTx,
         ClientSignalrRx,
         ClientReducerApply,
+        ServerHubConnected,
+        ServerHubDisconnected,
+        ServerHubJoin,
+        ServerHubLeave,
+        ClientSignalrConnect,
+        ClientSignalrDisconnect,
+        ClientSignalrReconnecting,
+        ClientSignalrReconnected,
+        ClientSignalrJoin,
+        ClientSignalrJoinError,
     ];
 }
 

--- a/src/Homespun.Web/src/api/client.ts
+++ b/src/Homespun.Web/src/api/client.ts
@@ -263,7 +263,7 @@ function getPathFromUrl(url: string): string {
 function isExcludedFromTelemetry(url: string): boolean {
   const path = getPathFromUrl(url)
   return (
-    path.includes('/api/clienttelemetry') || path.includes('/health') || path.includes('/metrics')
+    path.includes('/api/client-telemetry') || path.includes('/health') || path.includes('/metrics')
   )
 }
 

--- a/src/Homespun.Web/src/features/sessions/hooks/use-session.ts
+++ b/src/Homespun.Web/src/features/sessions/hooks/use-session.ts
@@ -3,6 +3,7 @@ import { useClaudeCodeHub } from '@/providers/signalr-provider'
 import { useSessionSettingsStore } from '@/stores/session-settings-store'
 import { normalizeSessionMode } from '@/lib/utils/session-mode'
 import type { ClaudeSession } from '@/types/signalr'
+import { sessionEventLog } from '@/lib/session-event-log'
 
 export interface UseSessionResult {
   session: ClaudeSession | null | undefined
@@ -76,6 +77,10 @@ export function useSession(sessionId: string): UseSessionResult {
     fetchSession()
 
     // Join session group
+    sessionEventLog('client.signalr.join', {
+      SessionId: sessionId,
+      Message: `client.signalr.join sessionId=${sessionId}`,
+    })
     methods
       .joinSession(sessionId)
       .then(() => {
@@ -84,8 +89,13 @@ export function useSession(sessionId: string): UseSessionResult {
           setIsJoined(true)
         }
       })
-      .catch(() => {
+      .catch((err: unknown) => {
         // Join failed, ensure isJoined stays false
+        sessionEventLog('client.signalr.join.error', {
+          SessionId: sessionId,
+          Level: 'Error',
+          Message: `client.signalr.join.error ${err instanceof Error ? err.message : String(err)}`,
+        })
         if (isMountedRef.current) {
           hasJoinedRef.current = false
           setIsJoined(false)
@@ -118,6 +128,10 @@ export function useSession(sessionId: string): UseSessionResult {
 
       // Re-join the current session
       const currentSessionId = currentSessionIdRef.current
+      sessionEventLog('client.signalr.join', {
+        SessionId: currentSessionId,
+        Message: `client.signalr.join (rejoin) sessionId=${currentSessionId}`,
+      })
       methods
         .joinSession(currentSessionId)
         .then(() => {
@@ -126,7 +140,12 @@ export function useSession(sessionId: string): UseSessionResult {
             setIsJoined(true)
           }
         })
-        .catch(() => {
+        .catch((err: unknown) => {
+          sessionEventLog('client.signalr.join.error', {
+            SessionId: currentSessionId,
+            Level: 'Error',
+            Message: `client.signalr.join.error (rejoin) ${err instanceof Error ? err.message : String(err)}`,
+          })
           if (isMountedRef.current) {
             hasJoinedRef.current = false
             setIsJoined(false)

--- a/src/Homespun.Web/src/lib/telemetry/telemetry-batcher.test.ts
+++ b/src/Homespun.Web/src/lib/telemetry/telemetry-batcher.test.ts
@@ -283,7 +283,7 @@ describe('TelemetryBatcher', () => {
       window.dispatchEvent(new Event('beforeunload'))
 
       expect(mockSendBeacon).toHaveBeenCalledWith(
-        '/api/clienttelemetry',
+        '/api/client-telemetry',
         JSON.stringify({
           sessionId: 'test-session-id',
           events: [event],

--- a/src/Homespun.Web/src/lib/telemetry/telemetry-batcher.ts
+++ b/src/Homespun.Web/src/lib/telemetry/telemetry-batcher.ts
@@ -23,7 +23,7 @@ export class TelemetryBatcher {
       batchSize: 50,
       flushInterval: 10000, // 10 seconds
       maxRetries: 3,
-      endpoint: '/api/clienttelemetry',
+      endpoint: '/api/client-telemetry',
       ...config,
     }
 

--- a/src/Homespun.Web/src/lib/telemetry/telemetry-service.test.ts
+++ b/src/Homespun.Web/src/lib/telemetry/telemetry-service.test.ts
@@ -51,7 +51,7 @@ describe('TelemetryService', () => {
 
       await service.flush()
 
-      expect(mockFetch).toHaveBeenCalledWith('/api/clienttelemetry', {
+      expect(mockFetch).toHaveBeenCalledWith('/api/client-telemetry', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/Homespun.Web/src/lib/telemetry/telemetry-service.ts
+++ b/src/Homespun.Web/src/lib/telemetry/telemetry-service.ts
@@ -19,7 +19,7 @@ export class TelemetryService {
   constructor(config: TelemetryConfig = {}) {
     this.config = {
       enabled: true,
-      endpoint: '/api/clienttelemetry',
+      endpoint: '/api/client-telemetry',
       batchSize: 50,
       flushInterval: 10000,
       ...config,

--- a/src/Homespun.Web/src/providers/signalr-provider.tsx
+++ b/src/Homespun.Web/src/providers/signalr-provider.tsx
@@ -23,6 +23,29 @@ import {
   type NotificationHubMethods,
 } from '@/lib/signalr/notification-hub'
 import type { ConnectionStatus } from '@/types/signalr'
+import { sessionEventLog } from '@/lib/session-event-log'
+
+/**
+ * Map Claude Code hub connection status to a session-event-log hop name so
+ * Loki can stitch the full "user opened page → hub connected → joined session
+ * → envelopes arrived" timeline from one query.
+ */
+function logClaudeCodeStatus(status: ConnectionStatus, error?: string): void {
+  const hop =
+    status === 'connected'
+      ? 'client.signalr.connect'
+      : status === 'disconnected'
+        ? 'client.signalr.disconnect'
+        : status === 'reconnecting'
+          ? 'client.signalr.reconnecting'
+          : null
+  if (!hop) return
+  sessionEventLog(hop, {
+    SessionId: 'hub',
+    Level: error ? 'Warning' : 'Information',
+    Message: error ? `${hop} error=${error}` : hop,
+  })
+}
 
 // ============================================================================
 // Context Types
@@ -124,8 +147,12 @@ export function SignalRProvider({
       onStatusChange: (status, error) => {
         setClaudeCodeStatus(status)
         setClaudeCodeError(error)
+        logClaudeCodeStatus(status, error)
       },
-      onReconnected: () => onClaudeCodeReconnectedRef.current?.(),
+      onReconnected: () => {
+        sessionEventLog('client.signalr.reconnected', { SessionId: 'hub' })
+        onClaudeCodeReconnectedRef.current?.()
+      },
     })
     setClaudeCodeConnection(claudeCodeConn)
     setClaudeCodeMethods(createClaudeCodeHubMethods(claudeCodeConn))
@@ -147,6 +174,7 @@ export function SignalRProvider({
       startConnection(claudeCodeConn, (status, error) => {
         setClaudeCodeStatus(status)
         setClaudeCodeError(error)
+        logClaudeCodeStatus(status, error)
       })
       startConnection(notificationConn, (status, error) => {
         setNotificationStatus(status)

--- a/src/Homespun.Web/src/providers/telemetry-provider.tsx
+++ b/src/Homespun.Web/src/providers/telemetry-provider.tsx
@@ -24,7 +24,7 @@ export function TelemetryProvider({ children, enabled = true, endpoint }: Teleme
 
     serviceRef.current = new TelemetryService({
       enabled: telemetryEnabled,
-      endpoint: endpoint || import.meta.env.VITE_TELEMETRY_ENDPOINT || '/api/clienttelemetry',
+      endpoint: endpoint || import.meta.env.VITE_TELEMETRY_ENDPOINT || '/api/client-telemetry',
       batchSize: import.meta.env.VITE_TELEMETRY_BATCH_SIZE
         ? parseInt(import.meta.env.VITE_TELEMETRY_BATCH_SIZE, 10)
         : 50,

--- a/tests/Homespun.Tests/Features/ClaudeCode/SingleContainerAgentExecutionServiceTests.cs
+++ b/tests/Homespun.Tests/Features/ClaudeCode/SingleContainerAgentExecutionServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Homespun.Features.ClaudeCode.Exceptions;
 using Homespun.Features.ClaudeCode.Services;
 using Homespun.Features.Observability;
@@ -14,11 +15,15 @@ public class SingleContainerAgentExecutionServiceTests
 {
     private static SingleContainerAgentExecutionService Build(
         string? workerUrl = "http://localhost:8081",
-        ISessionEventIngestor? ingestor = null)
+        ISessionEventIngestor? ingestor = null,
+        string hostWorkspaceRoot = "",
+        string containerWorkspaceRoot = "/workdir")
     {
         var opts = Options.Create(new SingleContainerAgentExecutionOptions
         {
             WorkerUrl = workerUrl ?? string.Empty,
+            HostWorkspaceRoot = hostWorkspaceRoot,
+            ContainerWorkspaceRoot = containerWorkspaceRoot,
         });
         return new SingleContainerAgentExecutionService(
             opts,
@@ -130,5 +135,81 @@ public class SingleContainerAgentExecutionServiceTests
         Assert.That(ex.CurrentSessionId, Is.EqualTo("current"));
         Assert.That(ex.Message, Does.Contain("requested"));
         Assert.That(ex.Message, Does.Contain("current"));
+    }
+
+    [Test]
+    public void TranslateWorkingDirectory_NonWindowsHost_PassesThroughUnchanged()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.Ignore("Test asserts non-Windows behaviour.");
+            return;
+        }
+
+        using var svc = Build(hostWorkspaceRoot: "/home/dev/projects", containerWorkspaceRoot: "/workdir");
+        var result = svc.TranslateWorkingDirectoryForContainer("/home/dev/projects/smoke/main");
+        Assert.That(result, Is.EqualTo("/home/dev/projects/smoke/main"));
+    }
+
+    [Test]
+    public void TranslateWorkingDirectory_WindowsHost_RewritesPrefixToContainerPath()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.Ignore("Test asserts Windows path-rewriting behaviour.");
+            return;
+        }
+
+        using var svc = Build(
+            hostWorkspaceRoot: @"C:\Users\dev\.homespun\projects",
+            containerWorkspaceRoot: "/workdir");
+        var result = svc.TranslateWorkingDirectoryForContainer(@"C:\Users\dev\.homespun\projects\smoke\main");
+        Assert.That(result, Is.EqualTo("/workdir/smoke/main"));
+    }
+
+    [Test]
+    public void TranslateWorkingDirectory_WindowsHost_RootItselfMapsToContainerRoot()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.Ignore("Test asserts Windows path-rewriting behaviour.");
+            return;
+        }
+
+        using var svc = Build(
+            hostWorkspaceRoot: @"C:\Users\dev\.homespun\projects",
+            containerWorkspaceRoot: "/workdir");
+        var result = svc.TranslateWorkingDirectoryForContainer(@"C:\Users\dev\.homespun\projects");
+        Assert.That(result, Is.EqualTo("/workdir"));
+    }
+
+    [Test]
+    public void TranslateWorkingDirectory_WindowsHost_PathOutsideWorkspaceRoot_Throws()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.Ignore("Test asserts Windows path-rewriting behaviour.");
+            return;
+        }
+
+        using var svc = Build(
+            hostWorkspaceRoot: @"C:\Users\dev\.homespun\projects",
+            containerWorkspaceRoot: "/workdir");
+        Assert.Throws<InvalidOperationException>(
+            () => svc.TranslateWorkingDirectoryForContainer(@"D:\other\path"));
+    }
+
+    [Test]
+    public void TranslateWorkingDirectory_WindowsHost_EmptyWorkspaceRoot_Throws()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.Ignore("Test asserts Windows path-rewriting behaviour.");
+            return;
+        }
+
+        using var svc = Build(hostWorkspaceRoot: "", containerWorkspaceRoot: "/workdir");
+        Assert.Throws<InvalidOperationException>(
+            () => svc.TranslateWorkingDirectoryForContainer(@"C:\anything"));
     }
 }


### PR DESCRIPTION
## Summary

- Correct client-telemetry endpoint from `/api/clienttelemetry` → `/api/client-telemetry` (the server route has a hyphen), restoring the previously-404ing batched telemetry path.
- Make `scripts/mock.ps1 -WithWorker` actually reach the SingleContainer shim by skipping the `mock` launch profile (which forced `ASPNETCORE_ENVIRONMENT=Mock` and short-circuited the gate in `Program.cs`).
- Translate host paths to container paths inside `SingleContainerAgentExecutionService` on Windows so the Linux worker can resolve the SDK's `cwd` (root cause of the misleading `Claude Code executable not found at /app/node_modules/@anthropic-ai/claude-agent-sdk/cli.js` `RUN_ERROR`). Linux/macOS hosts are pass-through.
- Add hub-lifecycle hops (`server.hub.{connected,disconnected,join,leave}`, `client.signalr.{connect,disconnect,reconnecting,reconnected,join,join.error}`) to the existing six-hop session-event log so future silent breaks in the SignalR path pinpoint exactly which hop dropped the event.

## Details

Original report: client telemetry returning 404, messages not reaching the chat window. The 404 was the wrong client endpoint. The chat regression turned out to be a combination of the SingleContainer shim never actually registering (mock launch profile wins) and, once registered, forwarding Windows-format working directories to the Linux worker. Added hub lifecycle logging so the next regression is diagnosable from `{SessionId}` logs alone.

`docker-compose.windows.yml` is opt-in (`docker compose -f docker-compose.yml -f docker-compose.windows.yml`) so Linux dev and production are unaffected.

## Test plan

- [x] `dotnet test tests/Homespun.Tests --filter SingleContainerAgentExecutionService` — 11 pass, 1 skipped (non-Windows branch, skipped on Windows host)
- [x] `dotnet test tests/Homespun.Tests --filter Observability` — 73/73 pass
- [x] Frontend `vitest run src/lib/telemetry src/lib/session-event-log.test.ts` — 39/39 pass
- [x] `tsc -b --noEmit` clean; `npm run lint` 0 errors
- [x] Live end-to-end: `./scripts/mock.ps1 -WithWorker` against a real Claude Agent SDK worker. Created session via `POST /api/sessions`, observed hop chain `server.sse.rx → server.agui.translate → server.signalr.tx → server.hub.join → client.signalr.join → client.reducer.apply` for seq=1 RUN_STARTED, seq=3 CUSTOM system.init, seq=4 TEXT_MESSAGE_START/CONTENT/END "Hi!", seq=6 RUN_FINISHED. No `RUN_ERROR`.
- [ ] Linux / macOS smoke (no regression in existing `scripts/mock.sh` flow — touch-free: `mock.sh` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)