### PR TITLE
feat(agents): show issue context in run-agent dialog

### DIFF
--- a/.fleece/changes/change_b8d30f4c86be465dad8b09324d3bb820.jsonl
+++ b/.fleece/changes/change_b8d30f4c86be465dad8b09324d3bb820.jsonl
@@ -1,0 +1,3 @@
+{"kind":"meta","follows":"5bf7b69487c84a8f810e46d8adb21e68"}
+{"kind":"add","at":"2026-05-18T21:39:53.7955082+00:00","by":"Homespun Bot","issueId":"rkh0cc","property":"tags","value":"openspec=show-issue-description-in-agent-panel"}
+{"kind":"set","at":"2026-05-18T21:49:07.6744418+00:00","by":"Homespun Bot","issueId":"rkh0cc","property":"status","value":"Progress"}

--- a/.fleece/changes/change_b8d30f4c86be465dad8b09324d3bb820.jsonl
+++ b/.fleece/changes/change_b8d30f4c86be465dad8b09324d3bb820.jsonl
@@ -1,3 +1,5 @@
 {"kind":"meta","follows":"5bf7b69487c84a8f810e46d8adb21e68"}
 {"kind":"add","at":"2026-05-18T21:39:53.7955082+00:00","by":"Homespun Bot","issueId":"rkh0cc","property":"tags","value":"openspec=show-issue-description-in-agent-panel"}
 {"kind":"set","at":"2026-05-18T21:49:07.6744418+00:00","by":"Homespun Bot","issueId":"rkh0cc","property":"status","value":"Progress"}
+{"kind":"set","at":"2026-05-18T23:21:47.0499759+00:00","by":"Homespun Bot","issueId":"rkh0cc","property":"status","value":"Review"}
+{"kind":"add","at":"2026-05-18T23:21:47.0499759+00:00","by":"Homespun Bot","issueId":"rkh0cc","property":"tags","value":"hsp-linked-pr=834"}

