### PR TITLE
fix: deliver post-result SDK task notifications live via long-lived session event stream

### DIFF
--- a/docs/superpowers/plans/2026-04-24-long-lived-session-events.md
+++ b/docs/superpowers/plans/2026-04-24-long-lived-session-events.md
@@ -1,0 +1,1205 @@
+# Long-lived session-event stream (post-result buffering fix) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver SDK task-notification events that arrive after a `result` message to the client in real time, instead of buffering them in the worker's `OutputChannel` until the user sends the next prompt.
+
+**Architecture:** Decouple event streaming from the per-turn HTTP request cycle. Add a long-lived `GET /api/sessions/:id/events` SSE endpoint on the worker that stays open for the life of the session. `POST /sessions` and `POST /sessions/:id/message` become JSON-returning control-plane calls (no SSE body). A new server-side `PerSessionEventStream` service runs a background task per worker session that consumes the long-lived stream, drives `ISessionEventIngestor` (for SignalR broadcast to the client), and fans out `SdkMessage`s to per-turn consumers via a `Channel<SdkMessage>`. The existing `IAgentExecutionService.StartSessionAsync` / `SendMessageAsync` contracts (returning `IAsyncEnumerable<SdkMessage>`) are preserved by reading from the fan-out channel.
+
+**Tech Stack:** ASP.NET 10, Hono 4 (Node 20), System.Threading.Channels, OpenTelemetry SDK, NUnit + Moq, Vitest.
+
+---
+
+## File Structure
+
+**New:**
+- `src/Homespun.Worker/src/routes/sessions.ts` — add `GET /api/sessions/:id/events` handler (long-lived SSE).
+- `src/Homespun.Server/Features/ClaudeCode/Services/IPerSessionEventStream.cs` — interface.
+- `src/Homespun.Server/Features/ClaudeCode/Services/PerSessionEventStream.cs` — impl.
+- `tests/Homespun.Tests/ClaudeCode/PerSessionEventStreamTests.cs` — unit tests.
+- `tests/Homespun.Api.Tests/Sessions/PostResultTaskNotificationTests.cs` — integration test.
+
+**Modify:**
+- `src/Homespun.Worker/src/services/sse-writer.ts` — remove the `return` on `msg.type === "result"`.
+- `src/Homespun.Worker/src/routes/sessions.ts` — `POST /sessions`, `POST /sessions/:id/message`, `POST /sessions/:id/clear-context` return JSON instead of SSE.
+- `src/Homespun.Server/Features/ClaudeCode/Services/DockerAgentExecutionService.cs` — replace `SendSseRequestAsync` usage with `PerSessionEventStream` subscriptions. Remove the `SdkResultMessage → yield break` early-termination in the SSE parser (moved into subscriber loop).
+- `src/Homespun.Server/Features/ClaudeCode/Services/SingleContainerAgentExecutionService.cs` — same treatment.
+- `src/Homespun.Server/Features/ClaudeCode/Services/MessageProcessingService.cs` — no signature change, but document that the `IAsyncEnumerable<SdkMessage>` it now receives comes from the fan-out channel.
+- `src/Homespun.Server/Program.cs` — register `IPerSessionEventStream` singleton.
+- `src/Homespun.Worker/src/routes/sessions.test.ts` (if present) — update expectations for JSON responses.
+
+**Do NOT touch unless driven by a test failure:**
+- `src/Homespun.Server/Features/ClaudeCode/Services/MessageProcessingService.cs` control-plane logic (still breaks on `SdkResultMessage`).
+- `src/Homespun.Web/**` — client is unchanged.
+- `src/Homespun.Server/Features/Testing/Services/MockAgentExecutionService.cs` — it builds its own `IAsyncEnumerable<SdkMessage>` without an SSE round-trip; no change needed.
+
+---
+
+## Task 1: Worker — strip the `return` on `result` in `sse-writer`
+
+**Files:**
+- Modify: `src/Homespun.Worker/src/services/sse-writer.ts:244-256`
+- Test: `src/Homespun.Worker/src/services/sse-writer.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `sse-writer.test.ts`:
+
+```ts
+import { streamSessionEvents } from './sse-writer.js';
+
+it('continues emitting after a result message', async () => {
+  const sm = buildMockSessionManager({
+    events: [
+      { type: 'assistant', message: { content: [{ type: 'text', text: 'hi' }] } },
+      { type: 'result', subtype: 'success', is_error: false, duration_ms: 1, duration_api_ms: 1, num_turns: 1, total_cost_usd: 0, session_id: 's', result: '' },
+      { type: 'system', subtype: 'task_notification', task_id: 't', status: 'completed', output_file: '/x', summary: 'ok', session_id: 's', uuid: 'u' },
+    ],
+  });
+  const chunks: string[] = [];
+  for await (const chunk of streamSessionEvents(sm, 's')) chunks.push(chunk);
+  const kinds = chunks.map(c => c.match(/^event: (\w+)/)?.[1]);
+  expect(kinds).toContain('status-update'); // the result
+  expect(kinds.filter(k => k === 'message').length).toBeGreaterThanOrEqual(2); // assistant + task_notification
+});
+```
+
+- [ ] **Step 2: Run the test and verify failure**
+
+```
+cd src/Homespun.Worker && npm test -- sse-writer
+```
+
+Expected: FAIL — the generator currently returns after the result status-update, so only one `message` event appears before close.
+
+- [ ] **Step 3: Remove the early return**
+
+In `sse-writer.ts:244-256`, change:
+
+```ts
+if (msg.type === "result") {
+  // Result -> TaskStatusUpdateEvent with completed/failed, final: true
+  const r = msg as any;
+  info(`A2A result: subtype='${r.subtype}', is_error=${r.is_error}`);
+  const finalState = r.is_error ? "failed" : "completed";
+  info(
+    `A2A state transition: working → ${finalState} (sessionId: ${sessionId})`,
+  );
+
+  const statusUpdate = translateResultToStatus(msg, ctx);
+  yield emitAndFormatSSE(sessionId, statusUpdate.kind, statusUpdate);
+  return;
+}
+```
+
+to:
+
+```ts
+if (msg.type === "result") {
+  const r = msg as any;
+  info(`A2A result: subtype='${r.subtype}', is_error=${r.is_error}`);
+  const finalState = r.is_error ? "failed" : "completed";
+  info(
+    `A2A state transition: working → ${finalState} (sessionId: ${sessionId})`,
+  );
+
+  const statusUpdate = translateResultToStatus(msg, ctx);
+  yield emitAndFormatSSE(sessionId, statusUpdate.kind, statusUpdate);
+  // Do NOT return — the SDK query iterator stays open across turns and still
+  // emits task_notification / task_updated / task_started events as background
+  // tools complete. The long-lived GET /events consumer on the server is
+  // responsible for draining them.
+  continue;
+}
+```
+
+- [ ] **Step 4: Run the test and verify pass**
+
+```
+cd src/Homespun.Worker && npm test -- sse-writer
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Homespun.Worker/src/services/sse-writer.ts src/Homespun.Worker/src/services/sse-writer.test.ts
+git commit -m "fix(worker): do not terminate SSE stream on SDK result message"
+```
+
+---
+
+## Task 2: Worker — add long-lived `GET /api/sessions/:id/events` endpoint
+
+**Files:**
+- Modify: `src/Homespun.Worker/src/routes/sessions.ts` (add route before existing `:id` GET)
+- Test: `src/Homespun.Worker/src/routes/sessions.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `sessions.test.ts`:
+
+```ts
+it('GET /api/sessions/:id/events streams events across result boundaries', async () => {
+  const { app, sessionId, push } = await bootWorkerWithSession();
+  const res = await app.request(`/api/sessions/${sessionId}/events`);
+  const reader = res.body!.getReader();
+  push({ type: 'assistant', message: { content: [{ type: 'text', text: 'a' }] } });
+  push({ type: 'result', subtype: 'success', session_id: 's', is_error: false, duration_ms: 1, duration_api_ms: 1, num_turns: 1, total_cost_usd: 0, result: '' });
+  push({ type: 'system', subtype: 'task_notification', task_id: 't', status: 'completed', output_file: '/x', summary: 'ok', session_id: 's', uuid: 'u' });
+  const buf = await readN(reader, 3);
+  expect(buf.split('event: status-update').length - 1).toBe(1);
+  expect(buf.split('event: message').length - 1).toBeGreaterThanOrEqual(2);
+});
+```
+
+(Assumes a helper `bootWorkerWithSession` and `readN` in the existing test harness. If absent, implement them similarly to the existing route tests using the worker's Hono app instance.)
+
+- [ ] **Step 2: Run the test and verify failure**
+
+```
+cd src/Homespun.Worker && npm test -- sessions
+```
+
+Expected: FAIL — 404, no such route.
+
+- [ ] **Step 3: Add the route**
+
+Insert into `src/Homespun.Worker/src/routes/sessions.ts`, immediately before the `GET /:id` handler:
+
+```ts
+// GET /sessions/:id/events - Long-lived SSE stream of session events.
+// Stays open for the life of the session; emits every A2A event including
+// task notifications that arrive after the SDK result message.
+sessions.get('/:id/events', async (c) => {
+  const sessionId = c.req.param('id');
+  info(`GET /sessions/${sessionId}/events - long-lived SSE consumer opened`);
+
+  c.header('Content-Type', 'text/event-stream');
+  c.header('Cache-Control', 'no-cache');
+  c.header('Connection', 'keep-alive');
+
+  return stream(c, async (s) => {
+    for await (const chunk of streamSessionEvents(sessionManager, sessionId)) {
+      await s.write(chunk);
+    }
+  });
+});
+```
+
+- [ ] **Step 4: Run the test and verify pass**
+
+```
+cd src/Homespun.Worker && npm test -- sessions
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Homespun.Worker/src/routes/sessions.ts src/Homespun.Worker/src/routes/sessions.test.ts
+git commit -m "feat(worker): add GET /api/sessions/:id/events long-lived SSE endpoint"
+```
+
+---
+
+## Task 3: Worker — convert `POST /sessions` to JSON response
+
+**Files:**
+- Modify: `src/Homespun.Worker/src/routes/sessions.ts:54-86`
+- Test: `src/Homespun.Worker/src/routes/sessions.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+it('POST /api/sessions returns JSON { sessionId, conversationId } and does not stream', async () => {
+  const app = buildApp();
+  const res = await app.request('/api/sessions', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ prompt: 'hi', mode: 'Build', model: 'opus', workingDirectory: '/tmp' }),
+  });
+  expect(res.headers.get('content-type')).toContain('application/json');
+  const body = await res.json();
+  expect(body.sessionId).toBeDefined();
+});
+```
+
+- [ ] **Step 2: Run the test and verify failure**
+
+```
+cd src/Homespun.Worker && npm test -- sessions
+```
+
+Expected: FAIL — response is `text/event-stream`.
+
+- [ ] **Step 3: Replace the handler body**
+
+Change `sessions.post('/', ...)` to:
+
+```ts
+sessions.post('/', async (c) => {
+  const body = await c.req.json<StartSessionRequest>();
+  info(`POST /sessions - mode=${body.mode}, model=${body.model}, workingDirectory=${body.workingDirectory}, resumeSessionId=${body.resumeSessionId || 'none'}`);
+
+  try {
+    const ws = await sessionManager.create({
+      prompt: body.prompt,
+      model: body.model,
+      mode: body.mode,
+      systemPrompt: body.systemPrompt,
+      workingDirectory: body.workingDirectory,
+      resumeSessionId: body.resumeSessionId,
+    });
+    return c.json({ sessionId: ws.id, conversationId: ws.conversationId ?? null });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return c.json({ error: message, code: 'STARTUP_ERROR' }, 500);
+  }
+});
+```
+
+- [ ] **Step 4: Run the test and verify pass**
+
+```
+cd src/Homespun.Worker && npm test -- sessions
+```
+
+Expected: PASS. Existing "streams on POST" assertions will need updating in the next steps — do not fix unrelated failures here.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Homespun.Worker/src/routes/sessions.ts src/Homespun.Worker/src/routes/sessions.test.ts
+git commit -m "feat(worker): return JSON sessionId from POST /api/sessions (no SSE body)"
+```
+
+---
+
+## Task 4: Worker — convert `POST /sessions/:id/message` to JSON response
+
+**Files:**
+- Modify: `src/Homespun.Worker/src/routes/sessions.ts:89-115`
+- Test: `src/Homespun.Worker/src/routes/sessions.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+it('POST /api/sessions/:id/message returns { ok: true } JSON', async () => {
+  const { app, sessionId } = await bootWorkerWithSession();
+  const res = await app.request(`/api/sessions/${sessionId}/message`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ message: 'hi', mode: 'Build', model: 'opus' }),
+  });
+  expect(res.headers.get('content-type')).toContain('application/json');
+  expect(await res.json()).toEqual({ ok: true });
+});
+```
+
+- [ ] **Step 2: Run the test and verify failure**
+
+Expected: FAIL — still streaming.
+
+- [ ] **Step 3: Replace the handler body**
+
+```ts
+sessions.post('/:id/message', async (c) => {
+  const sessionId = c.req.param('id');
+  const body = await c.req.json<SendMessageRequest>();
+  info(`POST /sessions/${sessionId}/message - mode=${body.mode}, messageLength=${body.message?.length}, model=${body.model}`);
+
+  try {
+    await sessionManager.send(sessionId, body.message, body.model, body.mode);
+    return c.json({ ok: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return c.json({ ok: false, error: message, code: 'MESSAGE_ERROR' }, 500);
+  }
+});
+```
+
+- [ ] **Step 4: Run the test and verify pass**
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Homespun.Worker/src/routes/sessions.ts src/Homespun.Worker/src/routes/sessions.test.ts
+git commit -m "feat(worker): return JSON from POST /api/sessions/:id/message (no SSE body)"
+```
+
+---
+
+## Task 5: Worker — convert `POST /sessions/:id/clear-context` to JSON response
+
+**Files:**
+- Modify: `src/Homespun.Worker/src/routes/sessions.ts:228-270`
+- Test: `src/Homespun.Worker/src/routes/sessions.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+it('POST /api/sessions/:id/clear-context returns { oldSessionId, newSessionId } JSON', async () => {
+  const { app, sessionId } = await bootWorkerWithSession();
+  const res = await app.request(`/api/sessions/${sessionId}/clear-context`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ prompt: 'new', mode: 'Build', model: 'opus', workingDirectory: '/tmp' }),
+  });
+  expect(res.headers.get('content-type')).toContain('application/json');
+  const body = await res.json();
+  expect(body.oldSessionId).toBe(sessionId);
+  expect(body.newSessionId).toBeDefined();
+});
+```
+
+- [ ] **Step 2: Verify failure**
+
+Expected: FAIL — still streaming.
+
+- [ ] **Step 3: Replace the handler body**
+
+```ts
+sessions.post('/:id/clear-context', async (c) => {
+  const sessionId = c.req.param('id');
+  const body = await c.req.json<ClearContextRequest>();
+  info(`POST /sessions/${sessionId}/clear-context - mode=${body.mode}, model=${body.model}`);
+
+  try {
+    const { newSession, oldSessionId } = await sessionManager.clearContextAndCreate(
+      sessionId,
+      {
+        prompt: body.prompt,
+        model: body.model,
+        mode: body.mode,
+        systemPrompt: body.systemPrompt,
+        workingDirectory: body.workingDirectory,
+      }
+    );
+    return c.json({ oldSessionId, newSessionId: newSession.id });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return c.json({ error: message, code: 'CLEAR_CONTEXT_ERROR' }, 500);
+  }
+});
+```
+
+- [ ] **Step 4: Verify pass**
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Homespun.Worker/src/routes/sessions.ts src/Homespun.Worker/src/routes/sessions.test.ts
+git commit -m "feat(worker): return JSON from POST /api/sessions/:id/clear-context"
+```
+
+---
+
+## Task 6: Server — define `IPerSessionEventStream`
+
+**Files:**
+- Create: `src/Homespun.Server/Features/ClaudeCode/Services/IPerSessionEventStream.cs`
+
+- [ ] **Step 1: Create the file**
+
+```csharp
+using Homespun.Features.ClaudeCode.Data;
+
+namespace Homespun.Features.ClaudeCode.Services;
+
+/// <summary>
+/// Per-worker-session long-lived SSE consumer. Runs a background task that
+/// reads the worker's <c>GET /api/sessions/{id}/events</c> endpoint for the
+/// full life of the session, invokes <see cref="ISessionEventIngestor"/>
+/// on every A2A event (so SignalR broadcasts never stop), and fans out
+/// parsed <see cref="SdkMessage"/> values to per-turn subscribers.
+///
+/// <para>
+/// This service exists to decouple the client-visible event stream from the
+/// per-turn HTTP request cycle. The Claude Agent SDK emits
+/// <c>SDKTaskNotificationMessage</c> / <c>SDKTaskStartedMessage</c> /
+/// <c>SDKTaskUpdatedMessage</c> as background bash tasks settle — often
+/// minutes after the <c>result</c> message that ends a turn. Before this
+/// service, those events piled up in the worker's <c>OutputChannel</c> with
+/// no consumer; now they flow through the long-lived reader and reach the
+/// client live.
+/// </para>
+/// </summary>
+public interface IPerSessionEventStream
+{
+    /// <summary>
+    /// Starts the background reader for a worker session. Idempotent —
+    /// second calls for the same <paramref name="homespunSessionId"/> are
+    /// a no-op.
+    /// </summary>
+    Task StartAsync(
+        string homespunSessionId,
+        string workerUrl,
+        string workerSessionId,
+        string? projectId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Subscribes to SDK messages for a single turn. Returned enumerable
+    /// completes after the next <see cref="SdkResultMessage"/> is yielded.
+    /// Throws if no reader is running for <paramref name="homespunSessionId"/>.
+    /// </summary>
+    IAsyncEnumerable<SdkMessage> SubscribeTurnAsync(
+        string homespunSessionId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Stops the background reader and completes any pending subscriber.
+    /// Safe to call for an unknown session id.
+    /// </summary>
+    Task StopAsync(string homespunSessionId);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/Homespun.Server/Features/ClaudeCode/Services/IPerSessionEventStream.cs
+git commit -m "feat(server): define IPerSessionEventStream interface"
+```
+
+---
+
+## Task 7: Server — implement `PerSessionEventStream`
+
+**Files:**
+- Create: `src/Homespun.Server/Features/ClaudeCode/Services/PerSessionEventStream.cs`
+- Test: `tests/Homespun.Tests/ClaudeCode/PerSessionEventStreamTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/Homespun.Tests/ClaudeCode/PerSessionEventStreamTests.cs`:
+
+```csharp
+using System.Text;
+using Homespun.Features.ClaudeCode.Data;
+using Homespun.Features.ClaudeCode.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+
+namespace Homespun.Tests.ClaudeCode;
+
+public class PerSessionEventStreamTests
+{
+    [Test]
+    public async Task Ingests_events_that_arrive_after_result()
+    {
+        var ingestor = new Mock<ISessionEventIngestor>();
+        var fake = new FakeSseServer();
+        fake.Queue("status-update", """{"kind":"status-update","taskId":"t","contextId":"c","status":{"state":"completed","timestamp":"2026-04-24T00:00:00Z"},"final":true}""");
+        fake.Queue("message", """{"kind":"message","messageId":"m2","role":"agent","parts":[{"kind":"data","data":{"subtype":"task_notification","status":"completed"},"metadata":{"kind":"task_notification"}}]}""");
+        var stream = new PerSessionEventStream(ingestor.Object, fake.HttpClient, NullLogger<PerSessionEventStream>.Instance);
+        await stream.StartAsync("s", fake.BaseUrl, "w", "p", CancellationToken.None);
+
+        await fake.FlushAsync();
+
+        ingestor.Verify(i => i.IngestAsync("p", "s", "status-update", It.IsAny<System.Text.Json.JsonElement>(), It.IsAny<CancellationToken>()), Times.Once);
+        ingestor.Verify(i => i.IngestAsync("p", "s", "message", It.IsAny<System.Text.Json.JsonElement>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // FakeSseServer: minimal in-memory HttpClient handler yielding pre-queued SSE frames.
+    // Implementation lives at tests/Homespun.Tests/ClaudeCode/_fakes/FakeSseServer.cs
+}
+```
+
+Also create `tests/Homespun.Tests/ClaudeCode/_fakes/FakeSseServer.cs`:
+
+```csharp
+using System.Net;
+using System.Text;
+
+namespace Homespun.Tests.ClaudeCode;
+
+internal sealed class FakeSseServer
+{
+    private readonly List<(string kind, string data)> _queue = new();
+    private TaskCompletionSource<bool>? _flushed;
+
+    public string BaseUrl => "http://fake";
+    public HttpClient HttpClient { get; }
+
+    public FakeSseServer()
+    {
+        HttpClient = new HttpClient(new Handler(this));
+    }
+
+    public void Queue(string kind, string data) => _queue.Add((kind, data));
+
+    public Task FlushAsync()
+    {
+        _flushed ??= new TaskCompletionSource<bool>();
+        return _flushed.Task;
+    }
+
+    private sealed class Handler : HttpMessageHandler
+    {
+        private readonly FakeSseServer _parent;
+        public Handler(FakeSseServer parent) => _parent = parent;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var sb = new StringBuilder();
+            foreach (var (kind, data) in _parent._queue)
+            {
+                sb.Append("event: ").Append(kind).Append('\n');
+                sb.Append("data: ").Append(data).Append('\n');
+                sb.Append('\n');
+            }
+            var resp = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(sb.ToString(), Encoding.UTF8, "text/event-stream"),
+            };
+            _parent._flushed?.TrySetResult(true);
+            return Task.FromResult(resp);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test and verify failure**
+
+```
+dotnet test tests/Homespun.Tests --filter FullyQualifiedName~PerSessionEventStream
+```
+
+Expected: FAIL — `PerSessionEventStream` class does not exist.
+
+- [ ] **Step 3: Implement `PerSessionEventStream`**
+
+Create `src/Homespun.Server/Features/ClaudeCode/Services/PerSessionEventStream.cs`:
+
+```csharp
+using System.Collections.Concurrent;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Channels;
+using Homespun.Features.ClaudeCode.Data;
+
+namespace Homespun.Features.ClaudeCode.Services;
+
+public sealed class PerSessionEventStream : IPerSessionEventStream, IAsyncDisposable
+{
+    private readonly ISessionEventIngestor _ingestor;
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<PerSessionEventStream> _logger;
+    private readonly ConcurrentDictionary<string, Reader> _readers = new();
+
+    public PerSessionEventStream(
+        ISessionEventIngestor ingestor,
+        HttpClient httpClient,
+        ILogger<PerSessionEventStream> logger)
+    {
+        _ingestor = ingestor;
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    public Task StartAsync(
+        string homespunSessionId,
+        string workerUrl,
+        string workerSessionId,
+        string? projectId,
+        CancellationToken cancellationToken)
+    {
+        _readers.GetOrAdd(homespunSessionId, _ =>
+        {
+            var reader = new Reader(
+                _ingestor, _httpClient, _logger,
+                homespunSessionId, workerUrl, workerSessionId, projectId);
+            reader.Start();
+            return reader;
+        });
+        return Task.CompletedTask;
+    }
+
+    public IAsyncEnumerable<SdkMessage> SubscribeTurnAsync(
+        string homespunSessionId,
+        CancellationToken cancellationToken)
+    {
+        if (!_readers.TryGetValue(homespunSessionId, out var reader))
+        {
+            throw new InvalidOperationException(
+                $"No per-session event stream running for session {homespunSessionId}");
+        }
+        return reader.SubscribeTurnAsync(cancellationToken);
+    }
+
+    public async Task StopAsync(string homespunSessionId)
+    {
+        if (_readers.TryRemove(homespunSessionId, out var reader))
+        {
+            await reader.DisposeAsync();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var reader in _readers.Values) await reader.DisposeAsync();
+        _readers.Clear();
+    }
+
+    private sealed class Reader : IAsyncDisposable
+    {
+        private readonly ISessionEventIngestor _ingestor;
+        private readonly HttpClient _httpClient;
+        private readonly ILogger _logger;
+        private readonly string _sessionId;
+        private readonly string _workerUrl;
+        private readonly string _workerSessionId;
+        private readonly string? _projectId;
+        private readonly CancellationTokenSource _cts = new();
+        private Task? _readTask;
+        private Channel<SdkMessage>? _currentTurn;
+        private readonly object _turnLock = new();
+
+        public Reader(ISessionEventIngestor ingestor, HttpClient httpClient, ILogger logger,
+            string sessionId, string workerUrl, string workerSessionId, string? projectId)
+        {
+            _ingestor = ingestor;
+            _httpClient = httpClient;
+            _logger = logger;
+            _sessionId = sessionId;
+            _workerUrl = workerUrl;
+            _workerSessionId = workerSessionId;
+            _projectId = projectId;
+        }
+
+        public void Start()
+        {
+            _readTask = Task.Run(() => RunAsync(_cts.Token));
+        }
+
+        public IAsyncEnumerable<SdkMessage> SubscribeTurnAsync(CancellationToken cancellationToken)
+        {
+            lock (_turnLock)
+            {
+                if (_currentTurn is not null)
+                {
+                    throw new InvalidOperationException(
+                        $"Session {_sessionId} already has an active turn subscription");
+                }
+                _currentTurn = Channel.CreateUnbounded<SdkMessage>();
+            }
+            return DrainAsync(_currentTurn, cancellationToken);
+        }
+
+        private async IAsyncEnumerable<SdkMessage> DrainAsync(
+            Channel<SdkMessage> ch,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            try
+            {
+                await foreach (var msg in ch.Reader.ReadAllAsync(ct))
+                {
+                    yield return msg;
+                    if (msg is SdkResultMessage) yield break;
+                }
+            }
+            finally
+            {
+                lock (_turnLock) { _currentTurn = null; }
+            }
+        }
+
+        private async Task RunAsync(CancellationToken ct)
+        {
+            try
+            {
+                var url = $"{_workerUrl.TrimEnd('/')}/api/sessions/{_workerSessionId}/events";
+                using var request = new HttpRequestMessage(HttpMethod.Get, url);
+                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+                using var response = await _httpClient.SendAsync(
+                    request, HttpCompletionOption.ResponseHeadersRead, ct);
+                response.EnsureSuccessStatusCode();
+
+                await using var stream = await response.Content.ReadAsStreamAsync(ct);
+                using var reader = new StreamReader(stream);
+
+                string? eventType = null;
+                var data = new StringBuilder();
+
+                while (!ct.IsCancellationRequested)
+                {
+                    var line = await reader.ReadLineAsync(ct);
+                    if (line is null) break;
+
+                    if (line.StartsWith("event: ")) eventType = line[7..];
+                    else if (line.StartsWith("data: ")) data.Append(line[6..]);
+                    else if (line.Length == 0)
+                    {
+                        if (!string.IsNullOrEmpty(eventType) && data.Length > 0)
+                        {
+                            await DispatchAsync(eventType!, data.ToString(), ct);
+                        }
+                        eventType = null;
+                        data.Clear();
+                    }
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Per-session event stream for {SessionId} ended unexpectedly", _sessionId);
+            }
+            finally
+            {
+                lock (_turnLock)
+                {
+                    _currentTurn?.Writer.TryComplete();
+                    _currentTurn = null;
+                }
+            }
+        }
+
+        private async Task DispatchAsync(string kind, string raw, CancellationToken ct)
+        {
+            // 1. Ingest A2A events so SignalR keeps broadcasting regardless of turn state.
+            if (A2AMessageParser.IsA2AEventKind(kind))
+            {
+                try
+                {
+                    using var doc = JsonDocument.Parse(raw);
+                    await _ingestor.IngestAsync(
+                        string.IsNullOrEmpty(_projectId) ? "unknown" : _projectId,
+                        _sessionId, kind, doc.RootElement.Clone(), ct);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "Ingestor tap failed for session {SessionId} kind {Kind}", _sessionId, kind);
+                }
+            }
+
+            // 2. Fan out a parsed SdkMessage to the current turn subscriber, if any.
+            var sdkMessage = ParseToSdkMessage(kind, raw);
+            if (sdkMessage is null) return;
+
+            Channel<SdkMessage>? ch;
+            lock (_turnLock) { ch = _currentTurn; }
+            if (ch is not null)
+            {
+                await ch.Writer.WriteAsync(sdkMessage, ct);
+            }
+        }
+
+        private SdkMessage? ParseToSdkMessage(string kind, string raw)
+        {
+            if (kind == HomespunA2AEventKind.Task ||
+                kind == HomespunA2AEventKind.Message ||
+                kind == HomespunA2AEventKind.StatusUpdate ||
+                kind == HomespunA2AEventKind.ArtifactUpdate)
+            {
+                var parsed = A2AMessageParser.ParseSseEvent(kind, raw);
+                return parsed is null ? null : A2AMessageParser.ConvertToSdkMessage(parsed, _sessionId);
+            }
+
+            if (kind == "session_started")
+            {
+                using var doc = JsonDocument.Parse(raw);
+                var wsid = doc.RootElement.TryGetProperty("sessionId", out var s) ? s.GetString() : null;
+                return new SdkSystemMessage(wsid ?? _sessionId, null, "session_started", null, null);
+            }
+            if (kind == "question_pending") return new SdkQuestionPendingMessage(_sessionId, raw);
+            if (kind == "plan_pending") return new SdkPlanPendingMessage(_sessionId, raw);
+            return null;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            _cts.Cancel();
+            if (_readTask is not null)
+            {
+                try { await _readTask; } catch { }
+            }
+            _cts.Dispose();
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test and verify pass**
+
+```
+dotnet test tests/Homespun.Tests --filter FullyQualifiedName~PerSessionEventStream
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Register in DI**
+
+Edit `src/Homespun.Server/Program.cs`. Find the `IAgentExecutionService` registration and add next to it:
+
+```csharp
+builder.Services.AddSingleton<IPerSessionEventStream, PerSessionEventStream>();
+```
+
+Also ensure `HttpClient` is resolvable — `PerSessionEventStream` takes `HttpClient` by constructor. Use an HttpClientFactory-backed registration:
+
+```csharp
+builder.Services.AddHttpClient<IPerSessionEventStream, PerSessionEventStream>(c =>
+{
+    c.Timeout = Timeout.InfiniteTimeSpan;
+});
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Homespun.Server/Features/ClaudeCode/Services/PerSessionEventStream.cs \
+        src/Homespun.Server/Program.cs \
+        tests/Homespun.Tests/ClaudeCode/PerSessionEventStreamTests.cs \
+        tests/Homespun.Tests/ClaudeCode/_fakes/FakeSseServer.cs
+git commit -m "feat(server): add PerSessionEventStream background reader"
+```
+
+---
+
+## Task 8: Server — rewire `DockerAgentExecutionService` to use `PerSessionEventStream`
+
+**Files:**
+- Modify: `src/Homespun.Server/Features/ClaudeCode/Services/DockerAgentExecutionService.cs`
+- Test: `tests/Homespun.Tests/ClaudeCode/DockerAgentExecutionServiceTests.cs` (existing; update assertions)
+
+- [ ] **Step 1: Write failing test**
+
+Add a test that asserts `StartSessionAsync` consults `IPerSessionEventStream`:
+
+```csharp
+[Test]
+public async Task StartSessionAsync_starts_per_session_event_stream()
+{
+    var perSession = new Mock<IPerSessionEventStream>();
+    perSession.Setup(p => p.SubscribeTurnAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .Returns(AsyncEmpty(new SdkResultMessage("s", null, "success", 0, 0, false, 1, 0, "", null)));
+    var svc = BuildService(perSession: perSession.Object);
+
+    await foreach (var _ in svc.StartSessionAsync(DefaultStartRequest())) { }
+
+    perSession.Verify(p => p.StartAsync(
+        It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(),
+        It.IsAny<CancellationToken>()), Times.Once);
+}
+```
+
+(Add `AsyncEmpty<T>(params T[] items)` helper in the test file if not present.)
+
+- [ ] **Step 2: Verify failure**
+
+```
+dotnet test tests/Homespun.Tests --filter StartSessionAsync_starts_per_session_event_stream
+```
+
+Expected: FAIL — `IPerSessionEventStream` not injected, `StartAsync` never called.
+
+- [ ] **Step 3: Inject + wire**
+
+Add `IPerSessionEventStream` to the constructor parameters of `DockerAgentExecutionService`. Store as `_perSession`.
+
+Rewrite the streaming portion of `StartSessionAsync`. Replace the `SendSseRequestAsync` call in the `StartSessionAsync` background Task (around line 356) with:
+
+```csharp
+// Parse the POST /api/sessions JSON response to get the worker session id.
+var startResponse = await _httpClient.PostAsJsonAsync($"{workerUrl}/api/sessions", startRequest, CamelCaseJsonOptions, cts.Token);
+startResponse.EnsureSuccessStatusCode();
+var startBody = await startResponse.Content.ReadFromJsonAsync<WorkerStartResponse>(CamelCaseJsonOptions, cts.Token)
+    ?? throw new InvalidOperationException("Worker POST /api/sessions returned empty body");
+
+session = session with { WorkerSessionId = startBody.SessionId };
+_sessions[sessionId] = session;
+
+await _perSession.StartAsync(sessionId, workerUrl, startBody.SessionId, request.ProjectId, cts.Token);
+
+// Emit the legacy session_started message so downstream consumers match the old contract.
+await channel.Writer.WriteAsync(
+    new SdkSystemMessage(startBody.SessionId, null, "session_started", request.Model, null),
+    cancellationToken);
+
+await foreach (var msg in _perSession.SubscribeTurnAsync(sessionId, cts.Token))
+{
+    var remapped = RemapSessionId(msg, sessionId);
+    await channel.Writer.WriteAsync(remapped, cancellationToken);
+    if (msg is SdkResultMessage resultMsg)
+    {
+        session.ConversationId = resultMsg.SessionId;
+        _sessions[sessionId] = session;
+    }
+}
+channel.Writer.Complete();
+```
+
+Add a helper record at the bottom of the file:
+
+```csharp
+private sealed record WorkerStartResponse(string SessionId, string? ConversationId);
+```
+
+Rewrite `SendMessageAsync` (around line 421–467):
+
+```csharp
+public async IAsyncEnumerable<SdkMessage> SendMessageAsync(
+    AgentMessageRequest request,
+    [EnumeratorCancellation] CancellationToken cancellationToken = default)
+{
+    _sessionToIssue.TryGetValue(request.SessionId, out var issueId);
+    using var issueScope = IssueLogScope.BeginIssueScope(_logger, issueId);
+
+    _logger.LogInformation("SendMessageAsync called for session {SessionId}", request.SessionId);
+
+    if (!_sessions.TryGetValue(request.SessionId, out var session))
+    {
+        _logger.LogError("Session {SessionId} not found in _sessions dictionary", request.SessionId);
+        yield break;
+    }
+    if (string.IsNullOrEmpty(session.WorkerSessionId))
+    {
+        _logger.LogError("Worker session ID is empty - session was not properly initialized");
+        yield break;
+    }
+
+    session.LastActivityAt = DateTime.UtcNow;
+
+    var messageRequest = new
+    {
+        Message = request.Message,
+        Model = request.Model,
+        Mode = request.Mode.ToString(),
+    };
+
+    using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, session.Cts.Token);
+
+    var sendResponse = await _httpClient.PostAsJsonAsync(
+        $"{session.WorkerUrl}/api/sessions/{session.WorkerSessionId}/message",
+        messageRequest, CamelCaseJsonOptions, linkedCts.Token);
+    sendResponse.EnsureSuccessStatusCode();
+
+    await foreach (var msg in _perSession.SubscribeTurnAsync(request.SessionId, linkedCts.Token))
+    {
+        var remapped = RemapSessionId(msg, request.SessionId);
+        yield return remapped;
+
+        if (msg is SdkResultMessage resultMsg)
+        {
+            session.ConversationId = resultMsg.SessionId;
+            _sessions[request.SessionId] = session;
+        }
+    }
+}
+```
+
+Also call `_perSession.StopAsync(sessionId)` from `StopSessionAsync` before tearing down the container.
+
+Delete `SendSseRequestAsync` and `TryIngestA2AEventAsync` (they are now redundant) — do this only after all callers are removed.
+
+- [ ] **Step 4: Verify pass + run full Docker service test suite**
+
+```
+dotnet test tests/Homespun.Tests --filter FullyQualifiedName~DockerAgentExecutionService
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Homespun.Server/Features/ClaudeCode/Services/DockerAgentExecutionService.cs \
+        tests/Homespun.Tests/ClaudeCode/DockerAgentExecutionServiceTests.cs
+git commit -m "refactor(server): route DockerAgentExecutionService events via PerSessionEventStream"
+```
+
+---
+
+## Task 9: Server — same rewire for `SingleContainerAgentExecutionService`
+
+**Files:**
+- Modify: `src/Homespun.Server/Features/ClaudeCode/Services/SingleContainerAgentExecutionService.cs`
+- Test: `tests/Homespun.Tests/ClaudeCode/SingleContainerAgentExecutionServiceTests.cs` (if exists; otherwise extend sessions tests).
+
+- [ ] **Step 1: Write failing test (mirror Task 8's test structure)**
+
+- [ ] **Step 2: Verify failure**
+
+- [ ] **Step 3: Inject `IPerSessionEventStream`, replace `StreamAgentEventsAsync`**
+
+Inject `IPerSessionEventStream` via constructor. In `StartSessionAsync` (around line 132), change:
+
+```csharp
+await foreach (var msg in StreamAgentEventsAsync(url, startBody, sessionId, request.ProjectId, session.Cts.Token))
+{
+    ...
+}
+```
+
+to a pattern mirroring Task 8 (`POST` JSON → start `PerSessionEventStream` → subscribe). In `SendMessageAsync` (line 183–188) do the same: `POST` JSON, then subscribe to the per-session stream.
+
+Remove `StreamAgentEventsAsync` + `TryIngestA2AAsync` once unused.
+
+- [ ] **Step 4: Verify pass**
+
+```
+dotnet test tests/Homespun.Tests --filter FullyQualifiedName~SingleContainer
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Homespun.Server/Features/ClaudeCode/Services/SingleContainerAgentExecutionService.cs \
+        tests/Homespun.Tests/ClaudeCode/SingleContainerAgentExecutionServiceTests.cs
+git commit -m "refactor(server): route SingleContainerAgentExecutionService via PerSessionEventStream"
+```
+
+---
+
+## Task 10: Integration test — post-result task notification reaches the client
+
+**Files:**
+- Create: `tests/Homespun.Api.Tests/Sessions/PostResultTaskNotificationTests.cs`
+
+- [ ] **Step 1: Write the test**
+
+```csharp
+using Homespun.Api.Tests.TestHarness;
+using Homespun.Features.ClaudeCode.Data;
+using NUnit.Framework;
+
+namespace Homespun.Api.Tests.Sessions;
+
+public class PostResultTaskNotificationTests : IntegrationTestBase
+{
+    [Test]
+    public async Task Task_notification_after_result_is_broadcast_via_signalr()
+    {
+        using var harness = await TestHarness.BuildAsync();
+        var sessionId = await harness.StartMockSessionAsync(prompt: "run background bash");
+
+        // Mock worker emits the sequence:
+        //  1. assistant message
+        //  2. status-update completed (result)
+        //  3. 500ms later: system task_notification
+        harness.MockWorker.QueueAssistantText("ok");
+        harness.MockWorker.QueueResultSuccess();
+        await Task.Delay(500);
+        harness.MockWorker.QueueTaskNotification(taskId: "t1", status: "completed");
+
+        // Client subscribes to the SignalR hub before any prior work.
+        var broadcasts = await harness.WaitForBroadcastsAsync(sessionId, count: 3, timeout: TimeSpan.FromSeconds(5));
+
+        Assert.That(broadcasts.Any(b => b.Event.Type == "CUSTOM" && (b.Event as dynamic).Name == "raw"), Is.True,
+            "task_notification should have been broadcast live, not buffered for the next prompt");
+    }
+}
+```
+
+(Extend `TestHarness` / `MockWorker` as needed to queue post-result events; follow existing patterns in `tests/Homespun.Api.Tests`.)
+
+- [ ] **Step 2: Run the test and verify failure before the wiring is in place**
+
+If running out of order: expected FAIL with event count < 3.
+
+- [ ] **Step 3: Run after Tasks 1–9 land — expect PASS**
+
+```
+dotnet test tests/Homespun.Api.Tests --filter FullyQualifiedName~PostResultTaskNotification
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/Homespun.Api.Tests/Sessions/PostResultTaskNotificationTests.cs
+git commit -m "test(server): task notification after result reaches client via SignalR"
+```
+
+---
+
+## Task 11: Pre-PR checklist
+
+- [ ] **Step 1: Backend tests**
+
+```
+dotnet test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Frontend lint, format, typecheck, unit tests**
+
+```
+cd src/Homespun.Web
+npm run lint:fix
+npm run format:check
+npm run generate:api:fetch
+npm run typecheck
+npm test
+```
+
+Expected: all PASS.
+
+- [ ] **Step 3: Worker tests**
+
+```
+cd src/Homespun.Worker
+npm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: E2E**
+
+```
+cd src/Homespun.Web
+npm run test:e2e
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Storybook build**
+
+```
+cd src/Homespun.Web
+npm run build-storybook
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Manual smoke with `dev-live`**
+
+```
+dotnet run --project src/Homespun.AppHost --launch-profile dev-live
+```
+
+Ask an agent to run a background `sleep 10 && echo done` and then say "I'll wait for notifications". Confirm the `task_notification` event appears in the UI within a second of the bash finishing, without the user sending a second prompt.
+
+- [ ] **Step 7: Final commit (if any housekeeping was needed)**
+
+```bash
+git status
+git commit -m "chore: pre-PR cleanup" || true
+```
+
+---
+
+## Self-Review
+
+**Spec coverage**
+- Post-result events reach the client live → Tasks 1, 2, 7, 8, 9, 10.
+- Worker HTTP contract change → Tasks 3, 4, 5.
+- Server background consumer + fan-out → Tasks 6, 7, 8, 9.
+- Regression coverage → Tasks 7, 10, 11.
+
+**Placeholder scan** — no "TBD"/"implement later"/unresolved deferrals. Every code block is the exact text to insert.
+
+**Type consistency** — `IPerSessionEventStream.StartAsync` / `SubscribeTurnAsync` / `StopAsync` signatures match their callsites in Tasks 8, 9. `WorkerStartResponse` defined in Task 8 and reused there only (single file scope).

--- a/src/Homespun.Server/Features/ClaudeCode/Services/DockerAgentExecutionService.cs
+++ b/src/Homespun.Server/Features/ClaudeCode/Services/DockerAgentExecutionService.cs
@@ -199,22 +199,79 @@ public class DockerAgentExecutionService : IAgentExecutionService, IAsyncDisposa
         string? LastMessageSubtype);
 
     private readonly ISessionEventIngestor _eventIngestor;
+    private readonly IPerSessionEventStream _perSession;
 
+    /// <summary>
+    /// Response parsed from the worker's <c>POST /api/sessions</c> and
+    /// <c>POST /api/sessions/:id/message</c> endpoints now that those endpoints
+    /// return JSON rather than an SSE stream (task 3 / task 4 of the
+    /// <c>fix-post-result-events</c> plan).
+    /// </summary>
+    private sealed record WorkerStartResponse(string SessionId, string? ConversationId);
 
     public DockerAgentExecutionService(
         IOptions<DockerAgentExecutionOptions> options,
         ILogger<DockerAgentExecutionService> logger,
         ISecretsService secretsService,
-        ISessionEventIngestor eventIngestor)
+        ISessionEventIngestor eventIngestor,
+        IPerSessionEventStream perSession)
     {
         _options = options.Value;
         _logger = logger;
         _secretsService = secretsService;
         _eventIngestor = eventIngestor;
+        _perSession = perSession;
         _httpClient = new HttpClient
         {
             Timeout = _options.RequestTimeout
         };
+    }
+
+    /// <summary>
+    /// Test-only constructor accepting a pre-built <see cref="HttpClient"/>. Allows unit
+    /// tests to intercept worker HTTP traffic via a custom
+    /// <see cref="HttpMessageHandler"/>. Not used in production DI.
+    /// </summary>
+    internal DockerAgentExecutionService(
+        IOptions<DockerAgentExecutionOptions> options,
+        ILogger<DockerAgentExecutionService> logger,
+        ISecretsService secretsService,
+        ISessionEventIngestor eventIngestor,
+        IPerSessionEventStream perSession,
+        HttpClient httpClient)
+    {
+        _options = options.Value;
+        _logger = logger;
+        _secretsService = secretsService;
+        _eventIngestor = eventIngestor;
+        _perSession = perSession;
+        _httpClient = httpClient;
+    }
+
+    /// <summary>
+    /// Test-only seam that seeds the internal session dictionary. Allows unit
+    /// tests to exercise <see cref="SendMessageAsync"/> / <see cref="StopSessionAsync"/>
+    /// without spinning up a Docker container.
+    /// </summary>
+    internal void RegisterSessionForTesting(
+        string homespunSessionId,
+        string? workerSessionId,
+        string workerUrl,
+        string? projectId = null,
+        string? issueId = null)
+    {
+        var session = new DockerSession(
+            SessionId: homespunSessionId,
+            ContainerId: "test-container",
+            ContainerName: "test-container-name",
+            WorkerUrl: workerUrl,
+            WorkingDirectory: "/workdir",
+            WorkerSessionId: workerSessionId,
+            Cts: new CancellationTokenSource(),
+            CreatedAt: DateTime.UtcNow,
+            IssueId: issueId,
+            ProjectId: projectId);
+        _sessions[homespunSessionId] = session;
     }
 
     /// <summary>
@@ -353,28 +410,8 @@ public class DockerAgentExecutionService : IAgentExecutionService, IAsyncDisposa
                     ResumeSessionId = request.ResumeSessionId
                 };
 
-                await foreach (var msg in SendSseRequestAsync($"{workerUrl}/api/sessions", startRequest, sessionId, request.ProjectId, cts.Token))
-                {
-                    // Capture the worker session ID from session_started lifecycle event
-                    if (msg is SdkSystemMessage sysMsg && sysMsg.Subtype == "session_started" &&
-                        !string.IsNullOrEmpty(sysMsg.SessionId) && sysMsg.SessionId != sessionId)
-                    {
-                        session = session with { WorkerSessionId = sysMsg.SessionId };
-                        _sessions[sessionId] = session;
-                        _logger.LogInformation("Stored WorkerSessionId={WorkerSessionId} for Docker session {SessionId}",
-                            sysMsg.SessionId, sessionId);
-                    }
-
-                    // Remap session IDs to our session ID
-                    var remapped = RemapSessionId(msg, sessionId);
-                    await channel.Writer.WriteAsync(remapped, cancellationToken);
-
-                    if (msg is SdkResultMessage resultMsg)
-                    {
-                        session.ConversationId = resultMsg.SessionId;
-                        _sessions[sessionId] = session;
-                    }
-                }
+                await RunSessionStartAndDrainTurnAsync(
+                    sessionId, workerUrl, session, startRequest, channel, request.ProjectId, cts);
                 channel.Writer.Complete();
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
@@ -451,9 +488,20 @@ public class DockerAgentExecutionService : IAgentExecutionService, IAsyncDisposa
 
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, session.Cts.Token);
 
-        await foreach (var msg in SendSseRequestAsync(
-            $"{session.WorkerUrl}/api/sessions/{session.WorkerSessionId}/message",
-            messageRequest, request.SessionId, session.ProjectId, linkedCts.Token))
+        // The worker's /message endpoint is JSON-only after task 4 — stream events
+        // ride the long-lived /events SSE consumed by PerSessionEventStream.
+        var messageUrl = $"{session.WorkerUrl}/api/sessions/{session.WorkerSessionId}/message";
+        var json = JsonSerializer.Serialize(messageRequest, CamelCaseJsonOptions);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var response = await _httpClient.PostAsync(messageUrl, content, linkedCts.Token);
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(linkedCts.Token);
+            throw new AgentConnectionLostException(
+                $"Worker returned {response.StatusCode} for POST {messageUrl}: {errorBody}", request.SessionId);
+        }
+
+        await foreach (var msg in _perSession.SubscribeTurnAsync(request.SessionId, linkedCts.Token))
         {
             var remapped = RemapSessionId(msg, request.SessionId);
             yield return remapped;
@@ -482,6 +530,19 @@ public class DockerAgentExecutionService : IAgentExecutionService, IAsyncDisposa
             session.Cts.Dispose();
 
             _sessionToIssue.TryRemove(sessionId, out _);
+
+            // Halt the long-lived PerSessionEventStream reader before tearing the
+            // session down so no post-stop events race an already-removed session
+            // dictionary entry. StopAsync is safe to call for unknown ids.
+            try
+            {
+                await _perSession.StopAsync(sessionId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "PerSessionEventStream.StopAsync failed for session {SessionId}; continuing teardown", sessionId);
+            }
 
             // Stop worker session via HTTP if exists
             if (!string.IsNullOrEmpty(session.WorkerSessionId))
@@ -2380,222 +2441,114 @@ public class DockerAgentExecutionService : IAgentExecutionService, IAsyncDisposa
         }
     }
 
-    private async IAsyncEnumerable<SdkMessage> SendSseRequestAsync(
-        string url,
-        object requestBody,
+    /// <summary>
+    /// Drives the worker's <c>POST /api/sessions</c> JSON endpoint to create or resume a
+    /// session, starts the singleton <see cref="IPerSessionEventStream"/> reader against
+    /// the worker's long-lived <c>GET /api/sessions/:id/events</c> endpoint, and drains
+    /// the first turn's <see cref="SdkMessage"/>s onto the caller-provided channel.
+    ///
+    /// <para>
+    /// After task 3/4 of the <c>fix-post-result-events</c> plan the worker no longer
+    /// streams events as the response body of <c>POST /api/sessions</c>; it returns a
+    /// JSON handshake and every subsequent event (for any turn, including post-result
+    /// background events) flows through the long-lived SSE endpoint. The
+    /// <see cref="IPerSessionEventStream"/> singleton is the sole consumer of that stream,
+    /// so both <see cref="StartSessionAsync"/> and <see cref="SendMessageAsync"/> share
+    /// the same reader across the full worker-session lifetime.
+    /// </para>
+    /// </summary>
+    private async Task RunSessionStartAndDrainTurnAsync(
         string sessionId,
+        string workerUrl,
+        DockerSession session,
+        object startRequestBody,
+        System.Threading.Channels.Channel<SdkMessage> channel,
         string? projectId,
-        [EnumeratorCancellation] CancellationToken cancellationToken)
+        CancellationTokenSource cts)
     {
-        var json = JsonSerializer.Serialize(requestBody, CamelCaseJsonOptions);
+        var startUrl = $"{workerUrl}/api/sessions";
+        var json = JsonSerializer.Serialize(startRequestBody, CamelCaseJsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
 
-        using var request = new HttpRequestMessage(HttpMethod.Post, url)
-        {
-            Content = content
-        };
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
-
-        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-
+        using var response = await _httpClient.PostAsync(startUrl, content, cts.Token);
         if (!response.IsSuccessStatusCode)
         {
-            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
-            throw new AgentConnectionLostException($"Worker returned {response.StatusCode}: {errorBody}", sessionId);
+            var errorBody = await response.Content.ReadAsStringAsync(cts.Token);
+            throw new AgentConnectionLostException(
+                $"Worker returned {response.StatusCode} for POST {startUrl}: {errorBody}", sessionId);
         }
 
-        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
-        using var reader = new StreamReader(stream);
-
-        string? currentEventType = null;
-        var dataBuffer = new StringBuilder();
-
-        while (!cancellationToken.IsCancellationRequested)
+        var responseBody = await response.Content.ReadAsStringAsync(cts.Token);
+        var startResponse = JsonSerializer.Deserialize<WorkerStartResponse>(
+            responseBody,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        if (startResponse is null || string.IsNullOrEmpty(startResponse.SessionId))
         {
-            // Read the next line, handling premature stream termination gracefully.
-            // HttpIOException(ResponseEnded) occurs when the worker's chunked HTTP response
-            // ends without proper termination (e.g., worker process crashed or SDK query failed).
-            string? line;
-            try
+            throw new AgentConnectionLostException(
+                $"Worker {startUrl} returned an empty / malformed start response: {responseBody}", sessionId);
+        }
+
+        session = session with { WorkerSessionId = startResponse.SessionId };
+        _sessions[sessionId] = session;
+        _logger.LogInformation(
+            "Stored WorkerSessionId={WorkerSessionId} for Docker session {SessionId}",
+            startResponse.SessionId, sessionId);
+
+        await _perSession.StartAsync(sessionId, workerUrl, startResponse.SessionId, projectId, cts.Token);
+
+        await foreach (var msg in _perSession.SubscribeTurnAsync(sessionId, cts.Token))
+        {
+            var remapped = RemapSessionId(msg, sessionId);
+            await channel.Writer.WriteAsync(remapped, cts.Token);
+
+            if (msg is SdkResultMessage resultMsg)
             {
-                line = await reader.ReadLineAsync(cancellationToken);
-            }
-            catch (HttpIOException ex) when (ex.HttpRequestError == HttpRequestError.ResponseEnded)
-            {
-                _logger.LogWarning(ex,
-                    "SSE stream for session {SessionId} ended prematurely (worker connection lost)", sessionId);
-                throw new AgentConnectionLostException(
-                    "Worker connection lost: the agent container's response ended prematurely. " +
-                    "This usually means the Claude SDK query failed to start. Check container logs for details.",
-                    ex, sessionId);
-            }
-
-            if (line == null) break;
-
-            if (line.StartsWith("event: "))
-            {
-                currentEventType = line[7..];
-            }
-            else if (line.StartsWith("data: "))
-            {
-                dataBuffer.Append(line[6..]);
-            }
-            else if (string.IsNullOrEmpty(line))
-            {
-                if (!string.IsNullOrEmpty(currentEventType) && dataBuffer.Length > 0)
-                {
-                    var rawData = dataBuffer.ToString();
-
-                    // Tap the A2A-native path: persist + translate + broadcast a
-                    // SessionEventEnvelope before we do anything legacy-SDK with the event.
-                    // Append-before-legacy-broadcast preserves the refresh-fidelity invariant.
-                    await TryIngestA2AEventAsync(
-                        currentEventType, rawData, sessionId, projectId, cancellationToken);
-
-                    var msg = ParseSseEvent(currentEventType, rawData, sessionId);
-                    if (msg != null)
-                    {
-                        yield return msg;
-
-                        if (msg is SdkResultMessage)
-                        {
-                            yield break;
-                        }
-                    }
-                }
-
-                currentEventType = null;
-                dataBuffer.Clear();
+                session.ConversationId = resultMsg.SessionId;
+                _sessions[sessionId] = session;
             }
         }
     }
 
     /// <summary>
-    /// Non-destructive tap that forwards A2A-kind SSE events to the
-    /// <see cref="ISessionEventIngestor"/> (A2AEventStore append + translate + envelope
-    /// broadcast). Non-A2A events (<c>session_started</c>, <c>question_pending</c>,
-    /// <c>plan_pending</c>, <c>error</c>, raw SDK-shaped events emitted for backwards
-    /// compatibility) are skipped here — they reach the client via the legacy per-type
-    /// broadcast path until that path is retired in the dead-code-deletion phase.
-    ///
-    /// <para>
-    /// Failures are logged and swallowed so the ingestion side effect never tears down the
-    /// SSE consumer — the legacy SdkMessage yield must continue regardless.
-    /// </para>
+    /// Test-only wrapper that runs the post-container portion of
+    /// <see cref="StartSessionAsync"/> synchronously against a caller-supplied channel
+    /// and returns the drained messages. Lets unit tests exercise the HTTP + per-session
+    /// stream wiring without spinning up a Docker container.
     /// </summary>
-    private async Task TryIngestA2AEventAsync(
-        string eventKind,
-        string rawData,
+    internal async Task<List<SdkMessage>> RunStartSessionWorkerLoopForTestingAsync(
         string sessionId,
-        string? projectId,
+        string workerUrl,
+        AgentStartRequest request,
         CancellationToken cancellationToken)
     {
-        if (!A2AMessageParser.IsA2AEventKind(eventKind))
+        if (!_sessions.TryGetValue(sessionId, out var session))
         {
-            return;
+            throw new InvalidOperationException(
+                $"Test seed missing: call RegisterSessionForTesting for {sessionId} first.");
         }
 
-        try
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var channel = System.Threading.Channels.Channel.CreateUnbounded<SdkMessage>();
+        var startRequest = new
         {
-            using var doc = JsonDocument.Parse(rawData);
-            // Clone so the JsonElement outlives the JsonDocument's `using` scope — the
-            // ingestor persists the element and the store may keep it alive beyond this
-            // method's stack frame when bursts are in flight.
-            var payload = doc.RootElement.Clone();
+            WorkingDirectory = "/workdir",
+            Mode = request.Mode.ToString(),
+            Model = request.Model,
+            Prompt = request.Prompt,
+            SystemPrompt = request.SystemPrompt,
+            ResumeSessionId = request.ResumeSessionId,
+        };
 
-            // projectId is best-effort; when not available (legacy non-issue sessions) we
-            // fall back to a stable "unknown" bucket so the event log still writes. The
-            // replay endpoint does not need projectId in its URL — it only uses sessionId.
-            var effectiveProjectId = string.IsNullOrEmpty(projectId) ? "unknown" : projectId;
+        await RunSessionStartAndDrainTurnAsync(
+            sessionId, workerUrl, session, startRequest, channel, request.ProjectId, cts);
+        channel.Writer.Complete();
 
-            await _eventIngestor.IngestAsync(
-                effectiveProjectId, sessionId, eventKind, payload, cancellationToken);
-        }
-        catch (Exception ex)
+        var yielded = new List<SdkMessage>();
+        await foreach (var msg in channel.Reader.ReadAllAsync(cancellationToken))
         {
-            _logger.LogWarning(ex,
-                "SessionEventIngestor tap failed for session {SessionId} kind {EventKind}; legacy path continues",
-                sessionId, eventKind);
+            yielded.Add(msg);
         }
-    }
-
-    private SdkMessage? ParseSseEvent(string eventType, string data, string sessionId)
-    {
-        try
-        {
-            // A2A protocol events have 'task', 'message', or 'status-update' as event types
-            if (eventType == HomespunA2AEventKind.Task ||
-                eventType == HomespunA2AEventKind.Message ||
-                eventType == HomespunA2AEventKind.StatusUpdate ||
-                eventType == HomespunA2AEventKind.ArtifactUpdate)
-            {
-                var a2aEvent = A2AMessageParser.ParseSseEvent(eventType, data);
-                if (a2aEvent != null)
-                {
-                    var sdkMessage = A2AMessageParser.ConvertToSdkMessage(a2aEvent, sessionId);
-                    if (sdkMessage != null)
-                    {
-                        _logger.LogDebug("Parsed A2A event {EventType} -> {SdkMessageType}",
-                            eventType, sdkMessage.Type);
-                        return sdkMessage;
-                    }
-
-                    // A2A event parsed but no SDK message needed (e.g., 'working' status)
-                    _logger.LogDebug("A2A event {EventType} parsed but no SDK message conversion needed", eventType);
-                    return null;
-                }
-
-                _logger.LogWarning("Failed to parse A2A event {EventType}: {Data}", eventType, data);
-                return null;
-            }
-
-            // Legacy event types for backwards compatibility during migration
-            // "session_started" is a custom lifecycle event, not a raw SDK message
-            if (eventType == "session_started")
-            {
-                // Parse to extract the worker session ID
-                using var doc = JsonDocument.Parse(data);
-                var workerSessionId = doc.RootElement.TryGetProperty("sessionId", out var sid)
-                    ? sid.GetString() : null;
-
-                return new SdkSystemMessage(
-                    workerSessionId ?? sessionId,
-                    null,
-                    "session_started",
-                    null,
-                    null
-                );
-            }
-
-            // "question_pending" is a control event from canUseTool
-            if (eventType == "question_pending")
-            {
-                return new SdkQuestionPendingMessage(sessionId, data);
-            }
-
-            // "plan_pending" is a control event from canUseTool (ExitPlanMode paused)
-            if (eventType == "plan_pending")
-            {
-                return new SdkPlanPendingMessage(sessionId, data);
-            }
-
-            // "error" is a custom lifecycle event
-            if (eventType == "error")
-            {
-                _logger.LogWarning("Received error event from worker: {Data}", data);
-                return null;
-            }
-
-            // Unknown event type. A2A-native workers only emit A2A events plus the four
-            // legacy control events handled above; anything else is dropped.
-            _logger.LogDebug("Dropping unknown SSE event type: {EventType}", eventType);
-            return null;
-        }
-        catch (JsonException ex)
-        {
-            _logger.LogWarning(ex, "Failed to parse SSE event {EventType}: {Data}", eventType, data);
-            return null;
-        }
+        return yielded;
     }
 
     /// <summary>

--- a/src/Homespun.Server/Features/ClaudeCode/Services/DockerAgentExecutionService.cs
+++ b/src/Homespun.Server/Features/ClaudeCode/Services/DockerAgentExecutionService.cs
@@ -198,7 +198,6 @@ public class DockerAgentExecutionService : IAgentExecutionService, IAsyncDisposa
         string? LastMessageType,
         string? LastMessageSubtype);
 
-    private readonly ISessionEventIngestor _eventIngestor;
     private readonly IPerSessionEventStream _perSession;
 
     /// <summary>
@@ -213,13 +212,11 @@ public class DockerAgentExecutionService : IAgentExecutionService, IAsyncDisposa
         IOptions<DockerAgentExecutionOptions> options,
         ILogger<DockerAgentExecutionService> logger,
         ISecretsService secretsService,
-        ISessionEventIngestor eventIngestor,
         IPerSessionEventStream perSession)
     {
         _options = options.Value;
         _logger = logger;
         _secretsService = secretsService;
-        _eventIngestor = eventIngestor;
         _perSession = perSession;
         _httpClient = new HttpClient
         {
@@ -236,14 +233,12 @@ public class DockerAgentExecutionService : IAgentExecutionService, IAsyncDisposa
         IOptions<DockerAgentExecutionOptions> options,
         ILogger<DockerAgentExecutionService> logger,
         ISecretsService secretsService,
-        ISessionEventIngestor eventIngestor,
         IPerSessionEventStream perSession,
         HttpClient httpClient)
     {
         _options = options.Value;
         _logger = logger;
         _secretsService = secretsService;
-        _eventIngestor = eventIngestor;
         _perSession = perSession;
         _httpClient = httpClient;
     }
@@ -416,6 +411,21 @@ public class DockerAgentExecutionService : IAgentExecutionService, IAsyncDisposa
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
+                // Best-effort: tear down the per-session reader so we don't leak it in
+                // _readers wired to a potentially dead worker URL. If the session id is
+                // later reused (issue-reuse mode), SubscribeTurnAsync would otherwise
+                // throw "already has an active turn subscription" or hold stale state.
+                try
+                {
+                    await _perSession.StopAsync(sessionId);
+                }
+                catch (Exception stopEx)
+                {
+                    _logger.LogWarning(stopEx,
+                        "Best-effort StopAsync failed for session {SessionId} during error handling",
+                        sessionId);
+                }
+
                 _logger.LogError(ex, "Error in Docker session {SessionId}", sessionId);
 
                 // Fetch container logs before stopping for diagnostics
@@ -488,8 +498,8 @@ public class DockerAgentExecutionService : IAgentExecutionService, IAsyncDisposa
 
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, session.Cts.Token);
 
-        // The worker's /message endpoint is JSON-only after task 4 — stream events
-        // ride the long-lived /events SSE consumed by PerSessionEventStream.
+        // The worker's /message endpoint is JSON-only under the long-lived SSE design —
+        // stream events ride the long-lived /events SSE consumed by PerSessionEventStream.
         var messageUrl = $"{session.WorkerUrl}/api/sessions/{session.WorkerSessionId}/message";
         var json = JsonSerializer.Serialize(messageRequest, CamelCaseJsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");

--- a/src/Homespun.Server/Features/ClaudeCode/Services/IPerSessionEventStream.cs
+++ b/src/Homespun.Server/Features/ClaudeCode/Services/IPerSessionEventStream.cs
@@ -1,0 +1,51 @@
+using Homespun.Features.ClaudeCode.Data;
+
+namespace Homespun.Features.ClaudeCode.Services;
+
+/// <summary>
+/// Per-worker-session long-lived SSE consumer. Runs a background task that
+/// reads the worker's <c>GET /api/sessions/{id}/events</c> endpoint for the
+/// full life of the session, invokes <see cref="ISessionEventIngestor"/>
+/// on every A2A event (so SignalR broadcasts never stop), and fans out
+/// parsed <see cref="SdkMessage"/> values to per-turn subscribers.
+///
+/// <para>
+/// This service exists to decouple the client-visible event stream from the
+/// per-turn HTTP request cycle. The Claude Agent SDK emits
+/// <c>SDKTaskNotificationMessage</c> / <c>SDKTaskStartedMessage</c> /
+/// <c>SDKTaskUpdatedMessage</c> as background bash tasks settle — often
+/// minutes after the <c>result</c> message that ends a turn. Before this
+/// service, those events piled up in the worker's <c>OutputChannel</c> with
+/// no consumer; now they flow through the long-lived reader and reach the
+/// client live.
+/// </para>
+/// </summary>
+public interface IPerSessionEventStream
+{
+    /// <summary>
+    /// Starts the background reader for a worker session. Idempotent —
+    /// second calls for the same <paramref name="homespunSessionId"/> are
+    /// a no-op.
+    /// </summary>
+    Task StartAsync(
+        string homespunSessionId,
+        string workerUrl,
+        string workerSessionId,
+        string? projectId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Subscribes to SDK messages for a single turn. Returned enumerable
+    /// completes after the next <see cref="SdkResultMessage"/> is yielded.
+    /// Throws if no reader is running for <paramref name="homespunSessionId"/>.
+    /// </summary>
+    IAsyncEnumerable<SdkMessage> SubscribeTurnAsync(
+        string homespunSessionId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Stops the background reader and completes any pending subscriber.
+    /// Safe to call for an unknown session id.
+    /// </summary>
+    Task StopAsync(string homespunSessionId);
+}

--- a/src/Homespun.Server/Features/ClaudeCode/Services/IPerSessionEventStream.cs
+++ b/src/Homespun.Server/Features/ClaudeCode/Services/IPerSessionEventStream.cs
@@ -38,6 +38,16 @@ public interface IPerSessionEventStream
     /// Subscribes to SDK messages for a single turn. Returned enumerable
     /// completes after the next <see cref="SdkResultMessage"/> is yielded.
     /// Throws if no reader is running for <paramref name="homespunSessionId"/>.
+    ///
+    /// <para>
+    /// Any <see cref="SdkMessage"/>s dispatched by the reader before a
+    /// subscriber attaches are buffered (up to 256) and replayed into the
+    /// subscriber's channel on attach in FIFO order; older messages are
+    /// dropped on overflow with a Warning. This closes the subscribe-race
+    /// window where a <c>question_pending</c>, <c>plan_pending</c>, or
+    /// <see cref="SdkResultMessage"/> could arrive before the server has
+    /// called this method for the current turn.
+    /// </para>
     /// </summary>
     IAsyncEnumerable<SdkMessage> SubscribeTurnAsync(
         string homespunSessionId,

--- a/src/Homespun.Server/Features/ClaudeCode/Services/PerSessionEventStream.cs
+++ b/src/Homespun.Server/Features/ClaudeCode/Services/PerSessionEventStream.cs
@@ -16,10 +16,15 @@ namespace Homespun.Features.ClaudeCode.Services;
 /// <c>GET /api/sessions/{id}/events</c> endpoint, line-parses every frame, and drives
 /// <see cref="ISessionEventIngestor.IngestAsync"/> for every A2A-kind event. Parsed
 /// <see cref="SdkMessage"/> values (the four remaining control-plane variants) are
-/// fanned out to a single active per-turn subscriber through a bounded
-/// <see cref="Channel{T}"/>; when the current turn has no subscriber the messages are
-/// dropped on the floor — the A2A/envelope broadcast path has already delivered the
-/// content-bearing events to clients.
+/// fanned out to a single active per-turn subscriber through an unbounded
+/// <see cref="Channel{T}"/>. When no turn subscriber is currently attached, messages
+/// are stored in a bounded pre-subscribe FIFO (cap
+/// <see cref="Reader.PreSubscribeBufferCapacity"/>) and drained into the subscriber's
+/// channel on attach; on overflow the oldest entry is evicted and a Warning logged.
+/// This closes the subscribe-race window where a <c>canUseTool</c> hook or
+/// status-update completed could arrive before the server called
+/// <see cref="IPerSessionEventStream.SubscribeTurnAsync"/>. The A2A/ingestor path runs
+/// unconditionally, so content-bearing events are never at risk.
 /// </para>
 ///
 /// <para>
@@ -159,6 +164,14 @@ public sealed class PerSessionEventStream : IPerSessionEventStream, IAsyncDispos
     /// </summary>
     private sealed class Reader : IAsyncDisposable
     {
+        /// <summary>
+        /// Cap on messages held in the pre-subscribe FIFO. 256 comfortably covers a
+        /// typical burst of control-plane messages (system/question/plan/result) that
+        /// can race the subscribe window while preventing unbounded growth on idle
+        /// sessions where a subscriber never attaches.
+        /// </summary>
+        internal const int PreSubscribeBufferCapacity = 256;
+
         private readonly PerSessionEventStream _owner;
         private readonly string _homespunSessionId;
         private readonly string _workerUrl;
@@ -166,8 +179,10 @@ public sealed class PerSessionEventStream : IPerSessionEventStream, IAsyncDispos
         private readonly string? _projectId;
         private readonly CancellationTokenSource _cts = new();
         private readonly object _turnLock = new();
+        private readonly Queue<SdkMessage> _preSubscribeBuffer = new();
         private Channel<SdkMessage>? _turnChannel;
         private Task? _readTask;
+        private int _droppedPreSubscribeCount;
 
         public Reader(
             PerSessionEventStream owner,
@@ -211,6 +226,22 @@ public sealed class PerSessionEventStream : IPerSessionEventStream, IAsyncDispos
                     SingleWriter = true,
                     AllowSynchronousContinuations = false,
                 });
+
+                // Drain any messages the reader buffered before a subscriber attached.
+                // TryWrite is synchronous on unbounded channels and always succeeds, so
+                // this is safe to do under the lock. Preserving the FIFO order means the
+                // subscriber sees the same sequence the reader observed.
+                while (_preSubscribeBuffer.TryDequeue(out var buffered))
+                {
+                    if (!channel.Writer.TryWrite(buffered))
+                    {
+                        // Unreachable for unbounded channels, but defensive.
+                        _owner._logger.LogWarning(
+                            "PerSessionEventStream {SessionId} failed to drain buffered message into new turn channel",
+                            _homespunSessionId);
+                    }
+                }
+
                 _turnChannel = channel;
                 return channel;
             }
@@ -355,9 +386,25 @@ public sealed class PerSessionEventStream : IPerSessionEventStream, IAsyncDispos
             lock (_turnLock)
             {
                 channel = _turnChannel;
+                if (channel is null)
+                {
+                    // No subscriber yet — park the message in the pre-subscribe FIFO so
+                    // it is replayed when SubscribeTurnAsync attaches. Oldest-first
+                    // eviction on overflow: the A2A/ingestor path has already persisted
+                    // content-bearing events, so overflow only drops control-plane
+                    // signals. Warn loudly.
+                    if (_preSubscribeBuffer.Count >= PreSubscribeBufferCapacity)
+                    {
+                        _preSubscribeBuffer.Dequeue();
+                        _droppedPreSubscribeCount++;
+                        _owner._logger.LogWarning(
+                            "PerSessionEventStream {SessionId} pre-subscribe buffer overflow — dropped oldest control message (cumulative dropped: {DroppedCount})",
+                            _homespunSessionId, _droppedPreSubscribeCount);
+                    }
+                    _preSubscribeBuffer.Enqueue(sdkMessage);
+                    return;
+                }
             }
-
-            if (channel is null) return;
 
             try
             {

--- a/src/Homespun.Server/Features/ClaudeCode/Services/PerSessionEventStream.cs
+++ b/src/Homespun.Server/Features/ClaudeCode/Services/PerSessionEventStream.cs
@@ -1,0 +1,452 @@
+using System.Collections.Concurrent;
+using System.Net.Http.Headers;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Channels;
+using Homespun.Features.ClaudeCode.Data;
+
+namespace Homespun.Features.ClaudeCode.Services;
+
+/// <summary>
+/// Default <see cref="IPerSessionEventStream"/> implementation.
+///
+/// <para>
+/// Opens one long-lived HTTP SSE connection per worker session against the worker's
+/// <c>GET /api/sessions/{id}/events</c> endpoint, line-parses every frame, and drives
+/// <see cref="ISessionEventIngestor.IngestAsync"/> for every A2A-kind event. Parsed
+/// <see cref="SdkMessage"/> values (the four remaining control-plane variants) are
+/// fanned out to a single active per-turn subscriber through a bounded
+/// <see cref="Channel{T}"/>; when the current turn has no subscriber the messages are
+/// dropped on the floor — the A2A/envelope broadcast path has already delivered the
+/// content-bearing events to clients.
+/// </para>
+///
+/// <para>
+/// The reader is deliberately tolerant: malformed JSON, unknown event kinds, and
+/// transient dispatch exceptions are logged at Warning and swallowed so a single bad
+/// frame never tears down the stream. The loop only terminates on cancellation,
+/// disposal, or when the worker's HTTP response closes. In all three cases any
+/// pending turn subscriber's channel writer is completed so the consumer's
+/// <c>await foreach</c> exits cleanly.
+/// </para>
+/// </summary>
+public sealed class PerSessionEventStream : IPerSessionEventStream, IAsyncDisposable
+{
+    private readonly ISessionEventIngestor _ingestor;
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<PerSessionEventStream> _logger;
+    private readonly ConcurrentDictionary<string, Reader> _readers = new();
+    private int _disposed;
+
+    public PerSessionEventStream(
+        ISessionEventIngestor ingestor,
+        HttpClient httpClient,
+        ILogger<PerSessionEventStream> logger)
+    {
+        _ingestor = ingestor;
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(
+        string homespunSessionId,
+        string workerUrl,
+        string workerSessionId,
+        string? projectId,
+        CancellationToken cancellationToken)
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            throw new ObjectDisposedException(nameof(PerSessionEventStream));
+        }
+
+        // Idempotent: a second call for the same homespunSessionId returns the running reader.
+        _readers.GetOrAdd(homespunSessionId, id =>
+        {
+            var reader = new Reader(
+                this,
+                id,
+                workerUrl,
+                workerSessionId,
+                projectId);
+            reader.Start();
+            return reader;
+        });
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<SdkMessage> SubscribeTurnAsync(
+        string homespunSessionId,
+        CancellationToken cancellationToken)
+    {
+        if (!_readers.TryGetValue(homespunSessionId, out var reader))
+        {
+            throw new InvalidOperationException(
+                $"No reader running for session {homespunSessionId}; call StartAsync first.");
+        }
+
+        var channel = reader.BeginTurn();
+        return ReadTurnAsync(reader, channel, cancellationToken);
+    }
+
+    private static async IAsyncEnumerable<SdkMessage> ReadTurnAsync(
+        Reader reader,
+        Channel<SdkMessage> channel,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        try
+        {
+            await foreach (var msg in channel.Reader.ReadAllAsync(cancellationToken))
+            {
+                yield return msg;
+                if (msg is SdkResultMessage)
+                {
+                    // End the turn as soon as the result arrives; post-result events continue
+                    // to flow through the reader to the ingestor for broadcast.
+                    yield break;
+                }
+            }
+        }
+        finally
+        {
+            reader.EndTurn(channel);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task StopAsync(string homespunSessionId)
+    {
+        if (_readers.TryRemove(homespunSessionId, out var reader))
+        {
+            await reader.DisposeAsync();
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        foreach (var key in _readers.Keys.ToArray())
+        {
+            if (_readers.TryRemove(key, out var reader))
+            {
+                try
+                {
+                    await reader.DisposeAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Error disposing reader for session {SessionId}", key);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Per-session background-read state. Owns the CTS, the background task, and the
+    /// optional channel for the current turn subscriber. Turn state mutations are
+    /// serialized with <c>_turnLock</c>; the read loop takes the lock only when it
+    /// needs to fan a parsed <see cref="SdkMessage"/> out to the subscriber or when
+    /// it completes the writer at shutdown.
+    /// </summary>
+    private sealed class Reader : IAsyncDisposable
+    {
+        private readonly PerSessionEventStream _owner;
+        private readonly string _homespunSessionId;
+        private readonly string _workerUrl;
+        private readonly string _workerSessionId;
+        private readonly string? _projectId;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly object _turnLock = new();
+        private Channel<SdkMessage>? _turnChannel;
+        private Task? _readTask;
+
+        public Reader(
+            PerSessionEventStream owner,
+            string homespunSessionId,
+            string workerUrl,
+            string workerSessionId,
+            string? projectId)
+        {
+            _owner = owner;
+            _homespunSessionId = homespunSessionId;
+            _workerUrl = workerUrl;
+            _workerSessionId = workerSessionId;
+            _projectId = projectId;
+        }
+
+        public void Start()
+        {
+            // Detached — ownership is the CTS + the task handle captured below. We explicitly
+            // do NOT flow the caller's CancellationToken into the reader's lifetime; the
+            // reader lives until Stop/Dispose is invoked on this service.
+            _readTask = Task.Run(ReadLoopAsync);
+        }
+
+        public Channel<SdkMessage> BeginTurn()
+        {
+            lock (_turnLock)
+            {
+                if (_turnChannel is not null)
+                {
+                    throw new InvalidOperationException(
+                        $"A turn subscription is already active for session {_homespunSessionId}; only one turn at a time is supported.");
+                }
+
+                // Unbounded: post-result background events ride the same reader but never
+                // reach the turn subscriber (yield break on SdkResultMessage), so head-of-line
+                // blocking is not a concern. A bounded channel would risk dropping control
+                // messages (system/question/plan) under bursty Claude SDK behaviour.
+                var channel = Channel.CreateUnbounded<SdkMessage>(new UnboundedChannelOptions
+                {
+                    SingleReader = true,
+                    SingleWriter = true,
+                    AllowSynchronousContinuations = false,
+                });
+                _turnChannel = channel;
+                return channel;
+            }
+        }
+
+        public void EndTurn(Channel<SdkMessage> channel)
+        {
+            lock (_turnLock)
+            {
+                if (ReferenceEquals(_turnChannel, channel))
+                {
+                    _turnChannel = null;
+                    channel.Writer.TryComplete();
+                }
+            }
+        }
+
+        private async Task ReadLoopAsync()
+        {
+            var ct = _cts.Token;
+            var url = $"{_workerUrl.TrimEnd('/')}/api/sessions/{_workerSessionId}/events";
+
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, url);
+                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+                using var response = await _owner._httpClient.SendAsync(
+                    request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    _owner._logger.LogWarning(
+                        "Worker event stream for session {SessionId} returned {StatusCode}",
+                        _homespunSessionId, response.StatusCode);
+                    return;
+                }
+
+                await using var stream = await response.Content.ReadAsStreamAsync(ct);
+                using var reader = new StreamReader(stream, Encoding.UTF8);
+
+                string? currentEventType = null;
+                var dataBuffer = new StringBuilder();
+
+                while (!ct.IsCancellationRequested)
+                {
+                    string? line;
+                    try
+                    {
+                        line = await reader.ReadLineAsync(ct);
+                    }
+                    catch (HttpIOException ex) when (ex.HttpRequestError == HttpRequestError.ResponseEnded)
+                    {
+                        _owner._logger.LogDebug(ex,
+                            "Worker event stream for session {SessionId} ended", _homespunSessionId);
+                        break;
+                    }
+
+                    if (line is null) break;
+
+                    if (line.StartsWith("event: ", StringComparison.Ordinal))
+                    {
+                        currentEventType = line[7..];
+                    }
+                    else if (line.StartsWith("data: ", StringComparison.Ordinal))
+                    {
+                        dataBuffer.Append(line[6..]);
+                    }
+                    else if (string.IsNullOrEmpty(line))
+                    {
+                        if (!string.IsNullOrEmpty(currentEventType) && dataBuffer.Length > 0)
+                        {
+                            await DispatchAsync(currentEventType, dataBuffer.ToString(), ct);
+                        }
+
+                        currentEventType = null;
+                        dataBuffer.Clear();
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected on Stop/Dispose.
+            }
+            catch (Exception ex)
+            {
+                _owner._logger.LogWarning(ex,
+                    "Worker event stream for session {SessionId} ended with unexpected error",
+                    _homespunSessionId);
+            }
+            finally
+            {
+                // Complete any subscriber so the consumer's await-foreach exits cleanly.
+                lock (_turnLock)
+                {
+                    _turnChannel?.Writer.TryComplete();
+                    _turnChannel = null;
+                }
+            }
+        }
+
+        private async Task DispatchAsync(string eventKind, string rawData, CancellationToken ct)
+        {
+            // Ingest A2A-kind events regardless of whether a turn subscriber is attached —
+            // that is how post-result background events reach the client after a turn has
+            // ended.
+            if (A2AMessageParser.IsA2AEventKind(eventKind))
+            {
+                try
+                {
+                    using var doc = JsonDocument.Parse(rawData);
+                    var payload = doc.RootElement.Clone();
+                    var effectiveProjectId = string.IsNullOrEmpty(_projectId) ? "unknown" : _projectId;
+                    await _owner._ingestor.IngestAsync(
+                        effectiveProjectId, _homespunSessionId, eventKind, payload, ct);
+                }
+                catch (Exception ex)
+                {
+                    _owner._logger.LogWarning(ex,
+                        "Failed to ingest {EventKind} for session {SessionId}; continuing",
+                        eventKind, _homespunSessionId);
+                }
+            }
+
+            // Translate to a control-plane SdkMessage for the current turn subscriber, if any.
+            SdkMessage? sdkMessage;
+            try
+            {
+                sdkMessage = ParseToSdkMessage(eventKind, rawData);
+            }
+            catch (Exception ex)
+            {
+                _owner._logger.LogWarning(ex,
+                    "Failed to parse {EventKind} to SdkMessage for session {SessionId}",
+                    eventKind, _homespunSessionId);
+                return;
+            }
+
+            if (sdkMessage is null) return;
+
+            Channel<SdkMessage>? channel;
+            lock (_turnLock)
+            {
+                channel = _turnChannel;
+            }
+
+            if (channel is null) return;
+
+            try
+            {
+                await channel.Writer.WriteAsync(sdkMessage, ct);
+            }
+            catch (ChannelClosedException)
+            {
+                // Subscriber completed during a race — drop the message.
+            }
+            catch (OperationCanceledException)
+            {
+                // Shutdown path.
+            }
+        }
+
+        /// <summary>
+        /// Mirrors <c>DockerAgentExecutionService.ParseSseEvent</c>'s kind-to-SdkMessage
+        /// mapping for the four legacy control events plus the A2A-native path through
+        /// <see cref="A2AMessageParser.ConvertToSdkMessage"/>. Unknown kinds return null.
+        /// </summary>
+        private SdkMessage? ParseToSdkMessage(string eventKind, string rawData)
+        {
+            if (A2AMessageParser.IsA2AEventKind(eventKind))
+            {
+                var parsed = A2AMessageParser.ParseSseEvent(eventKind, rawData);
+                return parsed is null
+                    ? null
+                    : A2AMessageParser.ConvertToSdkMessage(parsed, _homespunSessionId);
+            }
+
+            switch (eventKind)
+            {
+                case "session_started":
+                {
+                    using var doc = JsonDocument.Parse(rawData);
+                    var workerSessionId = doc.RootElement.TryGetProperty("sessionId", out var sid)
+                        ? sid.GetString()
+                        : null;
+                    return new SdkSystemMessage(
+                        workerSessionId ?? _homespunSessionId,
+                        null,
+                        "session_started",
+                        null,
+                        null);
+                }
+                case "question_pending":
+                    return new SdkQuestionPendingMessage(_homespunSessionId, rawData);
+                case "plan_pending":
+                    return new SdkPlanPendingMessage(_homespunSessionId, rawData);
+                case "error":
+                    _owner._logger.LogWarning(
+                        "Received error event from worker for session {SessionId}: {Data}",
+                        _homespunSessionId, rawData);
+                    return null;
+                default:
+                    return null;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                _cts.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Already disposed — nothing to cancel.
+            }
+
+            if (_readTask is not null)
+            {
+                try
+                {
+                    await _readTask;
+                }
+                catch
+                {
+                    // Swallowed — the read loop already logs its own failures.
+                }
+            }
+
+            lock (_turnLock)
+            {
+                _turnChannel?.Writer.TryComplete();
+                _turnChannel = null;
+            }
+
+            _cts.Dispose();
+        }
+    }
+}

--- a/src/Homespun.Server/Features/ClaudeCode/Services/PerSessionEventStreamServiceCollectionExtensions.cs
+++ b/src/Homespun.Server/Features/ClaudeCode/Services/PerSessionEventStreamServiceCollectionExtensions.cs
@@ -1,0 +1,42 @@
+namespace Homespun.Features.ClaudeCode.Services;
+
+/// <summary>
+/// DI registration for <see cref="IPerSessionEventStream"/>.
+///
+/// <para>
+/// The service MUST be registered as a <b>singleton</b>: it holds a
+/// <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/> of
+/// per-session readers, and a transient registration would give every consumer its
+/// own isolated dictionary — two consumers would not see each other's
+/// <c>StartAsync</c> calls, and <c>SubscribeTurnAsync</c> would throw
+/// "no reader running" on the second consumer.
+/// </para>
+///
+/// <para>
+/// We use a <i>named</i> <see cref="HttpClient"/> rather than
+/// <c>AddHttpClient&lt;TI, TImpl&gt;</c> (which is implicitly Transient) so
+/// <see cref="IHttpClientFactory"/> can manage handler lifetime while the service
+/// itself stays a clean singleton. The client is configured with
+/// <see cref="Timeout.InfiniteTimeSpan"/> because the SSE connection is intentionally
+/// open for the session's entire duration.
+/// </para>
+/// </summary>
+public static class PerSessionEventStreamServiceCollectionExtensions
+{
+    public static IServiceCollection AddPerSessionEventStream(this IServiceCollection services)
+    {
+        services.AddHttpClient(nameof(PerSessionEventStream), c =>
+        {
+            c.Timeout = Timeout.InfiniteTimeSpan;
+        });
+        services.AddSingleton<IPerSessionEventStream>(sp =>
+        {
+            var factory = sp.GetRequiredService<IHttpClientFactory>();
+            return new PerSessionEventStream(
+                sp.GetRequiredService<ISessionEventIngestor>(),
+                factory.CreateClient(nameof(PerSessionEventStream)),
+                sp.GetRequiredService<ILogger<PerSessionEventStream>>());
+        });
+        return services;
+    }
+}

--- a/src/Homespun.Server/Features/ClaudeCode/Services/SingleContainerAgentExecutionService.cs
+++ b/src/Homespun.Server/Features/ClaudeCode/Services/SingleContainerAgentExecutionService.cs
@@ -1,4 +1,3 @@
-using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -26,6 +25,16 @@ namespace Homespun.Features.ClaudeCode.Services;
 /// intentional no-ops: the dev runs <c>docker compose up worker</c> separately
 /// and the shim holds no container-lifetime responsibility.
 /// </para>
+///
+/// <para>
+/// Event delivery runs through <see cref="IPerSessionEventStream"/> — the
+/// worker's <c>POST /api/sessions</c> and <c>POST /api/sessions/:id/message</c>
+/// endpoints now return JSON, and the long-lived <c>GET /api/sessions/:id/events</c>
+/// SSE reader owned by <see cref="IPerSessionEventStream"/> fans out parsed
+/// <see cref="SdkMessage"/>s to per-turn subscribers and drives the ingestor on
+/// every A2A event. This keeps post-result background events flowing to the
+/// client after a turn has ended, mirroring the Docker executor.
+/// </para>
 /// </summary>
 public sealed class SingleContainerAgentExecutionService : IAgentExecutionService, IDisposable
 {
@@ -36,8 +45,9 @@ public sealed class SingleContainerAgentExecutionService : IAgentExecutionServic
 
     private readonly SingleContainerAgentExecutionOptions _options;
     private readonly ILogger<SingleContainerAgentExecutionService> _logger;
-    private readonly ISessionEventIngestor _eventIngestor;
+    private readonly IPerSessionEventStream _perSession;
     private readonly HttpClient _httpClient;
+    private readonly bool _ownsHttpClient;
 
     private readonly SemaphoreSlim _slotLock = new(1, 1);
     private ActiveSession? _active;
@@ -56,14 +66,22 @@ public sealed class SingleContainerAgentExecutionService : IAgentExecutionServic
         public string? ProjectId { get; init; }
     }
 
+    /// <summary>
+    /// Response parsed from the worker's <c>POST /api/sessions</c> and
+    /// <c>POST /api/sessions/:id/message</c> endpoints now that those endpoints
+    /// return JSON rather than an SSE stream (task 3 / task 4 of the
+    /// <c>fix-post-result-events</c> plan).
+    /// </summary>
+    private sealed record WorkerStartResponse(string SessionId, string? ConversationId);
+
     public SingleContainerAgentExecutionService(
         IOptions<SingleContainerAgentExecutionOptions> options,
         ILogger<SingleContainerAgentExecutionService> logger,
-        ISessionEventIngestor eventIngestor)
+        IPerSessionEventStream perSession)
     {
         _options = options.Value;
         _logger = logger;
-        _eventIngestor = eventIngestor;
+        _perSession = perSession;
 
         if (string.IsNullOrWhiteSpace(_options.WorkerUrl))
         {
@@ -75,6 +93,32 @@ public sealed class SingleContainerAgentExecutionService : IAgentExecutionServic
         {
             Timeout = _options.RequestTimeout,
         };
+        _ownsHttpClient = true;
+    }
+
+    /// <summary>
+    /// Test-only constructor that accepts a pre-configured <see cref="HttpClient"/>
+    /// so unit tests can exercise the per-session wiring against
+    /// <see cref="Homespun.Tests.Helpers.MockHttpMessageHandler"/>-style fakes.
+    /// </summary>
+    internal SingleContainerAgentExecutionService(
+        IOptions<SingleContainerAgentExecutionOptions> options,
+        ILogger<SingleContainerAgentExecutionService> logger,
+        IPerSessionEventStream perSession,
+        HttpClient httpClient)
+    {
+        _options = options.Value;
+        _logger = logger;
+        _perSession = perSession;
+
+        if (string.IsNullOrWhiteSpace(_options.WorkerUrl))
+        {
+            throw new InvalidOperationException(
+                "AgentExecution:SingleContainer:WorkerUrl must be set when AgentExecution:Mode=SingleContainer.");
+        }
+
+        _httpClient = httpClient;
+        _ownsHttpClient = false;
     }
 
     public async IAsyncEnumerable<SdkMessage> StartSessionAsync(
@@ -128,19 +172,108 @@ public sealed class SingleContainerAgentExecutionService : IAgentExecutionServic
             homespunSessionId = sessionId,
         };
 
-        var url = $"{_options.WorkerUrl.TrimEnd('/')}/api/sessions";
-        await foreach (var msg in StreamAgentEventsAsync(url, startBody, sessionId, request.ProjectId, session.Cts.Token))
+        var workerUrl = _options.WorkerUrl.TrimEnd('/');
+        var startUrl = $"{workerUrl}/api/sessions";
+
+        // POST to the worker — response is JSON (task 3 of the fix-post-result-events
+        // plan: the worker no longer streams SSE from the start endpoint).
+        var startJson = JsonSerializer.Serialize(startBody, CamelCaseJsonOptions);
+        using var startContent = new StringContent(startJson, Encoding.UTF8, "application/json");
+        using var startResponse = await _httpClient.PostAsync(startUrl, startContent, session.Cts.Token);
+        if (!startResponse.IsSuccessStatusCode)
         {
-            if (msg is SdkSystemMessage sys && sys.Subtype == "session_started" &&
-                !string.IsNullOrEmpty(sys.SessionId))
-            {
-                session.WorkerSessionId = sys.SessionId;
-            }
+            var errorBody = await startResponse.Content.ReadAsStringAsync(session.Cts.Token);
+            throw new InvalidOperationException(
+                $"SingleContainer worker at {startUrl} returned {startResponse.StatusCode}: {errorBody}");
+        }
+
+        var responseBody = await startResponse.Content.ReadAsStringAsync(session.Cts.Token);
+        var parsed = JsonSerializer.Deserialize<WorkerStartResponse>(
+            responseBody,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        if (parsed is null || string.IsNullOrEmpty(parsed.SessionId))
+        {
+            throw new InvalidOperationException(
+                $"SingleContainer worker at {startUrl} returned an empty / malformed start response: {responseBody}");
+        }
+
+        session.WorkerSessionId = parsed.SessionId;
+
+        // Start the long-lived per-session reader and drain the first turn's
+        // messages through it. Matching task 8 of this plan: every executor
+        // routes events through IPerSessionEventStream so post-result background
+        // events (task_notification / task_updated / task_started) keep flowing
+        // to the client after the turn's SdkResultMessage.
+        await _perSession.StartAsync(sessionId, workerUrl, parsed.SessionId, request.ProjectId, session.Cts.Token);
+
+        await foreach (var msg in DrainWithBestEffortStopAsync(sessionId, session.Cts.Token))
+        {
             if (msg is SdkResultMessage result)
             {
                 session.ConversationId = result.SessionId;
             }
             yield return msg;
+        }
+    }
+
+    /// <summary>
+    /// Wraps <see cref="IPerSessionEventStream.SubscribeTurnAsync"/> so a faulted
+    /// turn drain best-effort stops the reader. Mirrors the Task 8 I1 follow-up
+    /// on the Docker executor: if we skip this, a later session reusing the same
+    /// id would see a stale reader subscribed to the wrong worker session.
+    /// </summary>
+    private async IAsyncEnumerable<SdkMessage> DrainWithBestEffortStopAsync(
+        string sessionId,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        IAsyncEnumerator<SdkMessage>? enumerator = null;
+        try
+        {
+            enumerator = _perSession.SubscribeTurnAsync(sessionId, cancellationToken)
+                .GetAsyncEnumerator(cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            await BestEffortStopAsync(sessionId, ex);
+            throw;
+        }
+
+        try
+        {
+            while (true)
+            {
+                bool hasNext;
+                try
+                {
+                    hasNext = await enumerator.MoveNextAsync();
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    await BestEffortStopAsync(sessionId, ex);
+                    throw;
+                }
+
+                if (!hasNext) break;
+                yield return enumerator.Current;
+            }
+        }
+        finally
+        {
+            await enumerator.DisposeAsync();
+        }
+    }
+
+    private async Task BestEffortStopAsync(string sessionId, Exception cause)
+    {
+        try
+        {
+            await _perSession.StopAsync(sessionId);
+        }
+        catch (Exception stopEx)
+        {
+            _logger.LogWarning(stopEx,
+                "Best-effort PerSessionEventStream.StopAsync failed for session {SessionId} after {Cause}",
+                sessionId, cause.GetType().Name);
         }
     }
 
@@ -182,7 +315,15 @@ public sealed class SingleContainerAgentExecutionService : IAgentExecutionServic
 
         var url = $"{_options.WorkerUrl.TrimEnd('/')}/api/sessions/{active.WorkerSessionId}/message";
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, active.Cts.Token);
-        await foreach (var msg in StreamAgentEventsAsync(url, body, active.SessionId, null, linked.Token))
+
+        // The worker's /message endpoint is JSON-only under the long-lived SSE design —
+        // stream events ride the long-lived /events SSE consumed by PerSessionEventStream.
+        var messageJson = JsonSerializer.Serialize(body, CamelCaseJsonOptions);
+        using var content = new StringContent(messageJson, Encoding.UTF8, "application/json");
+        using var response = await _httpClient.PostAsync(url, content, linked.Token);
+        response.EnsureSuccessStatusCode();
+
+        await foreach (var msg in _perSession.SubscribeTurnAsync(active.SessionId, linked.Token))
         {
             yield return msg;
         }
@@ -208,6 +349,22 @@ public sealed class SingleContainerAgentExecutionService : IAgentExecutionServic
         if (toStop is null) return;
 
         toStop.Cts.Cancel();
+
+        // Halt the long-lived PerSessionEventStream reader before tearing the
+        // session down so no post-stop events race an already-removed slot.
+        // Even though this service doesn't tear down the container (it's
+        // shared), it must still stop the reader so a subsequent session for
+        // a different id doesn't have a stale reader subscribed to the wrong
+        // session. StopAsync is safe to call for unknown ids.
+        try
+        {
+            await _perSession.StopAsync(sessionId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "PerSessionEventStream.StopAsync failed for session {SessionId}; continuing teardown", sessionId);
+        }
 
         if (!string.IsNullOrEmpty(toStop.WorkerSessionId))
         {
@@ -434,103 +591,11 @@ public sealed class SingleContainerAgentExecutionService : IAgentExecutionServic
 
     public void Dispose()
     {
-        _httpClient.Dispose();
+        if (_ownsHttpClient)
+        {
+            _httpClient.Dispose();
+        }
         _slotLock.Dispose();
         _active?.Cts.Dispose();
-    }
-
-    private async IAsyncEnumerable<SdkMessage> StreamAgentEventsAsync(
-        string url,
-        object requestBody,
-        string sessionId,
-        string? projectId,
-        [EnumeratorCancellation] CancellationToken cancellationToken)
-    {
-        var json = JsonSerializer.Serialize(requestBody, CamelCaseJsonOptions);
-        using var content = new StringContent(json, Encoding.UTF8, "application/json");
-        using var request = new HttpRequestMessage(HttpMethod.Post, url) { Content = content };
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
-
-        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-        if (!response.IsSuccessStatusCode)
-        {
-            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
-            throw new InvalidOperationException(
-                $"SingleContainer worker at {url} returned {response.StatusCode}: {errorBody}");
-        }
-
-        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
-        using var reader = new StreamReader(stream);
-
-        string? eventType = null;
-        var data = new StringBuilder();
-
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            var line = await reader.ReadLineAsync(cancellationToken);
-            if (line is null) break;
-
-            if (line.StartsWith("event: "))
-            {
-                eventType = line[7..];
-            }
-            else if (line.StartsWith("data: "))
-            {
-                data.Append(line[6..]);
-            }
-            else if (line.Length == 0)
-            {
-                if (!string.IsNullOrEmpty(eventType) && data.Length > 0)
-                {
-                    var raw = data.ToString();
-                    await TryIngestA2AAsync(eventType, raw, sessionId, projectId, cancellationToken);
-                    var msg = TryParseSdkMessage(eventType, raw, sessionId);
-                    if (msg is not null)
-                    {
-                        yield return msg;
-                        if (msg is SdkResultMessage) yield break;
-                    }
-                }
-                eventType = null;
-                data.Clear();
-            }
-        }
-    }
-
-    private async Task TryIngestA2AAsync(string eventKind, string rawData, string sessionId, string? projectId, CancellationToken cancellationToken)
-    {
-        if (!A2AMessageParser.IsA2AEventKind(eventKind)) return;
-        try
-        {
-            using var doc = JsonDocument.Parse(rawData);
-            var payload = doc.RootElement.Clone();
-
-            var effectiveProjectId = string.IsNullOrEmpty(projectId) ? "unknown" : projectId;
-            await _eventIngestor.IngestAsync(effectiveProjectId, sessionId, eventKind, payload, cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex,
-                "SingleContainer ingestor tap failed for session {SessionId} kind {Kind}",
-                sessionId, eventKind);
-        }
-    }
-
-    private SdkMessage? TryParseSdkMessage(string eventKind, string rawData, string sessionId)
-    {
-        try
-        {
-            if (A2AMessageParser.IsA2AEventKind(eventKind))
-            {
-                var a2aEvent = A2AMessageParser.ParseSseEvent(eventKind, rawData);
-                if (a2aEvent is null) return null;
-                return A2AMessageParser.ConvertToSdkMessage(a2aEvent, sessionId);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to parse worker SSE event {EventKind}", eventKind);
-        }
-        return null;
     }
 }

--- a/src/Homespun.Server/Features/Testing/MockServiceExtensions.cs
+++ b/src/Homespun.Server/Features/Testing/MockServiceExtensions.cs
@@ -276,6 +276,10 @@ public static class MockServiceExtensions
             Console.WriteLine("[AgentExecution] SingleContainer: Registering SingleContainerAgentExecutionService");
             services.Configure<SingleContainerAgentExecutionOptions>(
                 configuration.GetSection(SingleContainerAgentExecutionOptions.SectionName));
+            // SingleContainerAgentExecutionService depends on the IPerSessionEventStream
+            // singleton for its rewired /events consumption path (task 9 of the
+            // fix-post-result-events plan). The mock DI graph must register it too.
+            services.AddPerSessionEventStream();
             services.AddSingleton<IAgentExecutionService, SingleContainerAgentExecutionService>();
         }
         else

--- a/src/Homespun.Server/Features/Testing/MockServiceExtensions.cs
+++ b/src/Homespun.Server/Features/Testing/MockServiceExtensions.cs
@@ -254,6 +254,10 @@ public static class MockServiceExtensions
                 if (!string.IsNullOrEmpty(hostPath))
                     opts.HostDataPath = hostPath;
             });
+            // DockerAgentExecutionService depends on the IPerSessionEventStream singleton
+            // for its rewired /events consumption path (task 8 of the
+            // fix-post-result-events plan). The mock DI graph must register it too.
+            services.AddPerSessionEventStream();
             services.AddSingleton<IAgentExecutionService, DockerAgentExecutionService>();
             services.AddSingleton<IContainerDiscoveryService, ContainerDiscoveryService>();
             services.AddHostedService(sp =>

--- a/src/Homespun.Server/Program.cs
+++ b/src/Homespun.Server/Program.cs
@@ -311,12 +311,11 @@ else
     // GET /api/sessions/{id}/events endpoint for the full session lifetime and drives
     // the ingestor on every A2A event. This is what keeps post-result background events
     // (task_notification / task_updated / task_started) flowing to the client after a
-    // turn has ended. The HttpClient is registered with an infinite timeout because the
-    // SSE connection is intentionally open for the session's entire duration.
-    builder.Services.AddHttpClient<IPerSessionEventStream, PerSessionEventStream>(c =>
-    {
-        c.Timeout = Timeout.InfiniteTimeSpan;
-    });
+    // turn has ended. MUST be a singleton (the service holds a per-session reader
+    // dictionary) — see PerSessionEventStreamServiceCollectionExtensions for the
+    // named-HttpClient wiring that keeps the service a clean singleton while
+    // IHttpClientFactory manages handler lifetime.
+    builder.Services.AddPerSessionEventStream();
 
     // Pending-tool-call registry + result appender — bridge between the translator's
     // input-required → TOOL_CALL_* emission and the hub's AnswerQuestion / ApprovePlan

--- a/src/Homespun.Server/Program.cs
+++ b/src/Homespun.Server/Program.cs
@@ -307,6 +307,17 @@ else
     // envelope broadcast. Single point where the append-before-broadcast invariant lives.
     builder.Services.AddSingleton<ISessionEventIngestor, SessionEventIngestor>();
 
+    // PerSessionEventStream — long-lived background reader that consumes the worker's
+    // GET /api/sessions/{id}/events endpoint for the full session lifetime and drives
+    // the ingestor on every A2A event. This is what keeps post-result background events
+    // (task_notification / task_updated / task_started) flowing to the client after a
+    // turn has ended. The HttpClient is registered with an infinite timeout because the
+    // SSE connection is intentionally open for the session's entire duration.
+    builder.Services.AddHttpClient<IPerSessionEventStream, PerSessionEventStream>(c =>
+    {
+        c.Timeout = Timeout.InfiniteTimeSpan;
+    });
+
     // Pending-tool-call registry + result appender — bridge between the translator's
     // input-required → TOOL_CALL_* emission and the hub's AnswerQuestion / ApprovePlan
     // handlers. The translator registers the toolCallId; the hub dequeues it and feeds a

--- a/src/Homespun.Worker/src/routes/sessions.ts
+++ b/src/Homespun.Worker/src/routes/sessions.ts
@@ -191,6 +191,24 @@ export function createSessionsRoute(sessionManager: SessionManager) {
     return c.json({ ok: true });
   });
 
+  // GET /sessions/:id/events - Long-lived SSE stream of session events.
+  // Stays open for the life of the session; emits every A2A event including
+  // task notifications that arrive after the SDK result message.
+  sessions.get('/:id/events', async (c) => {
+    const sessionId = c.req.param('id');
+    info(`GET /sessions/${sessionId}/events - long-lived SSE consumer opened`);
+
+    c.header('Content-Type', 'text/event-stream');
+    c.header('Cache-Control', 'no-cache');
+    c.header('Connection', 'keep-alive');
+
+    return stream(c, async (s) => {
+      for await (const chunk of streamSessionEvents(sessionManager, sessionId)) {
+        await s.write(chunk);
+      }
+    });
+  });
+
   // GET /sessions/:id - Get session info
   sessions.get('/:id', (c) => {
     const sessionId = c.req.param('id');

--- a/src/Homespun.Worker/src/routes/sessions.ts
+++ b/src/Homespun.Worker/src/routes/sessions.ts
@@ -50,39 +50,25 @@ export function createSessionsRoute(sessionManager: SessionManager) {
     });
   });
 
-  // POST /sessions - Start or resume a session (SSE stream)
+  // POST /sessions - Start or resume a session (JSON response)
   sessions.post('/', async (c) => {
     const body = await c.req.json<StartSessionRequest>();
     info(`POST /sessions - mode=${body.mode}, model=${body.model}, workingDirectory=${body.workingDirectory}, resumeSessionId=${body.resumeSessionId || 'none'}`);
 
-    c.header('Content-Type', 'text/event-stream');
-    c.header('Cache-Control', 'no-cache');
-    c.header('Connection', 'keep-alive');
-
-    return stream(c, async (s) => {
-      try {
-        const ws = await sessionManager.create({
-          prompt: body.prompt,
-          model: body.model,
-          mode: body.mode,
-          systemPrompt: body.systemPrompt,
-          workingDirectory: body.workingDirectory,
-          resumeSessionId: body.resumeSessionId,
-        });
-
-        for await (const chunk of streamSessionEvents(sessionManager, ws.id)) {
-          await s.write(chunk);
-        }
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        await s.write(formatSSE('error', {
-          sessionId: 'unknown',
-          message,
-          code: 'STARTUP_ERROR',
-          isRecoverable: false,
-        }));
-      }
-    });
+    try {
+      const ws = await sessionManager.create({
+        prompt: body.prompt,
+        model: body.model,
+        mode: body.mode,
+        systemPrompt: body.systemPrompt,
+        workingDirectory: body.workingDirectory,
+        resumeSessionId: body.resumeSessionId,
+      });
+      return c.json({ sessionId: ws.id, conversationId: ws.conversationId ?? null });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return c.json({ error: message, code: 'STARTUP_ERROR' }, 500);
+    }
   });
 
   // POST /sessions/:id/message - Send a message to an existing session (SSE stream)

--- a/src/Homespun.Worker/src/routes/sessions.ts
+++ b/src/Homespun.Worker/src/routes/sessions.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { stream } from 'hono/streaming';
 import type { SessionManager } from '../services/session-manager.js';
-import { streamSessionEvents, formatSSE } from '../services/sse-writer.js';
+import { streamSessionEvents } from '../services/sse-writer.js';
 import { discoverSessions } from '../services/session-discovery.js';
 import type {
   StartSessionRequest,
@@ -214,49 +214,28 @@ export function createSessionsRoute(sessionManager: SessionManager) {
     return c.json({ ok: true, message: 'Session stopped', sessionId });
   });
 
-  // POST /sessions/:id/clear-context - Clear context and start a new session (SSE stream)
+  // POST /sessions/:id/clear-context - Clear context and start a new session (JSON response)
   sessions.post('/:id/clear-context', async (c) => {
     const sessionId = c.req.param('id');
     const body = await c.req.json<ClearContextRequest>();
     info(`POST /sessions/${sessionId}/clear-context - mode=${body.mode}, model=${body.model}`);
 
-    c.header('Content-Type', 'text/event-stream');
-    c.header('Cache-Control', 'no-cache');
-    c.header('Connection', 'keep-alive');
-
-    return stream(c, async (s) => {
-      try {
-        const { newSession, oldSessionId } = await sessionManager.clearContextAndCreate(
-          sessionId,
-          {
-            prompt: body.prompt,
-            model: body.model,
-            mode: body.mode,
-            systemPrompt: body.systemPrompt,
-            workingDirectory: body.workingDirectory,
-          }
-        );
-
-        // Send initial event with new session info
-        await s.write(formatSSE('context_cleared', {
-          oldSessionId,
-          newSessionId: newSession.id,
-        }));
-
-        // Stream the new session events
-        for await (const chunk of streamSessionEvents(sessionManager, newSession.id)) {
-          await s.write(chunk);
+    try {
+      const { newSession, oldSessionId } = await sessionManager.clearContextAndCreate(
+        sessionId,
+        {
+          prompt: body.prompt,
+          model: body.model,
+          mode: body.mode,
+          systemPrompt: body.systemPrompt,
+          workingDirectory: body.workingDirectory,
         }
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        await s.write(formatSSE('error', {
-          sessionId,
-          message,
-          code: 'CLEAR_CONTEXT_ERROR',
-          isRecoverable: false,
-        }));
-      }
-    });
+      );
+      return c.json({ oldSessionId, newSessionId: newSession.id });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return c.json({ error: message, code: 'CLEAR_CONTEXT_ERROR' }, 500);
+    }
   });
 
   return sessions;

--- a/src/Homespun.Worker/src/routes/sessions.ts
+++ b/src/Homespun.Worker/src/routes/sessions.ts
@@ -71,33 +71,19 @@ export function createSessionsRoute(sessionManager: SessionManager) {
     }
   });
 
-  // POST /sessions/:id/message - Send a message to an existing session (SSE stream)
+  // POST /sessions/:id/message - Send a message to an existing session (JSON response)
   sessions.post('/:id/message', async (c) => {
     const sessionId = c.req.param('id');
     const body = await c.req.json<SendMessageRequest>();
     info(`POST /sessions/${sessionId}/message - mode=${body.mode}, messageLength=${body.message?.length}, model=${body.model}`);
 
-    c.header('Content-Type', 'text/event-stream');
-    c.header('Cache-Control', 'no-cache');
-    c.header('Connection', 'keep-alive');
-
-    return stream(c, async (s) => {
-      try {
-        await sessionManager.send(sessionId, body.message, body.model, body.mode);
-
-        for await (const chunk of streamSessionEvents(sessionManager, sessionId)) {
-          await s.write(chunk);
-        }
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        await s.write(formatSSE('error', {
-          sessionId,
-          message,
-          code: 'MESSAGE_ERROR',
-          isRecoverable: false,
-        }));
-      }
-    });
+    try {
+      await sessionManager.send(sessionId, body.message, body.model, body.mode);
+      return c.json({ ok: true });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return c.json({ ok: false, error: message, code: 'MESSAGE_ERROR' }, 500);
+    }
   });
 
   // POST /sessions/:id/answer - Answer a pending question (JSON response)

--- a/src/Homespun.Worker/src/services/sse-writer.ts
+++ b/src/Homespun.Worker/src/services/sse-writer.ts
@@ -252,7 +252,12 @@ export async function* streamSessionEvents(
 
         const statusUpdate = translateResultToStatus(msg, ctx);
         yield emitAndFormatSSE(sessionId, statusUpdate.kind, statusUpdate);
-        return;
+        // Do NOT return here: the SDK query iterator stays open across turns
+        // and still emits task_notification / task_started / task_updated
+        // messages whenever background tools finish (sometimes minutes after
+        // the result). The long-lived GET /events consumer on the server
+        // drains them; closing the generator orphans them in OutputChannel.
+        continue;
       }
 
       // Regular SDK messages -> A2A Message

--- a/tests/Homespun.Api.Tests/Features/PostResultTaskNotificationTests.cs
+++ b/tests/Homespun.Api.Tests/Features/PostResultTaskNotificationTests.cs
@@ -1,0 +1,235 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Homespun.Features.ClaudeCode.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Homespun.Api.Tests.Features;
+
+/// <summary>
+/// Integration test for the post-result task-notification bug fix.
+///
+/// <para>
+/// Before the <c>fix-post-result-events</c> refactor, an SDK task notification
+/// (an A2A <c>message</c> frame) arriving AFTER the SDK <c>result</c> (an A2A
+/// <c>status-update</c> with <c>state="completed"</c>, <c>final: true</c>)
+/// would buffer in the worker's OutputChannel until the user sent a new prompt.
+/// </para>
+///
+/// <para>
+/// The refactor wires every A2A frame straight from the worker's long-lived SSE
+/// stream through <see cref="PerSessionEventStream"/> into
+/// <see cref="ISessionEventIngestor"/> — which appends to
+/// <see cref="IA2AEventStore"/> and broadcasts via SignalR. This test proves the
+/// post-result frame still reaches the event store (the SignalR-broadcast
+/// source of truth) end-to-end, without any new prompt driving the turn.
+/// </para>
+///
+/// <para>
+/// The test swaps the named <c>PerSessionEventStream</c> <see cref="HttpClient"/>
+/// for a fake SSE handler that returns three frames: assistant message →
+/// status-update completed (result) → post-result task-notification message.
+/// It then resolves <see cref="IPerSessionEventStream"/> from the real DI graph,
+/// calls <see cref="IPerSessionEventStream.StartAsync"/>, and polls
+/// <see cref="IA2AEventStore.ReadAsync"/> until all three frames are persisted.
+/// </para>
+/// </summary>
+[TestFixture]
+public class PostResultTaskNotificationTests
+{
+    private const string SessionId = "test-session-post-result";
+    private const string WorkerSessionId = "worker-post-result";
+    private const string ProjectId = "proj-post-result";
+
+    [Test]
+    public async Task Task_notification_after_result_is_ingested_without_new_prompt()
+    {
+        var sseBody = BuildSseBody();
+
+        await using var factory = new PerSessionHarness(sseBody);
+        var store = factory.Services.GetRequiredService<IA2AEventStore>();
+        var stream = factory.Services.GetRequiredService<IPerSessionEventStream>();
+
+        // StartAsync kicks off the background reader. The fake handler returns the pre-baked
+        // SSE body and then EOF; the reader dispatches every frame through the real
+        // ISessionEventIngestor, which appends to the real IA2AEventStore.
+        await stream.StartAsync(
+            SessionId,
+            "http://fake-worker",
+            WorkerSessionId,
+            ProjectId,
+            CancellationToken.None);
+
+        // Poll until all three A2A events have been persisted. The reader's async
+        // pipeline may take a few ms to parse + dispatch + call the ingestor, and
+        // the ingestor in turn does translation + SignalR fan-out per event.
+        await WaitForConditionAsync(
+            async () =>
+            {
+                var records = await store.ReadAsync(SessionId, since: null, CancellationToken.None);
+                return records is not null && records.Count >= 3;
+            },
+            TimeSpan.FromSeconds(5));
+
+        var records = await store.ReadAsync(SessionId, since: null, CancellationToken.None);
+
+        Assert.That(records, Is.Not.Null, "session event log must exist after ingestion");
+        Assert.That(records!.Count, Is.EqualTo(3),
+            "expected all three frames (message, status-update, message) to be persisted");
+        Assert.That(
+            records.Select(r => r.EventKind).ToList(),
+            Is.EqualTo(new[] { "message", "status-update", "message" }),
+            "events must be persisted in the order they arrived on the SSE stream");
+
+        // The critical assertion: the THIRD record (the post-result task_notification)
+        // was persisted — which means ISessionEventIngestor.IngestAsync fired for it
+        // despite arriving after the result. That is exactly what the refactor guarantees.
+        Assert.That(records[2].EventKind, Is.EqualTo("message"),
+            "post-result task_notification must be the third persisted event");
+    }
+
+    /// <summary>
+    /// Builds an SSE body containing three frames: an assistant agent message, a
+    /// status-update carrying <c>completed</c> + <c>final: true</c> (the SDK result),
+    /// and a post-result message carrying a <c>task_notification</c> payload.
+    /// </summary>
+    private static string BuildSseBody()
+    {
+        var agentMessage = JsonSerializer.Serialize(new
+        {
+            kind = "message",
+            messageId = "m-1",
+            role = "agent",
+            taskId = "t-1",
+            contextId = SessionId,
+            parts = new object[]
+            {
+                new { kind = "text", text = "hi" },
+            },
+            metadata = new
+            {
+                sdkMessageType = "assistant",
+            },
+        });
+
+        var statusUpdate = JsonSerializer.Serialize(new
+        {
+            kind = "status-update",
+            taskId = "t-1",
+            contextId = SessionId,
+            status = new
+            {
+                state = "completed",
+                timestamp = "2026-04-24T00:00:00Z",
+            },
+            final = true,
+        });
+
+        var taskNotification = JsonSerializer.Serialize(new
+        {
+            kind = "message",
+            messageId = "m-2",
+            role = "agent",
+            taskId = "t-1",
+            contextId = SessionId,
+            parts = new object[]
+            {
+                new
+                {
+                    kind = "data",
+                    data = new { subtype = "task_notification" },
+                    metadata = new { kind = "task_notification" },
+                },
+            },
+            metadata = new
+            {
+                sdkMessageType = "task_notification",
+            },
+        });
+
+        var sb = new StringBuilder();
+        sb.Append("event: message\n");
+        sb.Append("data: ").Append(agentMessage).Append('\n');
+        sb.Append('\n');
+        sb.Append("event: status-update\n");
+        sb.Append("data: ").Append(statusUpdate).Append('\n');
+        sb.Append('\n');
+        sb.Append("event: message\n");
+        sb.Append("data: ").Append(taskNotification).Append('\n');
+        sb.Append('\n');
+        return sb.ToString();
+    }
+
+    private static async Task WaitForConditionAsync(
+        Func<Task<bool>> predicate,
+        TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await predicate()) return;
+            await Task.Delay(50);
+        }
+        Assert.Fail($"Condition not met within {timeout}");
+    }
+
+    /// <summary>
+    /// A specialization of <see cref="HomespunWebApplicationFactory"/> that swaps
+    /// the named <c>PerSessionEventStream</c> <see cref="HttpClient"/> primary
+    /// message handler for an in-memory fake SSE handler. The swap happens via
+    /// <see cref="IWebHostBuilder.ConfigureTestServices"/> so it wins over the
+    /// server-side default registration added by
+    /// <see cref="PerSessionEventStreamServiceCollectionExtensions.AddPerSessionEventStream"/>.
+    /// </summary>
+    private sealed class PerSessionHarness : HomespunWebApplicationFactory
+    {
+        private readonly string _sseBody;
+
+        public PerSessionHarness(string sseBody)
+        {
+            _sseBody = sseBody;
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            base.ConfigureWebHost(builder);
+            builder.ConfigureTestServices(services =>
+            {
+                // Register the PerSessionEventStream service. In Mock mode (which
+                // HomespunWebApplicationFactory uses by default), the mock-agent path skips
+                // this registration — so we opt back in here for the integration surface
+                // under test.
+                services.AddPerSessionEventStream();
+
+                // Swap the named HttpClient's primary handler for our fake SSE handler.
+                // ConfigureTestServices runs after the server's ConfigureServices, so this
+                // AddHttpClient call overrides the one that AddPerSessionEventStream made.
+                services
+                    .AddHttpClient(nameof(PerSessionEventStream))
+                    .ConfigurePrimaryHttpMessageHandler(() => new FakeSseHandler(_sseBody));
+            });
+        }
+    }
+
+    private sealed class FakeSseHandler : HttpMessageHandler
+    {
+        private readonly string _sseBody;
+
+        public FakeSseHandler(string sseBody)
+        {
+            _sseBody = sseBody;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var resp = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_sseBody, Encoding.UTF8, "text/event-stream"),
+            };
+            return Task.FromResult(resp);
+        }
+    }
+}

--- a/tests/Homespun.Tests/Features/ClaudeCode/DockerAgentExecutionServiceTests.cs
+++ b/tests/Homespun.Tests/Features/ClaudeCode/DockerAgentExecutionServiceTests.cs
@@ -1,5 +1,10 @@
+using System.Net;
+using System.Text.Json;
+using Homespun.Features.ClaudeCode.Data;
 using Homespun.Features.ClaudeCode.Services;
 using Homespun.Features.Secrets;
+using Homespun.Shared.Models.Sessions;
+using Homespun.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -9,12 +14,31 @@ namespace Homespun.Tests.Features.ClaudeCode;
 /// <summary>
 /// Unit tests for <see cref="DockerAgentExecutionService"/> covering the
 /// OTel environment injection (task 7.2) and the SIGTERM-friendly stop
-/// flag (task 7.3) introduced by the <c>worker-otel</c> change.
+/// flag (task 7.3) introduced by the <c>worker-otel</c> change, plus the
+/// rewire onto <see cref="IPerSessionEventStream"/> (task 8 of the
+/// <c>fix-post-result-events</c> plan).
 /// </summary>
 [TestFixture]
 public class DockerAgentExecutionServiceTests
 {
     private static DockerAgentExecutionService Build(
+        DockerAgentExecutionOptions? options = null,
+        IPerSessionEventStream? perSession = null)
+    {
+        return new DockerAgentExecutionService(
+            Options.Create(options ?? new DockerAgentExecutionOptions
+            {
+                ServerOtlpProxyUrl = "http://host.docker.internal:5101/api/otlp/v1",
+            }),
+            NullLogger<DockerAgentExecutionService>.Instance,
+            new Mock<ISecretsService>().Object,
+            new Mock<ISessionEventIngestor>().Object,
+            perSession ?? new Mock<IPerSessionEventStream>().Object);
+    }
+
+    private static DockerAgentExecutionService BuildWithHttp(
+        HttpClient httpClient,
+        IPerSessionEventStream perSession,
         DockerAgentExecutionOptions? options = null)
     {
         return new DockerAgentExecutionService(
@@ -24,7 +48,9 @@ public class DockerAgentExecutionServiceTests
             }),
             NullLogger<DockerAgentExecutionService>.Instance,
             new Mock<ISecretsService>().Object,
-            new Mock<Homespun.Features.ClaudeCode.Services.ISessionEventIngestor>().Object);
+            new Mock<ISessionEventIngestor>().Object,
+            perSession,
+            httpClient);
     }
 
     [Test]
@@ -262,5 +288,165 @@ public class DockerAgentExecutionServiceTests
         var redacted = DockerAgentExecutionService.RedactSecretsInDockerArgs(raw);
 
         Assert.That(redacted, Is.EqualTo(raw));
+    }
+
+    // -------------------------------------------------------------------
+    // Task 8: PerSessionEventStream rewire
+    // -------------------------------------------------------------------
+
+    /// <summary>
+    /// Emits a single <see cref="SdkResultMessage"/> and ends. Mirrors the shape
+    /// <see cref="IPerSessionEventStream.SubscribeTurnAsync"/> gives real consumers:
+    /// the sequence terminates on the first result message.
+    /// </summary>
+    private static async IAsyncEnumerable<SdkMessage> ResultOnly(string sessionId)
+    {
+        await Task.Yield();
+        yield return new SdkResultMessage(
+            SessionId: sessionId,
+            Uuid: Guid.NewGuid().ToString(),
+            Subtype: "success",
+            DurationMs: 42,
+            DurationApiMs: 10,
+            IsError: false,
+            NumTurns: 1,
+            TotalCostUsd: 0m,
+            Result: "ok",
+            Errors: null);
+    }
+
+    [Test]
+    public async Task SendMessageAsync_posts_json_then_subscribes_to_per_session_stream()
+    {
+        var handler = new MockHttpMessageHandler();
+        handler.RespondWith("/message", new { ok = true });
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://fake/") };
+
+        var perSession = new Mock<IPerSessionEventStream>();
+        perSession
+            .Setup(p => p.SubscribeTurnAsync("outer-s1", It.IsAny<CancellationToken>()))
+            .Returns(ResultOnly("outer-s1"));
+
+        var svc = BuildWithHttp(httpClient, perSession.Object);
+        svc.RegisterSessionForTesting(
+            homespunSessionId: "outer-s1",
+            workerSessionId: "worker-s1",
+            workerUrl: "http://fake",
+            projectId: "p1");
+
+        var request = new AgentMessageRequest(
+            SessionId: "outer-s1",
+            Message: "hello",
+            Mode: SessionMode.Build,
+            Model: "sonnet");
+
+        var yielded = new List<SdkMessage>();
+        await foreach (var msg in svc.SendMessageAsync(request, CancellationToken.None))
+        {
+            yielded.Add(msg);
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(yielded, Has.Count.EqualTo(1), "expected exactly the single SdkResultMessage");
+            Assert.That(yielded[0], Is.InstanceOf<SdkResultMessage>());
+            Assert.That(((SdkResultMessage)yielded[0]).SessionId, Is.EqualTo("outer-s1"),
+                "RemapSessionId should have rewritten the result's session id");
+        });
+
+        var messagePost = handler.CapturedRequests
+            .FirstOrDefault(r => r.Method == HttpMethod.Post && r.Url.Contains("/api/sessions/worker-s1/message"));
+        Assert.That(messagePost, Is.Not.Null, "expected a POST to /api/sessions/{workerSessionId}/message");
+        // Body is JSON; verify it round-trips and contains the message text.
+        var body = messagePost!.Body;
+        Assert.That(body, Is.Not.Null.And.Contains("\"message\""));
+        Assert.That(body, Does.Contain("hello"));
+
+        perSession.Verify(
+            p => p.SubscribeTurnAsync("outer-s1", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "SendMessageAsync must subscribe to the per-session stream exactly once for the turn");
+    }
+
+    [Test]
+    public async Task StopSessionAsync_stops_the_per_session_event_stream()
+    {
+        var handler = new MockHttpMessageHandler();
+        handler.RespondWithStatus("/api/sessions/worker-s1", HttpStatusCode.OK);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://fake/") };
+
+        var perSession = new Mock<IPerSessionEventStream>();
+        perSession.Setup(p => p.StopAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+
+        var svc = BuildWithHttp(httpClient, perSession.Object);
+        svc.RegisterSessionForTesting(
+            homespunSessionId: "outer-s1",
+            workerSessionId: "worker-s1",
+            workerUrl: "http://fake",
+            projectId: "p1");
+
+        await svc.StopSessionAsync("outer-s1", forceStopContainer: false, CancellationToken.None);
+
+        perSession.Verify(
+            p => p.StopAsync("outer-s1"),
+            Times.Once,
+            "StopSessionAsync must halt the per-session reader before teardown");
+    }
+
+    [Test]
+    public async Task StartSessionAsync_starts_per_session_event_stream_and_drains_turn()
+    {
+        // This test exercises only the HTTP + per-session-stream wiring, bypassing
+        // container startup by pre-registering the session through the test seam
+        // and invoking the internal runner directly.
+        var handler = new MockHttpMessageHandler();
+        handler.RespondWith("/api/sessions", new { sessionId = "worker-s1", conversationId = (string?)null });
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://fake/") };
+
+        var perSession = new Mock<IPerSessionEventStream>();
+        perSession
+            .Setup(p => p.StartAsync(
+                "outer-s1", "http://fake", "worker-s1", "p1", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Verifiable();
+        perSession
+            .Setup(p => p.SubscribeTurnAsync("outer-s1", It.IsAny<CancellationToken>()))
+            .Returns(ResultOnly("outer-s1"));
+
+        var svc = BuildWithHttp(httpClient, perSession.Object);
+        svc.RegisterSessionForTesting(
+            homespunSessionId: "outer-s1",
+            workerSessionId: null,
+            workerUrl: "http://fake",
+            projectId: "p1");
+
+        var request = new AgentStartRequest(
+            WorkingDirectory: "/tmp/clone",
+            Mode: SessionMode.Build,
+            Model: "sonnet",
+            Prompt: "go",
+            IssueId: "i1",
+            ProjectId: "p1",
+            HomespunSessionId: "outer-s1");
+
+        var yielded = await svc.RunStartSessionWorkerLoopForTestingAsync(
+            "outer-s1", "http://fake", request, CancellationToken.None);
+
+        perSession.Verify(
+            p => p.StartAsync("outer-s1", "http://fake", "worker-s1", "p1", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "StartSessionAsync must start the per-session reader with the parsed worker session id");
+
+        perSession.Verify(
+            p => p.SubscribeTurnAsync("outer-s1", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "StartSessionAsync must drain the first turn through the per-session subscription");
+
+        var startPost = handler.CapturedRequests
+            .FirstOrDefault(r => r.Method == HttpMethod.Post && r.Url.EndsWith("/api/sessions"));
+        Assert.That(startPost, Is.Not.Null, "expected a POST to /api/sessions");
+
+        Assert.That(yielded, Has.Some.InstanceOf<SdkResultMessage>(),
+            "the turn drain should surface the result message");
     }
 }

--- a/tests/Homespun.Tests/Features/ClaudeCode/DockerAgentExecutionServiceTests.cs
+++ b/tests/Homespun.Tests/Features/ClaudeCode/DockerAgentExecutionServiceTests.cs
@@ -32,7 +32,6 @@ public class DockerAgentExecutionServiceTests
             }),
             NullLogger<DockerAgentExecutionService>.Instance,
             new Mock<ISecretsService>().Object,
-            new Mock<ISessionEventIngestor>().Object,
             perSession ?? new Mock<IPerSessionEventStream>().Object);
     }
 
@@ -48,7 +47,6 @@ public class DockerAgentExecutionServiceTests
             }),
             NullLogger<DockerAgentExecutionService>.Instance,
             new Mock<ISecretsService>().Object,
-            new Mock<ISessionEventIngestor>().Object,
             perSession,
             httpClient);
     }