--- a/openspec/changes/show-issue-description-in-agent-panel/design.md
+++ b/openspec/changes/show-issue-description-in-agent-panel/design.md
@@ -1,0 +1,165 @@
+## Context
+
+The Run Agent dialog (`RunAgentDialog` in `src/Homespun.Web/src/features/agents/components/run-agent-dialog.tsx`) is the single user-facing entry point for starting an agent session on an issue. It hosts three tabs:
+
+- **Task Agent**: skill-driven dispatch via `POST /api/issues/{id}/run`. Always scoped to a single `issueId`. Textarea labelled "Additional instructions" — semantically additive on top of the skill's SKILL.md system prompt.
+- **Issues Agent**: skill-less free-text dispatch via `POST /api/issues-agent/sessions`. Scoped via `selectedIssueId` (may be unset). Textarea is the *primary* signal to the model.
+- **OpenSpec**: skill-driven dispatch with auto-selected OpenSpec stage skill. Always scoped to an `issueId` (the tab is only mounted when `issueId` is set). Textarea is layered after a schema-override system phrase at send time.
+
+Two issue-id props flow in from parents:
+
+- `issueId` — set when the dialog is opened from the issue-edit "Save & Run Agent" button or a row-level "Run Agent" action.
+- `selectedIssueId` — set when the dialog is opened from the issues graph with a node selected.
+
+Neither tab today fetches the issue itself. The Issues Agent and OpenSpec tabs dispatch with no information beyond what the server can resolve from the issue id, leaving the textarea blank.
+
+`useIssue(issueId, projectId)` already exists at `src/features/issues/hooks/use-issue.ts` and returns `{ issue, isLoading, ... }`. `useCopyToClipboard` already exists at `src/components/tool-ui/shared/use-copy-to-clipboard.ts` and exposes a `copy(text, id?)` plus a `copiedId` flash state. Both are reused.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the dialog self-explanatory about which issue it's about to operate on.
+- Reduce friction in launching the Issues Agent and OpenSpec tabs by prefilling the textarea with structured issue context.
+- Provide a quick copy-to-clipboard for the issue id from any tab.
+- Keep the markup shape ready for a future multi-issue selection in the Issues Agent tab.
+
+**Non-Goals:**
+- Multi-issue selection itself. (Markup is chip-list-shaped; behaviour is single-chip.)
+- Any backend, dispatch-payload contract, or server-side prompt-composition change.
+- Changes to the Task Agent tab's textarea content (it remains blank).
+- Changes to the OpenSpec tab's skill list, auto-selection, gating, or schema-override semantics.
+- A redesign of post-dispatch navigation behaviour. The existing rule is preserved; its observable behaviour changes are documented as accepted.
+
+## Decisions
+
+### D1. New `run-agent-panel` capability instead of modifying `agent-dispatch`
+
+**Choice:** The dialog-chrome behaviour is captured in a NEW capability spec `run-agent-panel` rather than added to `agent-dispatch` or to the existing OpenSpec-tab requirement in `openspec-integration`.
+
+**Rationale:** `agent-dispatch` is about server-side dispatch decisions plus the top-bar active-agents indicator; the dialog UX is a distinct concern. `openspec-integration` describes OpenSpec-specific semantics, which are orthogonal to the chrome the dialog wraps around them. A dedicated capability keeps each spec focused and makes future dialog-UX changes easy to scope.
+
+### D2. Effective issue id resolution
+
+**Choice:** `effectiveIssueId = issueId ?? selectedIssueId ?? null`. The strip renders ⇔ `effectiveIssueId !== null`. The prefill is driven by the same value.
+
+**Rationale:** When the dialog opens from an issue context, `issueId` is set. When it opens from a graph selection (via the "Issues Agent" button), only `selectedIssueId` is set; falling through to it is the only way the Issues Agent tab gets context in that flow. We do not attempt to repair the pre-existing Task-Agent oddity (using only `selectedIssueId` results in dispatching with `issueId === ''`); that's a separate concern.
+
+### D3. Shared header strip vs. duplicated per-tab strips
+
+**Choice:** Single shared `IssueIdStrip` rendered once in the dialog header, above `<Tabs>`.
+
+**Alternatives considered:**
+- Render the strip inside each `TabsContent` so each tab "owns" its chrome → three copies of the same UI, harder to keep in sync.
+
+**Rationale:** The spec says "shown in all three tabs"; a shared header strip satisfies that with one source of truth in the markup. It also visually communicates that the issue context is constant across tabs.
+
+### D4. Chip-list-shaped markup, one chip today
+
+**Choice:** The strip is rendered as a list of chips, with one chip populated. The chip displays the short id and a copy button.
+
+**Rationale:** The Issues Agent tab already accepts an optional `selectedIssueId`; a plausible future iteration extends this to a set. By shaping the markup as a list now, that extension is purely additive — no restructure required.
+
+### D5. Prefill format: structured key/value block
+
+**Choice:** The textarea is prefilled with:
+
+```
+Issue ID: {id}
+Title: {title}
+Description: {description}
+```
+
+Lines for absent fields are omitted (e.g. an issue with no description renders only Issue ID + Title).
+
+**Alternatives considered:**
+- Markdown-style prose ("This session is for issue rkh0cc, titled …") → noisier, harder to parse, no advantage.
+- Inject as a read-only context block above the textarea, leaving the textarea empty for additions → cleaner UX but requires the dispatch path to know how to layer two strings; bypasses the chosen "prefill is just text in the textarea" model.
+- Prefill description only → loses the unambiguous ID anchor inside the model's context.
+
+**Rationale:** Structured key/value reads cleanly, parses unambiguously for the model, and is easy for the human to scan and edit. The "first-write-wins" rule (D6) ensures the user's own edits are never overwritten.
+
+### D6. First-write-wins: prefill only when textarea is empty
+
+**Choice:** The prefill effect fires only when `userInstructions === ''` AND the issue has resolved. If the user types anything before the issue resolves, the prefill never overwrites it.
+
+**Rationale:** Avoids the surprising case where a slow network connection clobbers the user's in-progress edits when the response finally arrives.
+
+### D7. Loading state: chip appears immediately, prefill swaps in
+
+**Choice:** The strip renders the id chip as soon as `effectiveIssueId` is known (we have it as a prop, no fetch required). The textarea prefill is deferred until `useIssue` resolves successfully.
+
+**Rationale:** The id is available synchronously; rendering it immediately gives the user the ID + copy affordance with zero delay. The description block needs the fetched issue, so it gets a small natural delay.
+
+### D8. Issue fetch failure: chip renders, no prefill
+
+**Choice:** If `useIssue` resolves with an error, the strip still renders (the id is real and copyable), but the textarea stays empty. No error toast, no inline error chrome.
+
+**Rationale:** Failure of an enrichment fetch should not block the primary flow. The user can still dispatch the agent with manually-typed instructions.
+
+### D9. Task Agent tab is exempt from prefill
+
+**Choice:** Task Agent's textarea remains a blank "Additional instructions" surface. Only Issues Agent and OpenSpec receive the prefill.
+
+**Rationale:** The Task Agent tab is paired with a skill picker. Its textarea is semantically *additive* on top of the skill's SKILL.md system prompt; prefilling it with issue context would fight with the skill's own framing. Both Issues Agent and OpenSpec tabs treat the textarea as the primary free-form signal, where the prefill adds rather than conflicts.
+
+### D10. Issues Agent navigation gate: preserved literally
+
+**Choice:** The existing `IssuesAgentTabContent.handleStart` rule is kept exactly:
+
+```ts
+if (!userInstructions.trim()) {
+  navigate({ to: '/sessions/$sessionId', params: { sessionId: result.sessionId } })
+}
+onOpenChange(false)
+```
+
+With prefill in effect, the textarea is always populated when an issue is linked, so the navigation branch never fires in that case. The dialog closes without navigating; the user remains on the originating page.
+
+**Alternatives considered:**
+- Track a `userHasEdited` flag and treat unedited prefill as "empty" for the navigation gate → would preserve the existing UX feel but adds state and obscures the dispatch contract.
+- Always navigate when an issue is linked → simpler, takes the user to the session, but removes the "background dispatch" affordance.
+
+**Rationale:** The user has explicitly chosen the literal interpretation ("only navigate when there are no user instructions at all"). The observable consequence is that issue-bound Issues Agent dispatches now behave as "fire-and-forget" — the dialog closes and the user remains on the originating page. The agent still runs; the session is reachable from the sidebar session list (see the `move-sessions-to-sidebar` change). Documented here so future readers don't mistake this for an oversight.
+
+### D11. OpenSpec schema-override layering with prefill
+
+**Choice:** The OpenSpec tab's existing `handleStart` continues to prepend `schemaOverride` (when applicable) before the user's textarea content, joined by `\n\n`. With prefill, the final `userInstructions` payload becomes:
+
+```
+{schemaOverride}        ← only when the project's schema is non-default
+\n\n
+Issue ID: {id}
+Title: {title}
+Description: {description}
+\n\n
+{user's additions}      ← only if the user appended any
+```
+
+**Rationale:** No code change needed beyond the prefill itself. The existing `parts.filter(...).join('\n\n')` composition handles the layering for free.
+
+### D12. Reset on each dialog open
+
+**Choice:** The prefill applies on every open. `RunAgentDialog` already returns `null` when `open === false`, so its children unmount and remount on each open — internal state (including the prefilled textarea) is naturally reset.
+
+**Rationale:** Each open is a fresh launch context. A user who closes the dialog and reopens it expects to see the current canonical state, not a half-edited draft from a previous attempt.
+
+## Risks / Trade-offs
+
+- **[Risk] Slow `useIssue` resolution leaves the textarea empty for a beat after the dialog opens.**
+  → Mitigation: the id chip renders immediately so the user has something to anchor to. The textarea fills in within one round-trip (typically <100ms for a local server, sub-second on a cold cache). Acceptable.
+
+- **[Trade-off] Issue-bound Issues Agent dispatch now defaults to background.**
+  → Documented in D10. The sidebar session list (the `move-sessions-to-sidebar` change, in flight in parallel) provides the discoverability that compensates for not auto-navigating.
+
+- **[Risk] `userHasEdited` semantics are not tracked, so a user who clears the textarea after prefill (perhaps wanting to chat interactively) DOES trigger navigation.**
+  → Acceptable. "Clear the textarea" is a reasonable user action that signals "I don't want this context, just open the chat".
+
+- **[Risk] Future multi-issue selection on the Issues Agent tab will need the prefill rule to compose multiple issues' contexts.**
+  → The chip-list-shaped markup already supports this; the prefill rule would need a small extension (e.g. concatenate per-issue blocks). Not blocking this change.
+
+- **[Risk] Drift between the `Copy` flash UX here and the established `inline-issue-detail-row.tsx` flash UX.**
+  → Both use the same `useCopyToClipboard` hook + lucide `Copy`/`Check` icons + 2s flash. Drift would be a regression in either site, not a new inconsistency introduced here.
+
+## Open Questions
+
+None blocking. Implementation-level details are codified above.