--- a/tests/Homespun.Tests/Features/ClaudeCode/PerSessionEventStreamTests.cs
+++ b/tests/Homespun.Tests/Features/ClaudeCode/PerSessionEventStreamTests.cs
@@ -1,0 +1,261 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Homespun.Features.ClaudeCode.Data;
+using Homespun.Features.ClaudeCode.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Homespun.Tests.Features.ClaudeCode;
+
+/// <summary>
+/// Unit tests for <see cref="PerSessionEventStream"/> — the long-lived worker SSE
+/// consumer that drives <see cref="ISessionEventIngestor"/> on every A2A event and
+/// fans parsed <see cref="SdkMessage"/> values out to per-turn subscribers.
+/// </summary>
+[TestFixture]
+public class PerSessionEventStreamTests
+{
+    private const string HomespunSessionId = "s1";
+    private const string WorkerSessionId = "w1";
+    private const string ProjectId = "p1";
+    private const string WorkerBaseUrl = "http://fake";
+
+    /// <summary>
+    /// Fakes the worker's <c>GET /api/sessions/{id}/events</c> response by emitting a
+    /// pre-baked SSE body once, then returning EOF. The stream ends as soon as the
+    /// reader's <c>StreamReader</c> exhausts the buffer — plenty of time for the
+    /// background reader to dispatch every frame.
+    /// </summary>
+    private sealed class SseResponseHandler : HttpMessageHandler
+    {
+        private readonly string _body;
+        private readonly List<HttpRequestMessage> _requests = new();
+
+        public IReadOnlyList<HttpRequestMessage> Requests => _requests;
+
+        public SseResponseHandler(string body)
+        {
+            _body = body;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            _requests.Add(request);
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_body, Encoding.UTF8, "text/event-stream"),
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    /// <summary>
+    /// Builds an SSE body with two A2A frames: a <c>status-update</c> carrying a
+    /// <c>completed</c> state + <c>final: true</c>, and a <c>message</c> frame shaped
+    /// as a minimal agent message. The body is terminated by a trailing blank line so
+    /// the reader flushes the second frame before EOF.
+    /// </summary>
+    private static string BuildTwoFrameSseBody()
+    {
+        var statusUpdate = JsonSerializer.Serialize(new
+        {
+            kind = "status-update",
+            taskId = "t1",
+            contextId = HomespunSessionId,
+            status = new
+            {
+                state = "completed",
+                timestamp = "2026-04-24T00:00:00Z",
+            },
+            final = true,
+        });
+
+        var message = JsonSerializer.Serialize(new
+        {
+            kind = "message",
+            messageId = "m1",
+            role = "agent",
+            taskId = "t1",
+            contextId = HomespunSessionId,
+            parts = new object[]
+            {
+                new { kind = "text", text = "hi" },
+            },
+            metadata = new
+            {
+                sdkMessageType = "task_notification",
+            },
+        });
+
+        var sb = new StringBuilder();
+        sb.Append("event: status-update\n");
+        sb.Append("data: ").Append(statusUpdate).Append('\n');
+        sb.Append('\n');
+        sb.Append("event: message\n");
+        sb.Append("data: ").Append(message).Append('\n');
+        sb.Append('\n');
+        return sb.ToString();
+    }
+
+    private static async Task WaitForConditionAsync(
+        Func<bool> predicate,
+        TimeSpan? timeout = null,
+        TimeSpan? poll = null)
+    {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
+        var delay = poll ?? TimeSpan.FromMilliseconds(25);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate()) return;
+            await Task.Delay(delay);
+        }
+    }
+
+    [Test]
+    public async Task StartAsync_DispatchesEveryA2AFrameToIngestor()
+    {
+        var ingestor = new Mock<ISessionEventIngestor>();
+        ingestor
+            .Setup(i => i.IngestAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<JsonElement>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        using var handler = new SseResponseHandler(BuildTwoFrameSseBody());
+        using var httpClient = new HttpClient(handler);
+        var stream = new PerSessionEventStream(
+            ingestor.Object, httpClient, NullLogger<PerSessionEventStream>.Instance);
+
+        await stream.StartAsync(HomespunSessionId, WorkerBaseUrl, WorkerSessionId, ProjectId, CancellationToken.None);
+
+        // Wait until both frames have been dispatched (or timeout).
+        await WaitForConditionAsync(() =>
+        {
+            try
+            {
+                ingestor.Verify(i => i.IngestAsync(
+                    ProjectId, HomespunSessionId, "status-update",
+                    It.IsAny<JsonElement>(), It.IsAny<CancellationToken>()), Times.Once);
+                ingestor.Verify(i => i.IngestAsync(
+                    ProjectId, HomespunSessionId, "message",
+                    It.IsAny<JsonElement>(), It.IsAny<CancellationToken>()), Times.Once);
+                return true;
+            }
+            catch (MockException)
+            {
+                return false;
+            }
+        });
+
+        ingestor.Verify(i => i.IngestAsync(
+            ProjectId, HomespunSessionId, "status-update",
+            It.IsAny<JsonElement>(), It.IsAny<CancellationToken>()), Times.Once);
+        ingestor.Verify(i => i.IngestAsync(
+            ProjectId, HomespunSessionId, "message",
+            It.IsAny<JsonElement>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        // Request was shaped like the worker contract.
+        Assert.That(handler.Requests, Has.Count.EqualTo(1));
+        var req = handler.Requests[0];
+        Assert.That(req.Method, Is.EqualTo(HttpMethod.Get));
+        Assert.That(req.RequestUri?.ToString(), Is.EqualTo($"{WorkerBaseUrl}/api/sessions/{WorkerSessionId}/events"));
+        Assert.That(req.Headers.Accept.ToString(), Does.Contain("text/event-stream"));
+
+        await stream.StopAsync(HomespunSessionId);
+        await stream.DisposeAsync();
+    }
+
+    [Test]
+    public async Task StartAsync_IsIdempotentForSameSession()
+    {
+        var ingestor = new Mock<ISessionEventIngestor>();
+        ingestor
+            .Setup(i => i.IngestAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<JsonElement>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        using var handler = new SseResponseHandler(BuildTwoFrameSseBody());
+        using var httpClient = new HttpClient(handler);
+        var stream = new PerSessionEventStream(
+            ingestor.Object, httpClient, NullLogger<PerSessionEventStream>.Instance);
+
+        await stream.StartAsync(HomespunSessionId, WorkerBaseUrl, WorkerSessionId, ProjectId, CancellationToken.None);
+        await stream.StartAsync(HomespunSessionId, WorkerBaseUrl, WorkerSessionId, ProjectId, CancellationToken.None);
+
+        // Give the reader a moment to settle; only one HTTP request should have been made.
+        await Task.Delay(200);
+
+        Assert.That(handler.Requests, Has.Count.EqualTo(1),
+            "second StartAsync for the same session must be a no-op");
+
+        await stream.DisposeAsync();
+    }
+
+    [Test]
+    public async Task SubscribeTurnAsync_YieldsSdkResultMessageThenCompletes()
+    {
+        var ingestor = new Mock<ISessionEventIngestor>();
+        ingestor
+            .Setup(i => i.IngestAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<JsonElement>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        using var handler = new SseResponseHandler(BuildTwoFrameSseBody());
+        using var httpClient = new HttpClient(handler);
+        var stream = new PerSessionEventStream(
+            ingestor.Object, httpClient, NullLogger<PerSessionEventStream>.Instance);
+
+        await stream.StartAsync(HomespunSessionId, WorkerBaseUrl, WorkerSessionId, ProjectId, CancellationToken.None);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var messages = new List<SdkMessage>();
+        await foreach (var msg in stream.SubscribeTurnAsync(HomespunSessionId, cts.Token))
+        {
+            messages.Add(msg);
+            if (msg is SdkResultMessage) break;
+        }
+
+        Assert.That(messages, Has.Count.GreaterThanOrEqualTo(1));
+        Assert.That(messages.OfType<SdkResultMessage>().ToList(), Has.Count.EqualTo(1),
+            "status-update completed must materialize as exactly one SdkResultMessage");
+
+        await stream.DisposeAsync();
+    }
+
+    [Test]
+    public void SubscribeTurnAsync_ThrowsWhenReaderNotStarted()
+    {
+        var ingestor = new Mock<ISessionEventIngestor>();
+        using var handler = new SseResponseHandler(string.Empty);
+        using var httpClient = new HttpClient(handler);
+        var stream = new PerSessionEventStream(
+            ingestor.Object, httpClient, NullLogger<PerSessionEventStream>.Instance);
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var _ in stream.SubscribeTurnAsync("never-started", CancellationToken.None))
+            {
+                // never reached
+            }
+        });
+    }
+
+    [Test]
+    public async Task StopAsync_IsSafeForUnknownSession()
+    {
+        var ingestor = new Mock<ISessionEventIngestor>();
+        using var handler = new SseResponseHandler(string.Empty);
+        using var httpClient = new HttpClient(handler);
+        var stream = new PerSessionEventStream(
+            ingestor.Object, httpClient, NullLogger<PerSessionEventStream>.Instance);
+
+        Assert.DoesNotThrowAsync(async () => await stream.StopAsync("unknown"));
+
+        await stream.DisposeAsync();
+    }
+}

--- a/tests/Homespun.Tests/Features/ClaudeCode/PerSessionEventStreamTests.cs
+++ b/tests/Homespun.Tests/Features/ClaudeCode/PerSessionEventStreamTests.cs
@@ -261,6 +261,208 @@ public class PerSessionEventStreamTests
     }
 
     /// <summary>
+    /// The reader dispatches messages whether or not a subscriber is attached. This test
+    /// proves the pre-subscribe buffer: seed the handler with a status-update completed
+    /// (→ <see cref="SdkResultMessage"/>) AND a <c>question_pending</c> frame
+    /// (→ <see cref="SdkQuestionPendingMessage"/>), let the reader drain them before any
+    /// subscriber attaches, THEN call <see cref="IPerSessionEventStream.SubscribeTurnAsync"/>
+    /// and assert both messages are replayed in order.
+    /// </summary>
+    [Test]
+    public async Task BeginTurn_DrainsPreSubscribeBuffer_IntoNewChannel()
+    {
+        var ingestor = new Mock<ISessionEventIngestor>();
+        ingestor
+            .Setup(i => i.IngestAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<JsonElement>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Build a body containing a question_pending frame FIRST, then a status-update
+        // completed (→ SdkResultMessage). FIFO order must be preserved by the drain.
+        var questionData = JsonSerializer.Serialize(new
+        {
+            questionId = "q1",
+            prompt = "may I?",
+        });
+        var statusUpdate = JsonSerializer.Serialize(new
+        {
+            kind = "status-update",
+            taskId = "t1",
+            contextId = HomespunSessionId,
+            status = new
+            {
+                state = "completed",
+                timestamp = "2026-04-24T00:00:00Z",
+            },
+            final = true,
+        });
+
+        var sb = new StringBuilder();
+        sb.Append("event: question_pending\n");
+        sb.Append("data: ").Append(questionData).Append('\n');
+        sb.Append('\n');
+        sb.Append("event: status-update\n");
+        sb.Append("data: ").Append(statusUpdate).Append('\n');
+        sb.Append('\n');
+
+        using var handler = new SseResponseHandler(sb.ToString());
+        using var httpClient = new HttpClient(handler);
+        var stream = new PerSessionEventStream(
+            ingestor.Object, httpClient, NullLogger<PerSessionEventStream>.Instance);
+
+        await stream.StartAsync(HomespunSessionId, WorkerBaseUrl, WorkerSessionId, ProjectId, CancellationToken.None);
+
+        // Wait until the reader has drained the body into the pre-subscribe buffer. The
+        // ingestor only sees A2A frames (status-update), so a single IngestAsync call is
+        // our signal that the reader has processed both frames (question_pending is
+        // dispatched in-order ahead of it, buffered synchronously under the lock).
+        await WaitForConditionAsync(() =>
+        {
+            try
+            {
+                ingestor.Verify(i => i.IngestAsync(
+                    ProjectId, HomespunSessionId, "status-update",
+                    It.IsAny<JsonElement>(), It.IsAny<CancellationToken>()), Times.Once);
+                return true;
+            }
+            catch (MockException)
+            {
+                return false;
+            }
+        });
+
+        // Small yield so the reader has definitely enqueued the SdkResultMessage after
+        // the ingestor call (both happen inside the same DispatchAsync call for the
+        // status-update, but the SdkResultMessage push is after the ingestor await).
+        await Task.Delay(50);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var messages = new List<SdkMessage>();
+        await foreach (var msg in stream.SubscribeTurnAsync(HomespunSessionId, cts.Token))
+        {
+            messages.Add(msg);
+            if (msg is SdkResultMessage) break;
+        }
+
+        Assert.That(messages, Has.Count.EqualTo(2),
+            "buffer must replay both pre-subscribe messages into the new turn channel");
+        Assert.That(messages[0], Is.InstanceOf<SdkQuestionPendingMessage>(),
+            "FIFO order: question_pending was dispatched first");
+        Assert.That(messages[1], Is.InstanceOf<SdkResultMessage>(),
+            "FIFO order: status-update completed was dispatched second");
+
+        await stream.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Seeds the handler with more than <c>PreSubscribeBufferCapacity</c> control frames
+    /// (each <c>question_pending</c> → <see cref="SdkQuestionPendingMessage"/>). The
+    /// reader drains them into the buffer with no subscriber attached, which must
+    /// trigger oldest-first eviction and log a Warning on each overflow. On attach the
+    /// subscriber sees exactly <c>PreSubscribeBufferCapacity</c> messages.
+    /// </summary>
+    [Test]
+    public async Task DispatchAsync_OverflowsBuffer_LogsWarningAndDropsOldest()
+    {
+        const int seed = 258; // 2 over the 256 cap
+        const int expectedRetained = 256;
+
+        var ingestor = new Mock<ISessionEventIngestor>();
+        ingestor
+            .Setup(i => i.IngestAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<JsonElement>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var sb = new StringBuilder();
+        for (int i = 0; i < seed; i++)
+        {
+            var data = JsonSerializer.Serialize(new { questionId = $"q{i}", prompt = "p" });
+            sb.Append("event: question_pending\n");
+            sb.Append("data: ").Append(data).Append('\n');
+            sb.Append('\n');
+        }
+        // Terminator frame: use a status-update completed so the subscriber can
+        // deterministically break out after consuming the retained buffer tail.
+        var statusUpdate = JsonSerializer.Serialize(new
+        {
+            kind = "status-update",
+            taskId = "t1",
+            contextId = HomespunSessionId,
+            status = new { state = "completed", timestamp = "2026-04-24T00:00:00Z" },
+            final = true,
+        });
+        sb.Append("event: status-update\n");
+        sb.Append("data: ").Append(statusUpdate).Append('\n');
+        sb.Append('\n');
+
+        var logger = new Mock<ILogger<PerSessionEventStream>>();
+        logger.Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+
+        using var handler = new SseResponseHandler(sb.ToString());
+        using var httpClient = new HttpClient(handler);
+        var stream = new PerSessionEventStream(ingestor.Object, httpClient, logger.Object);
+
+        await stream.StartAsync(HomespunSessionId, WorkerBaseUrl, WorkerSessionId, ProjectId, CancellationToken.None);
+
+        // Wait until the terminating status-update has been processed by the ingestor —
+        // by then every preceding question_pending has also been dispatched (and thus
+        // buffered / evicted) because DispatchAsync is serial within the read loop.
+        await WaitForConditionAsync(() =>
+        {
+            try
+            {
+                ingestor.Verify(i => i.IngestAsync(
+                    ProjectId, HomespunSessionId, "status-update",
+                    It.IsAny<JsonElement>(), It.IsAny<CancellationToken>()), Times.Once);
+                return true;
+            }
+            catch (MockException)
+            {
+                return false;
+            }
+        });
+
+        // Small yield to ensure the SdkResultMessage produced from the status-update has
+        // been enqueued into the pre-subscribe buffer (after the ingestor await).
+        await Task.Delay(50);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var messages = new List<SdkMessage>();
+        await foreach (var msg in stream.SubscribeTurnAsync(HomespunSessionId, cts.Token))
+        {
+            messages.Add(msg);
+            if (msg is SdkResultMessage) break;
+        }
+
+        // 258 question_pending + 1 result = 259 total dispatched, buffer cap 256.
+        // The oldest 3 (2 question_pending + oldest... actually: after enqueueing the
+        // 257th message the buffer evicts #0; after 258th evicts #1; after the result
+        // evicts #2). Net retained: messages [3..257] (255 question_pending) + result =
+        // 256 total.
+        Assert.That(messages, Has.Count.EqualTo(expectedRetained),
+            "buffer must retain exactly PreSubscribeBufferCapacity messages after overflow");
+        Assert.That(messages.OfType<SdkResultMessage>().Count(), Is.EqualTo(1),
+            "terminating SdkResultMessage must be retained (youngest)");
+        Assert.That(messages[^1], Is.InstanceOf<SdkResultMessage>(),
+            "SdkResultMessage must be the youngest message retained");
+
+        // Verify Warning was logged at least twice (once per overflow; 3 overflows here).
+        logger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeast(2),
+            "pre-subscribe buffer overflow must log a Warning per evicted message");
+
+        await stream.DisposeAsync();
+    }
+
+    /// <summary>
     /// Regression guard for the DI lifetime bug: <see cref="PerSessionEventStream"/> holds
     /// a per-session reader dictionary, so a transient registration would orphan prior
     /// <c>StartAsync</c> calls whenever a second consumer resolves the service.

--- a/tests/Homespun.Tests/Features/ClaudeCode/PerSessionEventStreamTests.cs
+++ b/tests/Homespun.Tests/Features/ClaudeCode/PerSessionEventStreamTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using Homespun.Features.ClaudeCode.Data;
 using Homespun.Features.ClaudeCode.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -257,5 +258,30 @@ public class PerSessionEventStreamTests
         Assert.DoesNotThrowAsync(async () => await stream.StopAsync("unknown"));
 
         await stream.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Regression guard for the DI lifetime bug: <see cref="PerSessionEventStream"/> holds
+    /// a per-session reader dictionary, so a transient registration would orphan prior
+    /// <c>StartAsync</c> calls whenever a second consumer resolves the service.
+    /// <see cref="PerSessionEventStreamServiceCollectionExtensions.AddPerSessionEventStream"/>
+    /// must register the service as a singleton — if anyone reverts this, the test fails.
+    /// </summary>
+    [Test]
+    public async Task AddPerSessionEventStream_RegistersServiceAsSingleton()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<ISessionEventIngestor>(Mock.Of<ISessionEventIngestor>());
+        services.AddPerSessionEventStream();
+
+        // PerSessionEventStream is IAsyncDisposable-only, so the provider must be
+        // disposed asynchronously — synchronous disposal throws at the
+        // ServiceProviderEngineScope level.
+        await using var sp = services.BuildServiceProvider();
+        var a = sp.GetRequiredService<IPerSessionEventStream>();
+        var b = sp.GetRequiredService<IPerSessionEventStream>();
+
+        Assert.That(a, Is.SameAs(b));
     }
 }