--- a/openspec/changes/show-issue-description-in-agent-panel/proposal.md
+++ b/openspec/changes/show-issue-description-in-agent-panel/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+When the Run Agent dialog is opened from an issue context, the user today sees no indication of *which* issue they're about to operate on and no information about what the issue is. The Issues Agent and OpenSpec tabs in particular show a blank "Additional instructions" textarea that requires the user to either remember the issue, switch tabs in the browser to look it up, or trust the agent to figure it out server-side. This adds friction for the common case (launching an agent on the issue you were just looking at) and produces ambiguous prompts in the rarer case (launching the Issues Agent against a graph-selected issue without manually re-stating context).
+
+Surfacing the issue ID (with a copy affordance) consistently across all three tabs, and prefilling the description into the two free-form tabs, makes the dialog self-explanatory and reduces re-typing.
+
+## What Changes
+
+- **Shared "Issue Context" strip** rendered in the Run Agent dialog header, above the tabs. Visible on Task Agent, Issues Agent, and OpenSpec tabs. Hidden when no issue is linked.
+- The strip renders the effective issue id (resolution rule: `issueId ?? selectedIssueId ?? null`) as a single chip with a copy-to-clipboard button. Markup is shaped as a chip list so a future multi-issue selection drops into it without restructure, but renders one chip today.
+- The copy button reuses the existing `useCopyToClipboard` hook and the established lucide `Copy` → `Check` icon flash (2s) pattern.
+- **Issues Agent tab** prefills its textarea with a structured Issue ID / Title / Description block on first render after the issue resolves, only when the textarea is empty. Lines for absent fields (e.g. no description) are omitted. The block is fully editable.
+- **OpenSpec tab** applies the same prefill behaviour. The existing schema-override prepending continues to apply at send time, layered before the textarea content.
+- **Task Agent tab** textarea is unchanged — it remains a blank "Additional instructions" surface alongside the skill picker. The shared ID strip still appears above it.
+- **Issues Agent navigation gate** is preserved literally: post-dispatch navigation fires only when the textarea is empty at send time. With prefill in effect, issue-bound Issues Agent dispatches now behave as "fire-and-forget" — the dialog closes without navigating. The session remains reachable from the sidebar's session list. This is an explicit, documented acceptance of the existing rule applied to the new content baseline.
+
+## Capabilities
+
+### New Capabilities
+- `run-agent-panel`: the Run Agent dialog's per-tab and shared chrome behaviour — issue-context strip, textarea prefill rules, navigation gate.
+
+### Modified Capabilities
+None. The existing `openspec-integration` requirement "OpenSpec tab in run-agent panel" continues to describe OpenSpec dispatch semantics (skill list, auto-selection, gating, schema override); the new dialog-chrome requirements are defined in the new `run-agent-panel` capability and are orthogonal.
+
+## Impact
+
+**Affected code (frontend only — no backend changes):**
+- `src/Homespun.Web/src/features/agents/components/run-agent-dialog.tsx` — resolve `effectiveIssueId`, mount the new strip in the dialog header, wire `useIssue` once and pass through to the Issues Agent tab content, add prefill to the Issues Agent tab.
+- `src/Homespun.Web/src/features/agents/components/openspec-tab.tsx` — accept an `issue` prop and apply the same prefill.
+- New: `src/Homespun.Web/src/features/agents/components/issue-id-strip.tsx` — chip-list-shaped strip component with copy affordance. Co-located unit test.
+- New (optional, lightweight): `src/Homespun.Web/src/features/agents/lib/format-issue-context-block.ts` — pure helper for the structured block. Co-located unit test.
+- Tests: update `run-agent-dialog.test.tsx` (assertions on `userInstructions` payload shape and Issues Agent empty-vs-populated branches) and `openspec-tab.test.tsx` (schema-override composition and the empty-instructions branch).
+
+**No impact on:**
+- Backend (`Homespun.Server`, `Homespun.Worker`, `Homespun.Shared`).
+- The `POST /api/issues/{id}/run` or `POST /api/issues-agent/sessions` payload contracts (both still receive `userInstructions`; only its content changes).
+- The OpenSpec tab's existing skill semantics, auto-selection, gating, or schema-override behaviour.
+- The Task Agent tab's behaviour beyond the appearance of the shared strip.
+- Existing Playwright e2e specs — none assert textarea default content today.
+
+**Linked work:**
+- Fleece issue `rkh0cc` ("Show issue description in input of agent run panel"), tagged `openspec=show-issue-description-in-agent-panel`.