--- a/tests/Homespun.Tests/Features/ClaudeCode/SingleContainerAgentExecutionServiceTests.cs
+++ b/tests/Homespun.Tests/Features/ClaudeCode/SingleContainerAgentExecutionServiceTests.cs
@@ -1,7 +1,10 @@
+using System.Net;
 using System.Runtime.InteropServices;
+using Homespun.Features.ClaudeCode.Data;
 using Homespun.Features.ClaudeCode.Exceptions;
 using Homespun.Features.ClaudeCode.Services;
 using Homespun.Shared.Models.Sessions;
+using Homespun.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -13,9 +16,9 @@ public class SingleContainerAgentExecutionServiceTests
 {
     private static SingleContainerAgentExecutionService Build(
         string? workerUrl = "http://localhost:8081",
-        ISessionEventIngestor? ingestor = null,
         string hostWorkspaceRoot = "",
-        string containerWorkspaceRoot = "/workdir")
+        string containerWorkspaceRoot = "/workdir",
+        IPerSessionEventStream? perSession = null)
     {
         var opts = Options.Create(new SingleContainerAgentExecutionOptions
         {
@@ -26,7 +29,25 @@ public class SingleContainerAgentExecutionServiceTests
         return new SingleContainerAgentExecutionService(
             opts,
             NullLogger<SingleContainerAgentExecutionService>.Instance,
-            ingestor ?? new Mock<ISessionEventIngestor>().Object);
+            perSession ?? new Mock<IPerSessionEventStream>().Object);
+    }
+
+    private static SingleContainerAgentExecutionService BuildWithHttp(
+        HttpClient httpClient,
+        IPerSessionEventStream perSession,
+        string workerUrl = "http://fake")
+    {
+        var opts = Options.Create(new SingleContainerAgentExecutionOptions
+        {
+            WorkerUrl = workerUrl,
+            HostWorkspaceRoot = string.Empty,
+            ContainerWorkspaceRoot = "/workdir",
+        });
+        return new SingleContainerAgentExecutionService(
+            opts,
+            NullLogger<SingleContainerAgentExecutionService>.Instance,
+            perSession,
+            httpClient);
     }
 
     [Test]
@@ -65,9 +86,9 @@ public class SingleContainerAgentExecutionServiceTests
     public async Task BusyGuard_ReleasesSlotOnStop_ThenAllowsNewSession()
     {
         // Integration-style check using only public surface: without an HTTP worker the
-        // inner StreamAgentEventsAsync will fail; that's expected. We assert that
-        // after StopSessionAsync the slot is released so a second start would not
-        // throw SingleContainerBusyException on the fast path.
+        // per-session stream start will fail; that's expected. We assert that after
+        // StopSessionAsync the slot is released so a second start would not throw
+        // SingleContainerBusyException on the fast path.
         using var svc = Build();
 
         // Attempt to start with an unreachable URL — should throw but the slot is
@@ -208,5 +229,256 @@ public class SingleContainerAgentExecutionServiceTests
         using var svc = Build(hostWorkspaceRoot: "", containerWorkspaceRoot: "/workdir");
         Assert.Throws<InvalidOperationException>(
             () => svc.TranslateWorkingDirectoryForContainer(@"C:\anything"));
+    }
+
+    // -------------------------------------------------------------------
+    // Task 9: PerSessionEventStream rewire
+    // -------------------------------------------------------------------
+
+    /// <summary>
+    /// Emits a single <see cref="SdkResultMessage"/> and ends. Mirrors the shape
+    /// <see cref="IPerSessionEventStream.SubscribeTurnAsync"/> gives real consumers:
+    /// the sequence terminates on the first result message.
+    /// </summary>
+    private static async IAsyncEnumerable<SdkMessage> ResultOnly(string sessionId)
+    {
+        await Task.Yield();
+        yield return new SdkResultMessage(
+            SessionId: sessionId,
+            Uuid: Guid.NewGuid().ToString(),
+            Subtype: "success",
+            DurationMs: 42,
+            DurationApiMs: 10,
+            IsError: false,
+            NumTurns: 1,
+            TotalCostUsd: 0m,
+            Result: "ok",
+            Errors: null);
+    }
+
+    /// <summary>
+    /// Async enumerable that throws on first MoveNextAsync. Used to exercise
+    /// the error-path best-effort StopAsync call.
+    /// </summary>
+#pragma warning disable CS1998
+    private static async IAsyncEnumerable<SdkMessage> Throws()
+    {
+        throw new InvalidOperationException("worker blew up");
+#pragma warning disable CS0162 // Unreachable code detected — required to satisfy iterator shape.
+        yield break;
+#pragma warning restore CS0162
+    }
+#pragma warning restore CS1998
+
+    [Test]
+    public async Task StartSessionAsync_starts_per_session_event_stream_and_drains_turn()
+    {
+        var handler = new MockHttpMessageHandler();
+        handler.RespondWith(
+            "/api/sessions",
+            new { sessionId = "worker-s1", conversationId = (string?)null });
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://fake/") };
+
+        var perSession = new Mock<IPerSessionEventStream>();
+        perSession
+            .Setup(p => p.StartAsync(
+                "S1", "http://fake", "worker-s1", "p1", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Verifiable();
+        perSession
+            .Setup(p => p.SubscribeTurnAsync("S1", It.IsAny<CancellationToken>()))
+            .Returns(ResultOnly("S1"));
+
+        using var svc = BuildWithHttp(httpClient, perSession.Object);
+
+        var request = new AgentStartRequest(
+            WorkingDirectory: "/tmp",
+            Mode: SessionMode.Build,
+            Model: "sonnet",
+            Prompt: "go",
+            ProjectId: "p1",
+            HomespunSessionId: "S1");
+
+        var yielded = new List<SdkMessage>();
+        await foreach (var msg in svc.StartSessionAsync(request, CancellationToken.None))
+        {
+            yielded.Add(msg);
+        }
+
+        perSession.Verify(
+            p => p.StartAsync("S1", "http://fake", "worker-s1", "p1", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "StartSessionAsync must start the per-session reader with the parsed worker session id");
+
+        perSession.Verify(
+            p => p.SubscribeTurnAsync("S1", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "StartSessionAsync must drain the first turn through the per-session subscription");
+
+        var startPost = handler.CapturedRequests
+            .FirstOrDefault(r => r.Method == HttpMethod.Post && r.Url.EndsWith("/api/sessions"));
+        Assert.That(startPost, Is.Not.Null, "expected a POST to /api/sessions");
+
+        Assert.That(yielded, Has.Some.InstanceOf<SdkResultMessage>(),
+            "the turn drain should surface the result message");
+    }
+
+    [Test]
+    public async Task SendMessageAsync_posts_json_then_subscribes_to_per_session_stream()
+    {
+        var handler = new MockHttpMessageHandler();
+        handler.RespondWith(
+            "/api/sessions",
+            new { sessionId = "worker-s1", conversationId = (string?)null });
+        handler.RespondWith("/message", new { ok = true });
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://fake/") };
+
+        var perSession = new Mock<IPerSessionEventStream>();
+        perSession
+            .Setup(p => p.StartAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        perSession
+            .Setup(p => p.SubscribeTurnAsync("S1", It.IsAny<CancellationToken>()))
+            .Returns(() => ResultOnly("S1"));
+
+        using var svc = BuildWithHttp(httpClient, perSession.Object);
+
+        // First prime the active slot via StartSessionAsync so SendMessageAsync has
+        // an ActiveSession with a WorkerSessionId to target.
+        var startReq = new AgentStartRequest(
+            WorkingDirectory: "/tmp",
+            Mode: SessionMode.Build,
+            Model: "sonnet",
+            Prompt: "go",
+            ProjectId: "p1",
+            HomespunSessionId: "S1");
+
+        await foreach (var _ in svc.StartSessionAsync(startReq, CancellationToken.None))
+        {
+            // drain
+        }
+
+        // Now exercise SendMessageAsync — the code matches on either SessionId or
+        // WorkerSessionId. Use SessionId="S1" (outer).
+        var msgReq = new AgentMessageRequest(
+            SessionId: "S1",
+            Message: "hello",
+            Mode: SessionMode.Build,
+            Model: "sonnet");
+
+        var yielded = new List<SdkMessage>();
+        await foreach (var msg in svc.SendMessageAsync(msgReq, CancellationToken.None))
+        {
+            yielded.Add(msg);
+        }
+
+        Assert.That(yielded, Has.Count.EqualTo(1), "expected exactly the single SdkResultMessage");
+        Assert.That(yielded[0], Is.InstanceOf<SdkResultMessage>());
+
+        var messagePost = handler.CapturedRequests
+            .FirstOrDefault(r => r.Method == HttpMethod.Post && r.Url.Contains("/api/sessions/worker-s1/message"));
+        Assert.That(messagePost, Is.Not.Null, "expected a POST to /api/sessions/{workerSessionId}/message");
+        var body = messagePost!.Body;
+        Assert.That(body, Is.Not.Null.And.Contains("\"message\""));
+        Assert.That(body, Does.Contain("hello"));
+
+        // Exactly two SubscribeTurnAsync calls total: one for start, one for send.
+        perSession.Verify(
+            p => p.SubscribeTurnAsync("S1", It.IsAny<CancellationToken>()),
+            Times.Exactly(2),
+            "SendMessageAsync must subscribe to the per-session stream exactly once for its turn");
+    }
+
+    [Test]
+    public async Task StopSessionAsync_stops_the_per_session_event_stream()
+    {
+        var handler = new MockHttpMessageHandler();
+        handler.RespondWith(
+            "/api/sessions",
+            new { sessionId = "worker-s1", conversationId = (string?)null });
+        handler.RespondWithStatus("/api/sessions/worker-s1", HttpStatusCode.OK);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://fake/") };
+
+        var perSession = new Mock<IPerSessionEventStream>();
+        perSession
+            .Setup(p => p.StartAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        perSession
+            .Setup(p => p.SubscribeTurnAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(() => ResultOnly("S1"));
+        perSession.Setup(p => p.StopAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+
+        using var svc = BuildWithHttp(httpClient, perSession.Object);
+
+        // Prime an active session first.
+        var startReq = new AgentStartRequest(
+            WorkingDirectory: "/tmp",
+            Mode: SessionMode.Build,
+            Model: "sonnet",
+            Prompt: "go",
+            ProjectId: "p1",
+            HomespunSessionId: "S1");
+
+        await foreach (var _ in svc.StartSessionAsync(startReq, CancellationToken.None))
+        {
+            // drain
+        }
+
+        await svc.StopSessionAsync("S1", forceStopContainer: false, CancellationToken.None);
+
+        perSession.Verify(
+            p => p.StopAsync("S1"),
+            Times.Once,
+            "StopSessionAsync must halt the per-session reader, even though the container is shared");
+    }
+
+    [Test]
+    public async Task StartSessionAsync_stops_reader_on_worker_failure()
+    {
+        var handler = new MockHttpMessageHandler();
+        handler.RespondWith(
+            "/api/sessions",
+            new { sessionId = "worker-s1", conversationId = (string?)null });
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://fake/") };
+
+        var perSession = new Mock<IPerSessionEventStream>();
+        perSession
+            .Setup(p => p.StartAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        perSession
+            .Setup(p => p.SubscribeTurnAsync("S1", It.IsAny<CancellationToken>()))
+            .Returns(Throws());
+        perSession.Setup(p => p.StopAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+
+        using var svc = BuildWithHttp(httpClient, perSession.Object);
+
+        var request = new AgentStartRequest(
+            WorkingDirectory: "/tmp",
+            Mode: SessionMode.Build,
+            Model: "sonnet",
+            Prompt: "go",
+            ProjectId: "p1",
+            HomespunSessionId: "S1");
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var _ in svc.StartSessionAsync(request, CancellationToken.None))
+            {
+                // drain
+            }
+        });
+
+        perSession.Verify(
+            p => p.StopAsync("S1"),
+            Times.AtLeastOnce,
+            "StartSessionAsync must best-effort stop the per-session reader when the turn drain throws");
+
+        await Task.CompletedTask;
     }
 }

--- a/tests/Homespun.Worker/routes/sessions.test.ts
+++ b/tests/Homespun.Worker/routes/sessions.test.ts
@@ -141,11 +141,42 @@ describe('GET /sessions', () => {
 });
 
 describe('POST /sessions', () => {
-  it('returns SSE stream response', async () => {
+  it('returns JSON body with sessionId and conversationId', async () => {
+    const { sm, app } = createApp();
+    sm.create.mockResolvedValue({ id: 'new-session', conversationId: 'c1' });
+
+    const res = await app.request('/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        prompt: 'Hello',
+        model: 'sonnet',
+        mode: 'Plan',
+        systemPrompt: 'sys',
+        workingDirectory: '/tmp/wd',
+        resumeSessionId: 'prev-1',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json();
+    expect(body).toEqual({ sessionId: 'new-session', conversationId: 'c1' });
+
+    expect(sm.create).toHaveBeenCalledTimes(1);
+    expect(sm.create).toHaveBeenCalledWith({
+      prompt: 'Hello',
+      model: 'sonnet',
+      mode: 'Plan',
+      systemPrompt: 'sys',
+      workingDirectory: '/tmp/wd',
+      resumeSessionId: 'prev-1',
+    });
+  });
+
+  it('returns conversationId: null when WorkerSession has none', async () => {
     const { sm, app } = createApp();
     sm.create.mockResolvedValue({ id: 'new-session' });
-    sm.get.mockReturnValue({ id: 'new-session', conversationId: 'c1' });
-    sm.stream.mockReturnValue((async function* () {})());
 
     const res = await app.request('/', {
       method: 'POST',
@@ -158,13 +189,12 @@ describe('POST /sessions', () => {
     });
 
     expect(res.status).toBe(200);
-    const text = await res.text();
-    const events = parseSSEEvents(text);
-    // A2A Protocol: session start emits 'task' event instead of 'session_started'
-    expect(events.some((e) => e.event === 'task')).toBe(true);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json();
+    expect(body).toEqual({ sessionId: 'new-session', conversationId: null });
   });
 
-  it('returns STARTUP_ERROR event on create failure', async () => {
+  it('returns JSON 500 with STARTUP_ERROR code on create failure', async () => {
     const { sm, app } = createApp();
     sm.create.mockRejectedValue(new Error('SDK init failed'));
 
@@ -178,14 +208,10 @@ describe('POST /sessions', () => {
       }),
     });
 
-    const text = await res.text();
-    const events = parseSSEEvents(text);
-    const errorEvent = events.find((e) => e.event === 'error');
-    expect(errorEvent).toBeDefined();
-    expect(errorEvent!.data).toMatchObject({
-      code: 'STARTUP_ERROR',
-      message: 'SDK init failed',
-    });
+    expect(res.status).toBe(500);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json();
+    expect(body).toEqual({ error: 'SDK init failed', code: 'STARTUP_ERROR' });
   });
 });
 

--- a/tests/Homespun.Worker/routes/sessions.test.ts
+++ b/tests/Homespun.Worker/routes/sessions.test.ts
@@ -216,55 +216,28 @@ describe('POST /sessions', () => {
 });
 
 describe('POST /sessions/:id/message', () => {
-  it('calls send() and streams events', async () => {
+  it('returns JSON { ok: true } and calls send with (sessionId, message, model, mode)', async () => {
     const { sm, app } = createApp();
     sm.send.mockResolvedValue(undefined);
-    sm.get.mockReturnValue({ id: 'sess-1', conversationId: 'c1' });
-    sm.stream.mockReturnValue((async function* () {})());
 
     const res = await app.request('/sess-1/message', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ message: 'Follow up' }),
+      body: JSON.stringify({ message: 'Follow up', model: 'sonnet', mode: 'Build' }),
     });
 
     expect(res.status).toBe(200);
-    expect(sm.send).toHaveBeenCalledWith('sess-1', 'Follow up', undefined, undefined);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json();
+    expect(body).toEqual({ ok: true });
+
+    expect(sm.send).toHaveBeenCalledTimes(1);
+    expect(sm.send).toHaveBeenCalledWith('sess-1', 'Follow up', 'sonnet', 'Build');
   });
 
-  it('passes mode to send()', async () => {
+  it('returns JSON 500 with MESSAGE_ERROR code when send throws', async () => {
     const { sm, app } = createApp();
-    sm.send.mockResolvedValue(undefined);
-    sm.get.mockReturnValue({ id: 'sess-1', conversationId: 'c1' });
-    sm.stream.mockReturnValue((async function* () {})());
-
-    await app.request('/sess-1/message', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ message: 'Follow up', mode: 'Build' }),
-    });
-
-    expect(sm.send).toHaveBeenCalledWith('sess-1', 'Follow up', undefined, 'Build');
-  });
-
-  it('passes undefined mode when not provided', async () => {
-    const { sm, app } = createApp();
-    sm.send.mockResolvedValue(undefined);
-    sm.get.mockReturnValue({ id: 'sess-1', conversationId: 'c1' });
-    sm.stream.mockReturnValue((async function* () {})());
-
-    await app.request('/sess-1/message', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ message: 'Follow up' }),
-    });
-
-    expect(sm.send).toHaveBeenCalledWith('sess-1', 'Follow up', undefined, undefined);
-  });
-
-  it('returns MESSAGE_ERROR event on send failure', async () => {
-    const { sm, app } = createApp();
-    sm.send.mockRejectedValue(new Error('Session lost'));
+    sm.send.mockRejectedValue(new Error('boom'));
 
     const res = await app.request('/sess-1/message', {
       method: 'POST',
@@ -272,12 +245,10 @@ describe('POST /sessions/:id/message', () => {
       body: JSON.stringify({ message: 'Follow up' }),
     });
 
-    const text = await res.text();
-    const events = parseSSEEvents(text);
-    const errorEvent = events.find((e) => e.event === 'error');
-    expect(errorEvent!.data).toMatchObject({
-      code: 'MESSAGE_ERROR',
-    });
+    expect(res.status).toBe(500);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json();
+    expect(body).toEqual({ ok: false, error: 'boom', code: 'MESSAGE_ERROR' });
   });
 });
 

--- a/tests/Homespun.Worker/routes/sessions.test.ts
+++ b/tests/Homespun.Worker/routes/sessions.test.ts
@@ -8,6 +8,11 @@ import { createSessionsRoute } from '#src/routes/sessions.js';
 import { discoverSessions } from '#src/services/session-discovery.js';
 import { createMockSessionManager } from '../helpers/mock-session-manager.js';
 import { parseSSEEvents } from '../helpers/sse-helpers.js';
+import {
+  createAssistantMessage,
+  createResultMessage,
+  createSystemMessage,
+} from '../helpers/test-fixtures.js';
 
 const mockDiscoverSessions = vi.mocked(discoverSessions);
 
@@ -448,5 +453,51 @@ describe('DELETE /sessions/:id', () => {
     const res = await app.request('/bad-id', { method: 'DELETE' });
 
     expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /:id/events', () => {
+  it('emits every A2A event including task_notification arriving after result', async () => {
+    const { sm, app } = createApp();
+
+    // Seed: assistant text → result → task_notification (crosses the turn boundary).
+    const events = [
+      createAssistantMessage({ session_id: 's1' }),
+      createResultMessage({
+        session_id: 's1',
+        subtype: 'success',
+        is_error: false,
+      } as any),
+      createSystemMessage({ session_id: 's1', subtype: 'task_notification' } as any),
+    ];
+
+    sm.get.mockReturnValue({ id: 's1', conversationId: 's1' });
+    sm.stream.mockReturnValue(
+      (async function* () {
+        for (const e of events) yield e;
+      })(),
+    );
+
+    const res = await app.request('/s1/events');
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+
+    const text = await res.text();
+    const frames = parseSSEEvents(text);
+
+    const statusUpdates = frames.filter((f) => f.event === 'status-update');
+    const messages = frames.filter((f) => f.event === 'message');
+
+    // Result → completed translation should emit one status-update with
+    // state 'completed' and final: true.
+    const completed = statusUpdates.filter(
+      (f) =>
+        (f.data as any)?.status?.state === 'completed' &&
+        (f.data as any)?.final === true,
+    );
+    expect(completed).toHaveLength(1);
+    // At minimum: assistant text + task_notification (post-result) as message frames.
+    expect(messages.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/tests/Homespun.Worker/routes/sessions.test.ts
+++ b/tests/Homespun.Worker/routes/sessions.test.ts
@@ -453,6 +453,62 @@ describe('DELETE /sessions/:id', () => {
   });
 });
 
+describe('POST /sessions/:id/clear-context', () => {
+  it('returns JSON body with oldSessionId and newSessionId', async () => {
+    const { sm, app } = createApp();
+    sm.clearContextAndCreate.mockResolvedValue({
+      newSession: { id: 'new-sess' },
+      oldSessionId: 'old-sess',
+    });
+
+    const res = await app.request('/old-sess/clear-context', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        prompt: 'Restart',
+        model: 'sonnet',
+        mode: 'Build',
+        systemPrompt: 'sys',
+        workingDirectory: '/tmp/wd',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json();
+    expect(body).toEqual({ oldSessionId: 'old-sess', newSessionId: 'new-sess' });
+
+    expect(sm.clearContextAndCreate).toHaveBeenCalledTimes(1);
+    expect(sm.clearContextAndCreate).toHaveBeenCalledWith('old-sess', {
+      prompt: 'Restart',
+      model: 'sonnet',
+      mode: 'Build',
+      systemPrompt: 'sys',
+      workingDirectory: '/tmp/wd',
+    });
+  });
+
+  it('returns JSON 500 with CLEAR_CONTEXT_ERROR code when clearContextAndCreate throws', async () => {
+    const { sm, app } = createApp();
+    sm.clearContextAndCreate.mockRejectedValue(new Error('clear boom'));
+
+    const res = await app.request('/old-sess/clear-context', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        prompt: 'Restart',
+        model: 'sonnet',
+        mode: 'Build',
+      }),
+    });
+
+    expect(res.status).toBe(500);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json();
+    expect(body).toEqual({ error: 'clear boom', code: 'CLEAR_CONTEXT_ERROR' });
+  });
+});
+
 describe('GET /:id/events', () => {
   it('emits every A2A event including task_notification arriving after result', async () => {
     const { sm, app } = createApp();

--- a/tests/Homespun.Worker/services/sse-writer.test.ts
+++ b/tests/Homespun.Worker/services/sse-writer.test.ts
@@ -8,7 +8,11 @@ import {
 import { trace } from '@opentelemetry/api';
 import { emitAndFormatSSE, formatSSE, streamSessionEvents } from '#src/services/sse-writer.js';
 import { createMockSessionManager } from '../helpers/mock-session-manager.js';
-import { createAssistantMessage, createResultMessage } from '../helpers/test-fixtures.js';
+import {
+  createAssistantMessage,
+  createResultMessage,
+  createSystemMessage,
+} from '../helpers/test-fixtures.js';
 import { collectAsyncGenerator } from '../helpers/async-helpers.js';
 import { parseSSEEvents } from '../helpers/sse-helpers.js';
 
@@ -131,6 +135,42 @@ describe('streamSessionEvents (A2A Protocol)', () => {
     const finalUpdate = statusUpdates[statusUpdates.length - 1];
     expect(finalUpdate.data.final).toBe(true);
     expect(finalUpdate.data.status.state).toMatch(/completed|failed/);
+  });
+
+  // SDK query iterators stay open across turns; post-result task_notification
+  // / task_started / task_updated messages MUST keep flowing to the consumer.
+  // Closing the SSE generator on `result` orphans them in OutputChannel until
+  // the user's next prompt drains it, which is the bug this test guards.
+  it('keeps emitting after a result so post-result task_notification reaches the consumer', async () => {
+    const sm = createMockSessionManager();
+    sm.get.mockReturnValue({ id: 's1', conversationId: 's1' });
+
+    const assistantMsg = createAssistantMessage();
+    const resultMsg = createResultMessage();
+    const taskNotification = createSystemMessage({
+      subtype: 'task_notification',
+    } as any);
+
+    sm.stream.mockReturnValue(
+      (async function* () {
+        yield assistantMsg;
+        yield resultMsg;
+        yield taskNotification;
+      })(),
+    );
+
+    const chunks = await collectAsyncGenerator(streamSessionEvents(sm as any, 's1'));
+    const allText = chunks.join('');
+    const events = parseSSEEvents(allText);
+
+    const completed = events.filter(
+      (e) => e.event === 'status-update' && (e.data as any).status?.state === 'completed',
+    );
+    expect(completed).toHaveLength(1);
+
+    // assistant text + post-result task_notification system message
+    const messages = events.filter((e) => e.event === 'message');
+    expect(messages.length).toBeGreaterThanOrEqual(2);
   });
 
   // A2A Protocol: errors are emitted as status-update with state 'failed'


### PR DESCRIPTION
## Summary

- Fix bug where SDK \`task_notification\` / \`task_updated\` / \`task_started\` events emitted after an \`SDKResultMessage\` buffered in the worker's \`OutputChannel\` until the user sent another prompt, then flushed all at once.
- Decouple event streaming from the per-turn HTTP request cycle: worker exposes a long-lived \`GET /api/sessions/:id/events\` SSE endpoint; \`POST /api/sessions\`, \`POST /api/sessions/:id/message\`, \`POST /api/sessions/:id/clear-context\` now return JSON.
- Add \`IPerSessionEventStream\` singleton on the server: one long-lived SSE reader per session, always drives \`ISessionEventIngestor.IngestAsync\` (SignalR broadcasts never stall), fans \`SdkMessage\`s to at most one per-turn subscriber via \`Channel<SdkMessage>\` with a bounded (256) pre-subscribe replay buffer.
- Rewire \`DockerAgentExecutionService\` and \`SingleContainerAgentExecutionService\` to consume the new stream; delete obsolete per-turn SSE helpers (\`SendSseRequestAsync\`, \`StreamAgentEventsAsync\`, \`TryIngestA2A*\`, \`ParseSseEvent\`).

Stacked on #798 — merge that first. Plan doc: \`docs/superpowers/plans/2026-04-24-long-lived-session-events.md\`.

## Root cause (trace \`c3a45bd5d8d8399ee85a5e578ba5fc7c\`)

\`src/Homespun.Worker/src/services/sse-writer.ts\` terminated the SSE response on \`msg.type === "result"\`. Worker's \`runQueryForwarder\` kept the SDK query iterator alive across turns and continued pushing post-result events to \`OutputChannel\`. With no SSE consumer, events queued in the channel's internal buffer until the next user prompt opened a new SSE stream, which drained the backlog in one burst.

## Test plan

- [x] \`dotnet test\` — 2108 pass, 5 env-gated skips, 0 fail (1859 unit + 230 api + 19 apphost)
- [x] \`npm run typecheck\` / \`format:check\` / \`lint:fix\` in \`src/Homespun.Web\` — clean
- [x] \`npm test\` in \`src/Homespun.Web\` — 1839 pass (3 pre-existing timeout flakes, pass in isolation)
- [x] \`npm test\` in \`src/Homespun.Worker\` — 242 pass (2 pre-existing OTel bootstrap flakes)
- [x] \`npm run build-storybook\` — clean
- [x] New integration test \`PostResultTaskNotificationTests\` proves a post-result \`task_notification\` reaches \`IA2AEventStore\` without a second prompt
- [ ] Manual smoke on \`dev-live\` profile: agent runs a background bash, ends turn saying \"I'll wait for notifications\"; confirm the task-complete notification renders in the UI without sending a new prompt
- [ ] Follow-up issue: add reconnect-on-disconnect logic in \`PerSessionEventStream.Reader\` with \`Last-Event-ID\` support on the worker side

🤖 Generated with [Claude Code](https://claude.com/claude-code)