--- a/openspec/changes/show-issue-description-in-agent-panel/specs/run-agent-panel/spec.md
+++ b/openspec/changes/show-issue-description-in-agent-panel/specs/run-agent-panel/spec.md
@@ -1,0 +1,124 @@
+## ADDED Requirements
+
+### Requirement: Run Agent dialog shows an issue context strip when an issue is linked
+
+The Run Agent dialog SHALL render an "issue context strip" in its header, above the tab list, whenever at least one issue is linked to the open dialog.
+
+The set of linked issues SHALL be derived from the dialog's props as: `effectiveIssueIds = compact([issueId ?? selectedIssueId])` — at most one issue today, but the strip's markup SHALL be shaped to accommodate a list.
+
+The strip SHALL render one chip per linked issue. Each chip SHALL show the short issue id text and a button that copies the id to the clipboard.
+
+The copy button SHALL flash visual confirmation (Copy → Check icon swap) for approximately two seconds on success, using the `useCopyToClipboard` hook and the lucide icon pattern established elsewhere in the application.
+
+The strip SHALL be visible on all three tabs (Task Agent, Issues Agent, OpenSpec) because it lives in the shared dialog header above the `<Tabs>`.
+
+#### Scenario: Dialog opened with `issueId` shows the strip
+- **WHEN** the dialog is opened with `issueId = "rkh0cc"`
+- **THEN** the strip SHALL render one chip showing "rkh0cc" with a copy button
+- **AND** the chip SHALL be visible regardless of which tab is active
+
+#### Scenario: Dialog opened with only `selectedIssueId` shows the strip
+- **WHEN** the dialog is opened with `issueId = undefined` and `selectedIssueId = "rkh0cc"`
+- **THEN** the strip SHALL render one chip showing "rkh0cc"
+
+#### Scenario: Dialog opened with neither `issueId` nor `selectedIssueId` hides the strip
+- **WHEN** the dialog is opened with `issueId = undefined` and `selectedIssueId = null`
+- **THEN** the strip SHALL NOT render
+
+#### Scenario: Copy button writes the id to the clipboard and flashes confirmation
+- **WHEN** the user clicks the copy button on a chip
+- **THEN** the clipboard SHALL receive the chip's id
+- **AND** the button SHALL render a Check icon for approximately two seconds before reverting to the Copy icon
+
+### Requirement: Issues Agent and OpenSpec tabs prefill their textarea with structured issue context
+
+When an issue is linked to the open dialog AND the loaded issue data has resolved, the Issues Agent tab and the OpenSpec tab SHALL prefill their "Additional instructions" textarea with a structured block:
+
+```
+Issue ID: {id}
+Title: {title}
+Description: {description}
+```
+
+The prefill SHALL fire only when the textarea is empty at the moment the issue data resolves (first-write-wins). It SHALL NOT overwrite a non-empty textarea.
+
+Lines for absent fields SHALL be omitted. For example, an issue with no description SHALL produce a two-line block containing only Issue ID and Title.
+
+The prefilled content SHALL be fully editable by the user.
+
+The Task Agent tab SHALL NOT receive this prefill; its textarea remains a blank "Additional instructions" surface.
+
+#### Scenario: Issues Agent tab prefills on issue resolution
+- **WHEN** the dialog is opened on the Issues Agent tab with `selectedIssueId = "rkh0cc"`
+- **AND** the issue has title "Show issue description in input of agent run panel" and a non-empty description
+- **THEN** the textarea SHALL render the three-line structured block (Issue ID + Title + Description) once `useIssue` resolves
+
+#### Scenario: OpenSpec tab prefills on issue resolution
+- **WHEN** the dialog is opened on the OpenSpec tab with `issueId = "rkh0cc"`
+- **AND** the issue has title and description
+- **THEN** the textarea SHALL render the three-line structured block once `useIssue` resolves
+
+#### Scenario: Task Agent tab does not prefill
+- **WHEN** the dialog is opened on the Task Agent tab with `issueId = "rkh0cc"`
+- **THEN** the textarea SHALL remain empty
+- **AND** its placeholder "Additional instructions (optional)" SHALL be visible
+
+#### Scenario: Prefill does not overwrite user-typed content
+- **WHEN** the user types "custom instructions" into the Issues Agent textarea
+- **AND** `useIssue` subsequently resolves with the issue data
+- **THEN** the textarea SHALL still contain "custom instructions"
+- **AND** the prefill block SHALL NOT be applied
+
+#### Scenario: Issue with no description omits the Description line
+- **WHEN** the issue has title but no description
+- **THEN** the prefill block SHALL contain only "Issue ID: {id}" and "Title: {title}"
+- **AND** no "Description:" line SHALL appear
+
+#### Scenario: Issue fetch failure leaves the textarea empty
+- **WHEN** the dialog is opened with an issue id whose fetch fails
+- **THEN** the textarea SHALL remain empty
+- **AND** the strip SHALL still render the id chip
+- **AND** no error toast or inline error SHALL be shown in the dialog
+
+### Requirement: OpenSpec schema override composes with prefill at send time
+
+When the OpenSpec tab's `handleStart` dispatches a session, the `userInstructions` payload SHALL be composed as `[schemaOverride, textareaContent].filter(Boolean).join('\n\n')`, where `schemaOverride` is the existing `"use openspec schema '{schema}' for all openspec commands"` phrase (included only for non-default schemas) and `textareaContent` is the current value of the OpenSpec tab's textarea (which includes the prefilled block plus any user edits).
+
+#### Scenario: Non-default schema prepends override before the prefill
+- **WHEN** the project uses schema "custom-schema"
+- **AND** the textarea contains the prefilled three-line block
+- **THEN** the dispatched `userInstructions` SHALL be `"use openspec schema 'custom-schema' for all openspec commands\n\nIssue ID: rkh0cc\nTitle: ...\nDescription: ..."`
+
+#### Scenario: Default schema dispatches the prefill content as-is
+- **WHEN** the project uses the default schema
+- **AND** the textarea contains the prefilled three-line block
+- **THEN** the dispatched `userInstructions` SHALL be the three-line block exactly
+
+### Requirement: Issues Agent post-dispatch navigation gate is unchanged
+
+The Issues Agent tab's `handleStart` SHALL navigate to the freshly-created session's page IFF the textarea is empty at the moment of dispatch. Otherwise it SHALL close the dialog without navigating.
+
+This rule is preserved literally despite the prefill. With prefilled content populated by default for issue-linked launches, the navigation branch does not fire for those launches and the dialog closes without navigation. The agent still runs; the session is reachable from the sidebar's session list.
+
+#### Scenario: Empty textarea navigates to the session
+- **WHEN** the user clicks Start on the Issues Agent tab with an empty textarea (no issue linked, or the user cleared the prefill)
+- **THEN** the session SHALL be created
+- **AND** the dialog SHALL close
+- **AND** the user SHALL be navigated to `/sessions/{sessionId}`
+
+#### Scenario: Issue-bound dispatch closes the dialog without navigating
+- **WHEN** the user clicks Start on the Issues Agent tab with the prefilled three-line block present (unedited or edited but non-empty)
+- **THEN** the session SHALL be created
+- **AND** the dialog SHALL close
+- **AND** the user SHALL remain on the originating page
+- **AND** no navigation to `/sessions/{sessionId}` SHALL occur
+
+### Requirement: Dialog state resets on each open
+
+Each open of the Run Agent dialog SHALL produce a fresh state — including a fresh prefill — rather than restoring text from a previously-closed open.
+
+#### Scenario: Reopening the dialog re-prefills the textarea
+- **WHEN** the user types "additional context" into the Issues Agent textarea, then closes the dialog
+- **AND** subsequently reopens the dialog with the same `selectedIssueId`
+- **THEN** the textarea SHALL contain only the prefilled block
+- **AND** "additional context" SHALL NOT persist

--- a/openspec/changes/show-issue-description-in-agent-panel/tasks.md
+++ b/openspec/changes/show-issue-description-in-agent-panel/tasks.md
@@ -1,0 +1,63 @@
+## 1. Format helper
+
+- [x] 1.1 Add a pure helper `formatIssueContextBlock(issue: IssueResponse): string` at `src/Homespun.Web/src/features/agents/lib/format-issue-context-block.ts`. Returns the structured `Issue ID:` / `Title:` / `Description:` block, omitting absent Title/Description lines.
+- [x] 1.2 Co-located unit test for: (a) full fields, (b) missing description, (c) missing title (defensive), (d) trims trailing whitespace.
+
+## 2. Shared component — `IssueIdStrip`
+
+- [x] 2.1 Create `src/Homespun.Web/src/features/agents/components/issue-id-strip.tsx`. Props: `{ issueIds: string[] }`. Renders nothing when `issueIds` is empty. Otherwise renders a chip list — one chip per id — each chip containing the short id text plus a `Button` with a lucide `Copy` / `Check` icon swap (2s flash) wired via `useCopyToClipboard`. Use shadcn `Button` (size `sm`, variant `ghost`).
+- [x] 2.2 Co-located unit test `issue-id-strip.test.tsx`: (a) renders nothing for empty input, (b) renders one chip per id, (c) clicking the copy button writes the id to the clipboard (mock `navigator.clipboard.writeText`), (d) the icon switches to Check after click then back to Copy after ~2s.
+
+## 3. Hook reuse — `useIssue` integration
+
+- [x] 3.1 In `run-agent-dialog.tsx`, compute `effectiveIssueId = issueId ?? selectedIssueId ?? null`. Call `useIssue(effectiveIssueId ?? '', projectId)` (the hook's `enabled` guard skips the fetch when the id is empty).
+- [x] 3.2 Pass the resolved `issue` (or undefined) down to `IssuesAgentTabContent` and `OpenSpecTabContent` via new props so each tab can prefill without re-fetching.
+
+## 4. Dialog wiring — shared strip
+
+- [x] 4.1 Render `<IssueIdStrip issueIds={effectiveIssueId ? [effectiveIssueId] : []} />` in the `DialogHeader` of `RunAgentDialog`, between the existing `DialogTitle` / `DialogDescription` block and the `<Tabs>`.
+- [x] 4.2 Style the strip as a single horizontal row consistent with the rest of the dialog header. No "Issue:" label — the chip is self-evident.
+
+## 5. Issues Agent tab — prefill
+
+- [x] 5.1 Add a new optional `issue?: IssueResponse` prop to `IssuesAgentTabContent`. Thread it through from `RunAgentDialog`.
+- [x] 5.2 Add a `useEffect` that fires when `issue` becomes defined AND `userInstructions === ''`. When both conditions hold, set `userInstructions` to `formatIssueContextBlock(issue)`.
+- [x] 5.3 Update the helper text below the textarea to reflect the prefilled-baseline reality. E.g. when an issue is linked, show "The agent will start with this context. Edit to customize."; when no issue is linked, keep the existing "Leave empty to start an interactive session."
+
+## 6. OpenSpec tab — prefill
+
+- [x] 6.1 Add a new optional `issue?: IssueResponse` prop to `OpenSpecTabContent`. Thread it through from `RunAgentDialog`.
+- [x] 6.2 Add the same `useEffect` prefill behaviour as Issues Agent. No change to the existing `handleStart` composition — the prefill becomes part of `userInstructions`, and the existing `parts.filter(...).join('\n\n')` lays `schemaOverride` in front of it for free.
+
+## 7. Task Agent tab — strip-only
+
+- [x] 7.1 No textarea behaviour change. Verify the shared strip renders above the tab content (covered by §4 in the dialog header). No new code in `TaskAgentTabContent`.
+
+## 8. Tests — update existing
+
+- [x] 8.1 `src/features/agents/components/run-agent-dialog.test.tsx`: update the "includes user instructions in the dispatch" assertion (≈L300–328) to expect the prefilled block in the payload when an issue is linked, and to expect the literal user-typed content when no issue is linked. Update the Issues Agent empty-vs-populated branches (≈L414–469) to reflect that prefilled content is non-empty.
+- [x] 8.2 `src/features/agents/components/openspec-tab.test.tsx`: update the "prepends schema override to userInstructions" assertion (≈L289–310) to expect `schemaOverride` + prefilled block in order. Update the "dispatches with skill name and change name as arg" assertion (≈L263–287) to expect `userInstructions` to be defined (the prefill) when an issue is linked.
+
+## 9. Tests — new
+
+- [x] 9.1 `run-agent-dialog.test.tsx`: assert the navigation gate stays literal — issue-bound Issues Agent dispatch DOES NOT navigate to the session page (the dialog just closes).
+- [x] 9.2 `run-agent-dialog.test.tsx`: assert the strip is rendered in the header when `issueId` or `selectedIssueId` is set, and is NOT rendered when both are absent.
+- [x] 9.3 `run-agent-dialog.test.tsx`: assert the Task Agent textarea stays empty (no prefill) when an issue is linked.
+- [x] 9.4 `run-agent-dialog.test.tsx`: assert the Issues Agent and OpenSpec textareas are prefilled with the formatted block when an issue is linked.
+- [x] 9.5 `run-agent-dialog.test.tsx`: assert first-write-wins — typing into the textarea before `useIssue` resolves preserves the user's input.
+
+## 10. Stories
+
+- [x] 10.1 No existing Storybook story for `run-agent-dialog` or `openspec-tab` exists. If one is added during implementation, include a story showing the prefilled state. Otherwise N/A.
+
+## 11. Pre-PR checks
+
+- [x] 11.1 `dotnet test` (no backend changes expected, but the project's pre-PR checklist requires it).
+- [x] 11.2 In `src/Homespun.Web`: `npm run lint:fix`, `npm run format:check`, `npm run typecheck`, `npm test`, `npm run build-storybook`.
+- [ ] 11.3 Optional manual smoke test in `dev-mock`: verify (a) the strip appears in the header, (b) clicking copy flashes the icon, (c) opening from an issue context prefills the Issues Agent / OpenSpec textareas, (d) opening the Issues Agent button without a node selected hides the strip and leaves the textarea blank.
+
+## 12. Linking and review
+
+- [x] 12.1 Tag fleece issue `rkh0cc` with `openspec=show-issue-description-in-agent-panel` (`fleece edit rkh0cc --tags "openspec=show-issue-description-in-agent-panel"`).
+- [x] 12.2 Update issue status to `progress` when starting (`fleece edit rkh0cc -s progress`) and to `review` with `--linked-pr <number>` when opening the PR.
+- [x] 12.3 Commit `.fleece/` changes alongside code changes in the same PR.

--- a/src/Homespun.Web/src/features/agents/components/issue-id-strip.test.tsx
+++ b/src/Homespun.Web/src/features/agents/components/issue-id-strip.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { IssueIdStrip } from './issue-id-strip'
+
+describe('IssueIdStrip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders nothing for empty input', () => {
+    const { container } = render(<IssueIdStrip issueIds={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders one chip per id', () => {
+    render(<IssueIdStrip issueIds={['rkh0cc', 'abc123']} />)
+    expect(screen.getByText('rkh0cc')).toBeInTheDocument()
+    expect(screen.getByText('abc123')).toBeInTheDocument()
+    expect(screen.getAllByRole('button')).toHaveLength(2)
+  })
+
+  it('clicking the copy button writes the id to the clipboard', async () => {
+    // userEvent.setup() installs its own clipboard mock — spy on it after setup
+    const user = userEvent.setup()
+    const writeTextSpy = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue()
+
+    render(<IssueIdStrip issueIds={['rkh0cc']} />)
+
+    await user.click(screen.getByRole('button', { name: /copy rkh0cc/i }))
+
+    expect(writeTextSpy).toHaveBeenCalledWith('rkh0cc')
+  })
+
+  it('icon switches to Check after click then back to Copy after ~2s', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue()
+
+    render(<IssueIdStrip issueIds={['rkh0cc']} />)
+
+    // Before click: Copy button visible
+    expect(screen.getByRole('button', { name: /^copy rkh0cc$/i })).toBeInTheDocument()
+
+    // Fire the click — starts async clipboard write
+    fireEvent.click(screen.getByRole('button', { name: /^copy rkh0cc$/i }))
+    // Flush clipboard Promise microtask so setCopiedId is called
+    await act(async () => {})
+
+    // After click: aria-label changes to "Copied" (Check icon)
+    expect(screen.getByRole('button', { name: /^copied rkh0cc$/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^copy rkh0cc$/i })).not.toBeInTheDocument()
+
+    // After 2s: Copy icon returns
+    act(() => {
+      vi.advanceTimersByTime(2100)
+    })
+
+    expect(screen.getByRole('button', { name: /^copy rkh0cc$/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^copied rkh0cc$/i })).not.toBeInTheDocument()
+
+    vi.useRealTimers()
+  })
+})

--- a/src/Homespun.Web/src/features/agents/components/issue-id-strip.tsx
+++ b/src/Homespun.Web/src/features/agents/components/issue-id-strip.tsx
@@ -1,0 +1,35 @@
+import { Copy, Check } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useCopyToClipboard } from '@/components/tool-ui/shared/use-copy-to-clipboard'
+
+interface IssueIdStripProps {
+  issueIds: string[]
+}
+
+export function IssueIdStrip({ issueIds }: IssueIdStripProps) {
+  const { copiedId, copy } = useCopyToClipboard()
+
+  if (issueIds.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {issueIds.map((id) => (
+        <span
+          key={id}
+          className="flex items-center gap-1 rounded-md border px-2 py-0.5 font-mono text-sm"
+        >
+          {id}
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-5 w-5 p-0"
+            onClick={() => copy(id, id)}
+            aria-label={copiedId === id ? `Copied ${id}` : `Copy ${id}`}
+          >
+            {copiedId === id ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+          </Button>
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/src/Homespun.Web/src/features/agents/components/openspec-tab.test.tsx
+++ b/src/Homespun.Web/src/features/agents/components/openspec-tab.test.tsx
@@ -22,6 +22,7 @@ import {
 import type {
   DiscoveredSkills,
   IssueOpenSpecState,
+  IssueResponse,
   RunAgentAcceptedResponse,
   TaskGraphResponse,
   Project,
@@ -216,10 +217,23 @@ describe('OpenSpecTabContent', () => {
     mockGetProject.mockResolvedValue(createMockResponse(createProject()))
   })
 
-  function renderTab(state: IssueOpenSpecState | null) {
+  const MOCK_ISSUE: IssueResponse = {
+    id: 'issue-1',
+    title: 'Test Issue',
+    description: 'Test description',
+  }
+
+  const PREFILLED_BLOCK = 'Issue ID: issue-1\nTitle: Test Issue\nDescription: Test description'
+
+  function renderTab(state: IssueOpenSpecState | null, issue?: IssueResponse) {
     mockGetGraph.mockResolvedValue(createMockResponse(createGraph(state)))
     return render(
-      <OpenSpecTabContent projectId="project-1" issueId="issue-1" onOpenChange={vi.fn()} />,
+      <OpenSpecTabContent
+        projectId="project-1"
+        issueId="issue-1"
+        issue={issue}
+        onOpenChange={vi.fn()}
+      />,
       { wrapper: wrapper() }
     )
   }
@@ -261,11 +275,14 @@ describe('OpenSpecTabContent', () => {
   })
 
   it('dispatches with skill name and change name as arg', async () => {
-    renderTab({
-      branchState: BranchPresence.WITH_CHANGE,
-      changeState: ChangePhase.READY_TO_APPLY,
-      changeName: 'my-change',
-    })
+    renderTab(
+      {
+        branchState: BranchPresence.WITH_CHANGE,
+        changeState: ChangePhase.READY_TO_APPLY,
+        changeName: 'my-change',
+      },
+      MOCK_ISSUE
+    )
 
     // Wait for auto-selection to settle.
     const startBtn = await screen.findByTestId('openspec-start-agent')
@@ -280,6 +297,7 @@ describe('OpenSpecTabContent', () => {
             skillName: 'openspec-apply-change',
             skillArgs: { change: 'my-change' },
             mode: SessionMode.BUILD,
+            userInstructions: PREFILLED_BLOCK,
           }),
         })
       )
@@ -287,12 +305,15 @@ describe('OpenSpecTabContent', () => {
   })
 
   it('prepends schema override to userInstructions when non-default schema', async () => {
-    renderTab({
-      branchState: BranchPresence.WITH_CHANGE,
-      changeState: ChangePhase.READY_TO_APPLY,
-      changeName: 'my-change',
-      schemaName: 'custom-schema',
-    })
+    renderTab(
+      {
+        branchState: BranchPresence.WITH_CHANGE,
+        changeState: ChangePhase.READY_TO_APPLY,
+        changeName: 'my-change',
+        schemaName: 'custom-schema',
+      },
+      MOCK_ISSUE
+    )
 
     const startBtn = await screen.findByTestId('openspec-start-agent')
     await waitFor(() => expect(startBtn).not.toBeDisabled())
@@ -302,7 +323,7 @@ describe('OpenSpecTabContent', () => {
       expect(mockRunAgent).toHaveBeenCalledWith(
         expect.objectContaining({
           body: expect.objectContaining({
-            userInstructions: "use openspec schema 'custom-schema' for all openspec commands",
+            userInstructions: `use openspec schema 'custom-schema' for all openspec commands\n\n${PREFILLED_BLOCK}`,
           }),
         })
       )

--- a/src/Homespun.Web/src/features/agents/components/openspec-tab.tsx
+++ b/src/Homespun.Web/src/features/agents/components/openspec-tab.tsx
@@ -16,10 +16,11 @@ import { useProjectSkills } from '@/features/skills/hooks/use-project-skills'
 import { useTaskGraph } from '@/features/issues/hooks/use-task-graph'
 import { useProject } from '@/features/projects'
 import { isAgentConflictError, useRunAgent } from '../hooks/use-run-agent'
+import { formatIssueContextBlock } from '../lib/format-issue-context-block'
 import type { RunAgentResult } from '../hooks/use-run-agent'
 import { BaseBranchSelector } from './base-branch-selector'
 import { ChangePhase, SessionMode } from '@/api'
-import type { IssueOpenSpecState, SkillDescriptor } from '@/api/generated/types.gen'
+import type { IssueOpenSpecState, IssueResponse, SkillDescriptor } from '@/api/generated/types.gen'
 
 const MODELS = [
   { value: 'opus', label: 'Opus' },
@@ -59,6 +60,7 @@ const GATED_SKILLS: ReadonlySet<OpenSpecSkillName> = new Set([
 export interface OpenSpecTabContentProps {
   projectId: string
   issueId: string
+  issue?: IssueResponse
   onAgentStart?: (result: RunAgentResult) => void
   onOpenChange: (open: boolean) => void
   onError?: (error: Error) => void
@@ -124,6 +126,7 @@ export function buildSchemaOverride(schemaName: string | null | undefined): stri
 export function OpenSpecTabContent({
   projectId,
   issueId,
+  issue,
   onAgentStart,
   onOpenChange,
   onError,
@@ -177,6 +180,12 @@ export function OpenSpecTabContent({
       localStorage.setItem(BASE_BRANCH_STORAGE_KEY, selectedBaseBranch)
     }
   }, [selectedBaseBranch])
+
+  // Prefill textarea with issue context when the issue resolves, first-write-wins.
+  useEffect(() => {
+    if (!issue) return
+    setUserInstructions((prev) => (prev === '' ? formatIssueContextBlock(issue) : prev))
+  }, [issue])
 
   const effectiveBaseBranch = useMemo(
     () => selectedBaseBranch || project?.defaultBranch || '',

--- a/src/Homespun.Web/src/features/agents/components/run-agent-dialog.test.tsx
+++ b/src/Homespun.Web/src/features/agents/components/run-agent-dialog.test.tsx
@@ -16,6 +16,7 @@ import type { ReactNode } from 'react'
 import type {
   ClaudeModelInfo,
   DiscoveredSkills,
+  IssueResponse,
   RunAgentAcceptedResponse,
 } from '@/api/generated/types.gen'
 
@@ -48,6 +49,7 @@ const mockGetSkills = vi.mocked(Skills.getApiSkillsProjectByProjectId)
 const mockRunAgent = vi.mocked(Issues.postApiIssuesByIssueIdRun)
 const mockCreateIssuesAgentSession = vi.mocked(IssuesAgent.postApiIssuesAgentSession)
 const mockGetModels = vi.mocked(Models.getApiModels)
+const mockGetIssue = vi.mocked(Issues.getApiIssuesByIssueId)
 
 const MOCK_MODELS: ClaudeModelInfo[] = [
   {
@@ -67,6 +69,15 @@ const MOCK_MODELS: ClaudeModelInfo[] = [
     createdAt: '2025-10-01T00:00:00Z',
   },
 ]
+
+const MOCK_ISSUE: IssueResponse = {
+  id: 'issue-456',
+  title: 'Test Issue Title',
+  description: 'Test issue description',
+}
+
+const PREFILLED_BLOCK =
+  'Issue ID: issue-456\nTitle: Test Issue Title\nDescription: Test issue description'
 
 function createMockResponse<T>(data: T) {
   return {
@@ -130,6 +141,8 @@ describe('RunAgentDialog', () => {
     mockGetSkills.mockResolvedValue(createMockResponse(MOCK_SKILLS))
     mockRunAgent.mockResolvedValue(createMockResponse(createMockRunAgentResponse()))
     mockGetModels.mockResolvedValue(createMockResponse(MOCK_MODELS))
+    // Default: issue fetch fails gracefully so issue stays undefined (no prefill in most tests)
+    mockGetIssue.mockResolvedValue(createMockResponse(undefined as unknown as IssueResponse))
   })
 
   it('renders nothing when closed', () => {
@@ -196,6 +209,51 @@ describe('RunAgentDialog', () => {
     })
   })
 
+  describe('Issue ID strip', () => {
+    it('renders the strip when issueId is set', async () => {
+      render(
+        <RunAgentDialog
+          open={true}
+          onOpenChange={() => {}}
+          projectId="project-123"
+          issueId="issue-456"
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('issue-456')).toBeInTheDocument()
+      })
+    })
+
+    it('renders the strip when selectedIssueId is set and issueId is absent', async () => {
+      render(
+        <RunAgentDialog
+          open={true}
+          onOpenChange={() => {}}
+          projectId="project-123"
+          selectedIssueId="issue-456"
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('issue-456')).toBeInTheDocument()
+      })
+    })
+
+    it('does not render the strip when neither issueId nor selectedIssueId is set', async () => {
+      render(<RunAgentDialog open={true} onOpenChange={() => {}} projectId="project-123" />, {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+      })
+      expect(screen.queryByRole('button', { name: /copy/i })).not.toBeInTheDocument()
+    })
+  })
+
   describe('Task Agent Tab', () => {
     it('shows skill picker, mode, model, and start button', async () => {
       render(
@@ -216,6 +274,29 @@ describe('RunAgentDialog', () => {
       expect(within(taskTab).getByRole('combobox', { name: 'Select mode' })).toBeInTheDocument()
       expect(within(taskTab).getByRole('combobox', { name: 'Select model' })).toBeInTheDocument()
       expect(within(taskTab).getByRole('button', { name: /start agent/i })).toBeInTheDocument()
+    })
+
+    it('Task Agent textarea stays empty (no prefill) when an issue is linked', async () => {
+      mockGetIssue.mockResolvedValue(createMockResponse(MOCK_ISSUE))
+
+      render(
+        <RunAgentDialog
+          open={true}
+          onOpenChange={() => {}}
+          projectId="project-123"
+          issueId="issue-456"
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      const taskTab = getTaskTab()
+
+      await waitFor(() => {
+        expect(within(taskTab).getByRole('button', { name: /start agent/i })).toBeInTheDocument()
+      })
+
+      const textarea = within(taskTab).getByPlaceholderText(/additional instructions/i)
+      expect(textarea).toHaveValue('')
     })
 
     it('sends skillName and skillArgs when a skill is selected', async () => {
@@ -465,6 +546,101 @@ describe('RunAgentDialog', () => {
           to: '/sessions/$sessionId',
           params: { sessionId: 'session-123' },
         })
+      })
+    })
+
+    it('Issues Agent textarea is prefilled with formatted block when issue is linked', async () => {
+      mockGetIssue.mockResolvedValue(createMockResponse(MOCK_ISSUE))
+
+      render(
+        <RunAgentDialog
+          open={true}
+          onOpenChange={() => {}}
+          projectId="project-123"
+          selectedIssueId="issue-456"
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      const issuesTab = getIssuesTab()
+
+      await waitFor(() => {
+        const textarea = within(issuesTab).getByPlaceholderText(/additional instructions/i)
+        expect(textarea).toHaveValue(PREFILLED_BLOCK)
+      })
+    })
+
+    it('issue-bound Issues Agent dispatch does NOT navigate to session page', async () => {
+      const user = userEvent.setup()
+      const onOpenChange = vi.fn()
+
+      mockGetIssue.mockResolvedValue(createMockResponse(MOCK_ISSUE))
+      mockCreateIssuesAgentSession.mockResolvedValue({
+        data: {
+          sessionId: 'session-123',
+          branchName: 'issues-agent-123',
+          clonePath: '/tmp/clone',
+        },
+      } as never)
+
+      render(
+        <RunAgentDialog
+          open={true}
+          onOpenChange={onOpenChange}
+          projectId="project-123"
+          selectedIssueId="issue-456"
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      const issuesTab = getIssuesTab()
+
+      // Wait for prefill to settle
+      await waitFor(() => {
+        const textarea = within(issuesTab).getByPlaceholderText(/additional instructions/i)
+        expect(textarea).toHaveValue(PREFILLED_BLOCK)
+      })
+
+      await user.click(within(issuesTab).getByRole('button', { name: /start agent/i }))
+
+      await waitFor(() => {
+        expect(onOpenChange).toHaveBeenCalledWith(false)
+      })
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it('first-write-wins: user-typed content is preserved when useIssue resolves later', async () => {
+      // Simulate slow issue fetch with a deferred resolution
+      let resolveIssue!: (value: unknown) => void
+      const issuePromise = new Promise((resolve) => {
+        resolveIssue = resolve
+      })
+      mockGetIssue.mockReturnValue(issuePromise as ReturnType<typeof mockGetIssue>)
+
+      const user = userEvent.setup()
+
+      render(
+        <RunAgentDialog
+          open={true}
+          onOpenChange={() => {}}
+          projectId="project-123"
+          selectedIssueId="issue-456"
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      const issuesTab = getIssuesTab()
+
+      // User types before issue resolves
+      const textarea = await within(issuesTab).findByPlaceholderText(/additional instructions/i)
+      await user.type(textarea, 'custom instructions')
+
+      // Now issue resolves
+      resolveIssue(createMockResponse(MOCK_ISSUE))
+
+      // Wait a beat then check the textarea has not been overwritten
+      await waitFor(() => {
+        expect(textarea).toHaveValue('custom instructions')
       })
     })
   })

--- a/src/Homespun.Web/src/features/agents/components/run-agent-dialog.tsx
+++ b/src/Homespun.Web/src/features/agents/components/run-agent-dialog.tsx
@@ -24,15 +24,18 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { useAvailableModels, useRunAgent } from '../hooks'
 import { isAgentConflictError } from '../hooks/use-run-agent'
 import { normalizeStoredModel } from '../lib/normalize-stored-model'
+import { formatIssueContextBlock } from '../lib/format-issue-context-block'
 import { useProject } from '@/features/projects'
 import { BaseBranchSelector } from './base-branch-selector'
 import { OpenSpecTabContent } from './openspec-tab'
+import { IssueIdStrip } from './issue-id-strip'
 import { useCreateIssuesAgentSession } from '@/features/issues-agent/hooks/use-create-issues-agent-session'
 import { SkillPicker } from '@/features/skills'
 import { useProjectSkills } from '@/features/skills/hooks/use-project-skills'
+import { useIssue } from '@/features/issues/hooks/use-issue'
 import type { RunAgentResult } from '../hooks/use-run-agent'
 import type { CreateIssuesAgentSessionResult } from '@/features/issues-agent/hooks/use-create-issues-agent-session'
-import type { ClaudeModelInfo } from '@/api/generated/types.gen'
+import type { ClaudeModelInfo, IssueResponse } from '@/api/generated/types.gen'
 import { SessionMode, SkillCategory } from '@/api'
 
 // localStorage keys
@@ -81,6 +84,9 @@ export function RunAgentDialog({
     setActiveTab(computedDefaultTab)
   }
 
+  const effectiveIssueId = issueId ?? selectedIssueId ?? null
+  const { issue } = useIssue(effectiveIssueId ?? '', projectId)
+
   if (!open) {
     return null
   }
@@ -91,6 +97,7 @@ export function RunAgentDialog({
         <DialogHeader>
           <DialogTitle>Run Agent</DialogTitle>
           <DialogDescription>Configure and start an agent session</DialogDescription>
+          <IssueIdStrip issueIds={effectiveIssueId ? [effectiveIssueId] : []} />
         </DialogHeader>
 
         <Tabs
@@ -128,6 +135,7 @@ export function RunAgentDialog({
             <IssuesAgentTabContent
               projectId={projectId}
               selectedIssueId={selectedIssueId}
+              issue={issue}
               onSessionCreated={onSessionCreated}
               onOpenChange={onOpenChange}
               onError={onError}
@@ -144,6 +152,7 @@ export function RunAgentDialog({
               <OpenSpecTabContent
                 projectId={projectId}
                 issueId={issueId}
+                issue={issue}
                 onAgentStart={onAgentStart}
                 onOpenChange={onOpenChange}
                 onError={onError}
@@ -437,6 +446,7 @@ function TaskAgentTabContent({
 interface IssuesAgentTabContentProps {
   projectId: string
   selectedIssueId?: string | null
+  issue?: IssueResponse
   onSessionCreated?: (result: CreateIssuesAgentSessionResult) => void
   onOpenChange: (open: boolean) => void
   onError?: (error: Error) => void
@@ -445,6 +455,7 @@ interface IssuesAgentTabContentProps {
 function IssuesAgentTabContent({
   projectId,
   selectedIssueId,
+  issue,
   onSessionCreated,
   onOpenChange,
   onError,
@@ -481,6 +492,12 @@ function IssuesAgentTabContent({
     localStorage.setItem(ISSUES_MODE_STORAGE_KEY, selectedMode)
   }, [selectedMode])
 
+  // Prefill textarea with issue context when the issue resolves, first-write-wins.
+  useEffect(() => {
+    if (!issue) return
+    setUserInstructions((prev) => (prev === '' ? formatIssueContextBlock(issue) : prev))
+  }, [issue])
+
   const handleStart = useCallback(async () => {
     if (!selectedModel) return
     try {
@@ -514,6 +531,8 @@ function IssuesAgentTabContent({
     onOpenChange,
     onError,
   ])
+
+  const hasIssue = !!issue
 
   return (
     <div className="flex flex-1 flex-col gap-4 overflow-hidden py-4">
@@ -556,9 +575,11 @@ function IssuesAgentTabContent({
       />
 
       <p className="text-muted-foreground text-xs">
-        {userInstructions.trim()
-          ? 'The agent will start with these instructions.'
-          : 'Leave empty to start an interactive session.'}
+        {hasIssue
+          ? 'The agent will start with this context. Edit to customize.'
+          : userInstructions.trim()
+            ? 'The agent will start with these instructions.'
+            : 'Leave empty to start an interactive session.'}
       </p>
     </div>
   )

--- a/src/Homespun.Web/src/features/agents/lib/format-issue-context-block.test.ts
+++ b/src/Homespun.Web/src/features/agents/lib/format-issue-context-block.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { formatIssueContextBlock } from './format-issue-context-block'
+
+describe('formatIssueContextBlock', () => {
+  it('includes all fields when present', () => {
+    const result = formatIssueContextBlock({
+      id: 'rkh0cc',
+      title: 'My Issue',
+      description: 'Some description',
+    })
+    expect(result).toBe('Issue ID: rkh0cc\nTitle: My Issue\nDescription: Some description')
+  })
+
+  it('omits description line when absent', () => {
+    const result = formatIssueContextBlock({
+      id: 'rkh0cc',
+      title: 'My Issue',
+    })
+    expect(result).toBe('Issue ID: rkh0cc\nTitle: My Issue')
+  })
+
+  it('omits title line when absent (defensive)', () => {
+    const result = formatIssueContextBlock({
+      id: 'rkh0cc',
+    })
+    expect(result).toBe('Issue ID: rkh0cc')
+  })
+
+  it('does not produce trailing whitespace', () => {
+    const result = formatIssueContextBlock({
+      id: 'rkh0cc',
+      title: 'My Issue',
+      description: 'Some description',
+    })
+    expect(result).not.toMatch(/\s+$/)
+  })
+})

--- a/src/Homespun.Web/src/features/agents/lib/format-issue-context-block.ts
+++ b/src/Homespun.Web/src/features/agents/lib/format-issue-context-block.ts
@@ -1,0 +1,9 @@
+import type { IssueResponse } from '@/api/generated/types.gen'
+
+export function formatIssueContextBlock(issue: IssueResponse): string {
+  const lines: string[] = []
+  if (issue.id) lines.push(`Issue ID: ${issue.id}`)
+  if (issue.title) lines.push(`Title: ${issue.title}`)
+  if (issue.description) lines.push(`Description: ${issue.description}`)
+  return lines.join('\n')
+}


### PR DESCRIPTION
## Summary

- Adds a `IssueIdStrip` chip to the Run Agent dialog header (visible on all three tabs) showing the linked issue ID with a copy-to-clipboard button and 2s check-icon flash
- Issues Agent and OpenSpec tabs are prefilled with a structured `Issue ID: / Title: / Description:` block when an issue is linked; first-write-wins so user edits are preserved
- Task Agent tab is strip-only — no textarea prefill
- New `formatIssueContextBlock` helper and full TDD test coverage for all new behaviour

## Test plan

- [x] `format-issue-context-block.test.ts` — 4 unit tests (all pass)
- [x] `issue-id-strip.test.tsx` — 4 unit tests: empty render, chip-per-id, clipboard write, icon flash timer (all pass)
- [x] `run-agent-dialog.test.tsx` — new tests: strip presence/absence, Task Agent no-prefill, Issues Agent prefill, first-write-wins, navigation gate preserved
- [x] `openspec-tab.test.tsx` — updated dispatch and schema-override tests to assert prefilled content
- [x] `npm test` — 1975 tests pass (1 skipped)
- [x] `npm run typecheck` — clean
- [x] `npm run lint:fix` / `npm run format:check` — clean (pre-existing errors in error-boundary.tsx unrelated)
- [x] `npm run build-storybook` — clean
- [x] `dotnet test tests/Homespun.Tests` — 1808 pass
- [x] `dotnet test tests/Homespun.Api.Tests` — 251 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)